### PR TITLE
Add container erratum support

### DIFF
--- a/demodata/jira-compose-config.yaml
+++ b/demodata/jira-compose-config.yaml
@@ -22,4 +22,4 @@ issues:
    id: tier1_task
    parent_id: tier_epic
    on_respin: close
-   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_recipe_struct/demodata/recipe1.yaml
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/main/demodata/recipe1.yaml

--- a/demodata/jira-container-config.yaml
+++ b/demodata/jira-container-config.yaml
@@ -1,0 +1,27 @@
+project: BASEQESEC
+
+transitions:
+  closed:
+    - Done
+    - Dropped
+    - Completed
+  dropped:
+    - Dropped
+
+issues:
+
+ - summary: "Testing container ER#{{ ERRATUM.id }} {{ ERRATUM.summary }}"
+   description: "{{ ERRATUM.url }}"
+   assignee: '{{ ERRATUM.people_assigned_to }}'
+   type: epic
+   id: errata_epic
+   newa_id: "ER#{{ ERRATUM.id }}"
+   on_respin: keep
+
+ - summary: "Container errata respin {{ ERRATUM.components|join(' ') }}"
+   description: "testing container {{ ERRATUM.components|join(' ') }}"
+   assignee: '{{ ERRATUM.people_assigned_to }}'
+   type: task
+   id: errata_task
+   parent_id: errata_epic
+   on_respin: close

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -30,6 +30,7 @@ def _mock_errata_tool(monkeypatch):
         """ Return a meaningful json with info """
         return {
             "synopsis": "testing errata",
+            "content_types": ["rpm"],
             "people": {
                 "assigned_to": "user@domain.com"},
             "respin_count": "1"}

--- a/tests/unit/test_eval_test.py
+++ b/tests/unit/test_eval_test.py
@@ -2,6 +2,7 @@ from newa import ArtifactJob, Compose, Erratum, Event, EventType, eval_test
 
 event = Event(type_=EventType.ERRATUM, id='foo')
 erratum = Erratum(id='12345',
+                  content_type='rpm',
                   respin_count=1,
                   summary='test errata',
                   people_assigned_to='user',


### PR DESCRIPTION
Adds support for container type advisories.
Adds `action.newa_id` parameter allowing a user to override NEWA issue ID in the jira issue config file
Adds `components` attribute to Erratum class
Adds demodata/jira-container-config.yaml presenting possible usage