### PR TITLE
Implement basic 'report' subcommand

### DIFF
--- a/demodata/jira-config.yaml
+++ b/demodata/jira-config.yaml
@@ -33,7 +33,7 @@ issues:
    id: subtask_demo
    parent_id: errata_task
    on_respin: close
-   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_reportportal/demodata/recipe1.yaml
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/main/demodata/recipe1.yaml
 
  - summary: "Demo testrun 2"
    description: "Run demo test"
@@ -42,4 +42,4 @@ issues:
    id: subtask_demo2
    parent_id: errata_task
    on_respin: close
-   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_reportportal/demodata/recipe2.yaml
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/main/demodata/recipe2.yaml

--- a/demodata/jira-config.yaml
+++ b/demodata/jira-config.yaml
@@ -1,6 +1,16 @@
+project: BASEQESEC
+
+transitions:
+  closed:
+    - Done
+    - Dropped
+    - Completed
+  dropped:
+    - Dropped
+
 issues:
 
- - summary: "Testing ER#{{ ERRATUM.event.id }} {{ ERRATUM.summary }}"
+ - summary: "Testing ER#{{ ERRATUM.id }} {{ ERRATUM.summary }}"
    description: "{{ ERRATUM.url }}"
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: epic

--- a/demodata/jira-config.yaml
+++ b/demodata/jira-config.yaml
@@ -15,7 +15,7 @@ issues:
    parent_id: errata_epic
    on_respin: close
 
- - summary: "Demo test"
+ - summary: "Demo testrun 1"
    description: "Run demo test"
    when: EVENT is erratum
    assignee: '{{ ERRATUM.people_assigned_to }}'
@@ -23,4 +23,13 @@ issues:
    id: subtask_demo
    parent_id: errata_task
    on_respin: close
-   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/main/demodata/recipe.yaml
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_reportportal/demodata/recipe1.yaml
+
+ - summary: "Demo testrun 2"
+   description: "Run demo test"
+   assignee: '{{ ERRATUM.people_assigned_to }}'
+   type: subtask
+   id: subtask_demo2
+   parent_id: errata_task
+   on_respin: close
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_reportportal/demodata/recipe2.yaml

--- a/demodata/plan.fmf
+++ b/demodata/plan.fmf
@@ -1,10 +1,23 @@
-summary: demo testplan
-
-discover:
-    how: shell
-    tests:
-      - name: execution context test
-        test: echo PLANET=${PLANET} CITY=${CITY} color=$@{color}
-
 execute:
     how: tmt
+
+report:
+    how: reportportal
+
+/plan1:
+  summary: demo testplan 1
+
+  discover:
+    how: shell
+    tests:
+     - name: execution context test 1
+       test: echo PLANET=${PLANET} CITY=${CITY} color=$@{color}
+
+/plan2:
+  summary: demo testplan 2
+
+  discover:
+    how: shell
+    tests:
+     - name: execution context test 2
+       test: echo PLANET=${PLANET} CITY=${CITY} color=$@{color}

--- a/demodata/recipe1.yaml
+++ b/demodata/recipe1.yaml
@@ -1,0 +1,22 @@
+fixtures:
+  environment:
+    PLANET: Earth
+
+  git_url: https://github.com/RedHatQE/newa.git
+  git_ref: ks_reportportal
+  tmt_path: demodata
+  plan: /plan1
+
+dimensions:
+  cities:
+    - environment:
+        CITY: Brno
+    - environment:
+        CITY: Boston
+      when: CONTEXT.color is match("blue")
+  colors:
+    - context:
+        color: red
+      when: ENVIRONMENT.CITY is not match("Brno")
+    - context:
+        color: blue

--- a/demodata/recipe2.yaml
+++ b/demodata/recipe2.yaml
@@ -11,10 +11,12 @@ dimensions:
   cities:
     - environment:
         CITY: Brno
+      when: CONTEXT.color is match("blue")
     - environment:
         CITY: Boston
   colors:
     - context:
         color: red
+      when: ENVIRONMENT.CITY is not match("Brno")
     - context:
         color: blue

