### PR TITLE
Replace parent with parent_id in Jira config file

### DIFF
--- a/component-config.yaml.sample
+++ b/component-config.yaml.sample
@@ -1,10 +1,11 @@
 issues:
+
  - summary: "Errata respin {{ ERRATUM.respin_count }}"
    description: "{{ ERRATUM.srpms }}"
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: task
    id: errata_task
-   parent: errata_epic
+   parent_id: errata_epic
    on_respin: close
 
  - summary: "Testing ER#{{ ERRATUM.event.id }} {{ ERRATUM.summary }}"
@@ -19,7 +20,7 @@ issues:
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
    id: subtask_filelist
-   parent: errata_task
+   parent_id: errata_task
    on_respin: close
 
  - summary: "SPEC file review"
@@ -27,7 +28,7 @@ issues:
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
    id: subtask_spec
-   parent: errata_task
+   parent_id: errata_task
    on_respin: close
 
  - summary: "rpminspect review"
@@ -35,5 +36,5 @@ issues:
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
    id: subtask_rpminspect
-   parent: errata_task
+   parent_id: errata_task
    on_respin: close

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -209,7 +209,7 @@ class IssueAction:  # type: ignore[no-untyped-def]
     on_respin: Optional[OnRespinAction] = field(  # type: ignore[var-annotated]
         converter=lambda value: OnRespinAction(value) if value else None)
     type: IssueType = field(converter=IssueType)
-    parent: Optional[str] = None
+    parent_id: Optional[str] = None
 
 
 @define

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -146,8 +146,8 @@ def cmd_jira(ctx: CLIContext) -> None:
             if action.id in known_issues:
                 raise Exception(f'Issue "{action.id}" is already created!')
 
-            if action.parent and action.parent not in known_issues:
-                print(f'     !! Parent issue, "{action.parent}", is unknown, will try later')
+            if action.parent_id and action.parent_id not in known_issues:
+                print(f'     !! Parent issue, "{action.parent_id}", is unknown, will try later')
                 print()
 
                 issue_actions.append(action)
@@ -157,8 +157,8 @@ def cmd_jira(ctx: CLIContext) -> None:
             print(f'     Issue would be assigned to {action.assignee}.')
             print(f'       rendered: >>{render_template(action.assignee, ERRATUM=erratum_job)}<<')
             print(f'     Will remember the issue as `{action.id}`.')
-            if action.parent:
-                print(f'     Issue would have issue `{action.parent}` as its parent.')
+            if action.parent_id:
+                print(f'     Issue would have issue `{action.parent_id}` as its parent.')
             print()
 
             known_issues[action.id] = True


### PR DESCRIPTION
Replacing `parent` attribute with `parent_id` making its purpose more obvious.