--- a/demodata/recipe2.yaml
+++ b/demodata/recipe2.yaml
@@ -3,8 +3,9 @@ fixtures:
     PLANET: Earth
 
   git_url: https://github.com/RedHatQE/newa.git
-  git_ref: main
+  git_ref: ks_reportportal
   tmt_path: demodata
+  plan: /plan2
 
 dimensions:
   cities:
@@ -12,10 +13,8 @@ dimensions:
         CITY: Brno
     - environment:
         CITY: Boston
-      when: CONTEXT.color is match("blue")
   colors:
     - context:
         color: red
-      when: ENVIRONMENT.CITY is not match("Brno")
     - context:
         color: blue

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -588,7 +588,7 @@ class Request(Cloneable, Serializable):
                 '--tmt-environment',
                 'TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH=ksrot_newa',
                 '--tmt-environment',
-                'TMT_PLUGIN_REPORT_REPORTPORTAL_SUITE_PER_PLAN=true',
+                'TMT_PLUGIN_REPORT_REPORTPORTAL_SUITE_PER_PLAN=1',
                 '--context', f'newa_batch={self.get_hash(ctx.timestamp)}',
                 ]
         # check compose

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -785,7 +785,6 @@ class ErratumConfig(Serializable):  # type: ignore[no-untyped-def]
         factory=list, converter=lambda issues: [
             IssueAction(**issue) for issue in issues])
 
-<<<<<<< HEAD
 
 @frozen
 class IssueHandler:
@@ -1003,6 +1002,7 @@ class IssueHandler:
 #
 # ReportPortal communication
 #
+
 
 @define
 class ReportPortal:

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -527,9 +527,10 @@ class RecipeConfig(Cloneable, Serializable):
 
         # now for each combination merge data from individual dimensions
         merged_combinations = list(map(merge_combination_data, combinations))
-        total = len(merged_combinations)
+        # and filter them evaluating 'when' conditions
+        filtered_combinations = []
         for combination in merged_combinations:
-            # before creating a Request check if there is a condition present and evaluate it
+            # check if there is a condition present and evaluate it
             condition = combination.get('when', '')
             if condition:
                 # we will expose COMPOSE, ENVIRONMENT, CONTEXT to evaluate a condition
@@ -540,6 +541,10 @@ class RecipeConfig(Cloneable, Serializable):
                     CONTEXT=combination['context'])
                 if not test_result:
                     continue
+            filtered_combinations.append(combination)
+        # now build Request instances
+        total = len(filtered_combinations)
+        for combination in filtered_combinations:
             yield Request(id=f'REQ-{next(recipe_id_gen)}.{total}',
                           **combination)
 

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -678,9 +678,9 @@ class TFRequest(Cloneable, Serializable):
 class Execution(Cloneable, Serializable):
     """ A test job execution """
 
-    return_code: Optional[int] = 0
+    batch_id: str
+    return_code: int
     artifacts_url: Optional[str] = None
-    batch_id: str = ''
 
     def fetch_details(self) -> None:
         raise NotImplementedError

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -569,7 +569,7 @@ class Request(Cloneable, Serializable):
             'NO_COLOR': 'yes',
             }
         command: list[str] = [
-            'etesting-farm', 'request', '--no-wait',
+            'testing-farm', 'request', '--no-wait',
             ]
         rp_token = ctx.settings.rp_token
         rp_url = ctx.settings.rp_url

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -589,7 +589,7 @@ class Request(Cloneable, Serializable):
                 'TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH=ksrot_newa',
                 '--tmt-environment',
                 'TMT_PLUGIN_REPORT_REPORTPORTAL_SUITE_PER_PLAN=true',
-                '--context', f'newa_hash={self.get_hash(ctx.timestamp)}',
+                '--context', f'newa_batch={self.get_hash(ctx.timestamp)}',
                 ]
         # check compose
         if not self.compose:

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -278,7 +278,7 @@ def eval_test(
 
 
 def get_url_basename(url: str) -> str:
-    return os.path.splitext(os.path.basename(urllib.parse.urlparse(url).path))[0]
+    return os.path.basename(urllib.parse.urlparse(url).path)
 
 
 class EventType(Enum):

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import time
+import urllib
 from collections.abc import Iterable, Iterator
 from configparser import ConfigParser
 from enum import Enum
@@ -1033,9 +1034,9 @@ class ReportPortal:
                     path: str,
                     params: Optional[dict[str, str]] = None,
                     version: int = 1) -> JSON:
-        base_url = f'{self.url}/api/v{version}/{self.project}/{path.lstrip("/")}'
-        get_params = '&'.join([f'{k}={v}' for (k, v) in params.items()]) if params else ''
-        url = f'{base_url}?{get_params}'
+        url = urllib.parse.urljoin(self.url, f'/api/v{version}/{self.project}/{path.lstrip("/")}')
+        if params:
+            url = f'{url}?{urllib.parse.urlencode(params)}'
         headers = {"Authorization": f"bearer {self.token}", "Content-Type": "application/json"}
         req = requests.get(url, headers=headers)
         if req.status_code == 200:

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -558,12 +558,6 @@ class Request(Cloneable, Serializable):
     plan: Optional[str] = None
     # TODO: 'when' not really needed, adding it to silent the linter
     when: Optional[str] = None
-    # the purpose of 'seed' is to make each object unique as we will
-    # compute a hash of object YAML and use it as a identifier in RP
-    seed: Optional[str] = ''
-    # the purpose of 'batch_id' is to identify Requests executed in the
-    # same batch for the purpose of reporting and RP launch merging
-    batch_id: Optional[str] = ''
 
     def fetch_details(self) -> None:
         raise NotImplementedError

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1067,7 +1067,7 @@ class ReportPortal:
                        launch_ids: list[str],
                        launch_name: str,
                        description: str,
-                       attributes: Optional[dict[str, str]] = None) -> str:
+                       attributes: Optional[dict[str, str]] = None) -> str | None:
         query_data: JSON = {
             "attributes": [],
             'description': description,
@@ -1086,7 +1086,7 @@ class ReportPortal:
             print('Launches successfully merged')
             return str(data['id'])
         print('Failed to merge launches')
-        return ''
+        return None
 
 
 @define

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -391,13 +391,13 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
                 )[0]
         # for each Jira and request ID we build a list of RP launches
         jira_request_mapping[jira_id][request_id] = rp.find_launches_by_attr(
-            'newa_hash', execute_job.execution.batch_id)
+            'newa_batch', execute_job.execution.batch_id)
 
     # proceed with RP launch merge
     for jira_id in jira_request_mapping:
         to_merge = []
         description = f'{jira_id}: {len(jira_request_mapping[jira_id])} job requests in total:\n'
-        for request in jira_request_mapping[jira_id]:
+        for request in sorted(jira_request_mapping[jira_id].keys()):
             if len(jira_request_mapping[jira_id][request]):
                 description += f'  {request}: COMPLETED\n'
                 to_merge.extend(jira_request_mapping[jira_id][request])

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -270,7 +270,8 @@ def cmd_schedule(ctx: CLIContext) -> None:
         config = RecipeConfig.from_yaml_url(jira_job.recipe.url)
         # if rp_launch is not specified in the config, set it based on the recipe filename
         if 'rp_launch' not in config.fixtures:
-            config.fixtures['rp_launch'] = get_url_basename(jira_job.recipe.url)
+            config.fixtures['rp_launch'] = os.path.splitext(
+                get_url_basename(jira_job.recipe.url))[0]
         # build requests
         requests = list(config.build_requests(initial_config))
         ctx.logger.info(f'{len(requests)} requests have been generated')

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -425,5 +425,6 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
             try:
                 jira_connection.add_comment(jira_id,
                                             f"NEWA has imported test results to\n{launch_url}")
+                ctx.logger.info(f'Jira issue {jira_id} was updated with a link to RP launch {final_launch}')
             except jira.JIRAError as e:
                 raise Exception(f"Unable to add a comment to issue {jira_id}!") from e

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -474,15 +474,21 @@ def worker(ctx: CLIContext, schedule_file: Path) -> None:
 
 
 @main.command(name='report')
+@click.option(
+    '--rp-project',
+    default='',
+    )
 @click.pass_obj
-def cmd_report(ctx: CLIContext) -> None:
+def cmd_report(ctx: CLIContext, rp_project: str) -> None:
     ctx.enter_command('report')
 
     jira_request_mapping: dict[str, dict[str, list[str]]] = {}
     jira_launch_name_mapping: dict[str, str] = {}
+    if not rp_project:
+        rp_project = os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_PROJECT', '')
     rp = ReportPortal(url=os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_URL', ''),
                       token=os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN', ''),
-                      project=os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_PROJECT', ''))
+                      project=rp_project)
 
     # process each stored execute file
     for execute_job in ctx.load_execute_jobs('execute-'):

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -479,14 +479,20 @@ def worker(ctx: CLIContext, schedule_file: Path) -> None:
     default='',
     )
 @click.pass_obj
-def cmd_report(ctx: CLIContext, rp_project: str) -> None:
+@click.option(
+    '--rp-url',
+    default='',
+    )
+def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
     ctx.enter_command('report')
 
     jira_request_mapping: dict[str, dict[str, list[str]]] = {}
     jira_launch_name_mapping: dict[str, str] = {}
     if not rp_project:
         rp_project = os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_PROJECT', '')
-    rp = ReportPortal(url=os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_URL', ''),
+    if not rp_url:
+        rp_url = os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_URL', '')
+    rp = ReportPortal(url=rp_url,
                       token=os.environ.get('TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN', ''),
                       project=rp_project)
 

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 import logging
 import multiprocessing
 import os.path

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import itertools
 import logging
 import multiprocessing
@@ -271,8 +272,10 @@ def cmd_schedule(ctx: CLIContext) -> None:
         requests = list(config.build_requests(initial_config))
         ctx.logger.info(f'{len(requests)} requests have been generated')
 
-        # assign each Request the respective batch_id, us Jira issue ID for now.
-        batch_id = jira_job.id
+        # assign each Request the respective batch_id
+        # let's use hash of state_dirpath and Jira job ID for now.
+        batch_id = hashlib.sha256(f'{ctx.state_dirpath}: {jira_job.id}'.encode()
+                                 ).hexdigest()[:12]
         # create ScheduleJob object for each request
         for request in requests:
             request.batch_id = batch_id

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -118,7 +118,7 @@ def cmd_jira(ctx: CLIContext, issue_config: str) -> None:
         config = ErratumConfig.from_yaml_file(Path(os.path.expandvars(issue_config)))
 
         jira = IssueHandler(erratum_job, jira_url, jira_token, config.project, config.transitions)
-        ctx.logger.info(f"Initialized {jira}")
+        ctx.logger.info("Initialized Jira handler")
 
         # All issue action from the configuration.
         issue_actions = config.issues[:]

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -425,6 +425,7 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
             try:
                 jira_connection.add_comment(jira_id,
                                             f"NEWA has imported test results to\n{launch_url}")
-                ctx.logger.info(f'Jira issue {jira_id} was updated with a link to RP launch {final_launch}')
+                ctx.logger.info(
+                    f'Jira issue {jira_id} was updated with a link to RP launch {final_launch}')
             except jira.JIRAError as e:
                 raise Exception(f"Unable to add a comment to issue {jira_id}!") from e

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -274,8 +274,8 @@ def cmd_schedule(ctx: CLIContext) -> None:
 
         # assign each Request the respective batch_id
         # let's use hash of state_dirpath and Jira job ID for now.
-        batch_id = hashlib.sha256(f'{ctx.state_dirpath}: {jira_job.id}'.encode()
-                                 ).hexdigest()[:12]
+        batch_id = hashlib.sha256(f'{ctx.state_dirpath}: {jira_job.id}'.encode(),
+                                  ).hexdigest()[:12]
         # create ScheduleJob object for each request
         for request in requests:
             request.batch_id = batch_id


### PR DESCRIPTION
 - Modifies `execute` command so that test results are imported to ReportPortal
 - Implements `report` command that searches for imported launches in ReportPortal and merges them to a single one and reports final RP launch back to Jira.