### PR TITLE
Separate recipe reportportal configuration

### DIFF
--- a/demodata/jira-compose-config.yaml
+++ b/demodata/jira-compose-config.yaml
@@ -22,4 +22,4 @@ issues:
    id: tier1_task
    parent_id: tier_epic
    on_respin: close
-   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/main/demodata/recipe1.yaml
+   job_recipe: https://raw.githubusercontent.com/RedHatQE/newa/ks_recipe_struct/demodata/recipe1.yaml

--- a/demodata/recipe1.yaml
+++ b/demodata/recipe1.yaml
@@ -6,6 +6,10 @@ fixtures:
   git_ref: main
   tmt_path: demodata
   plan: /plan1
+  reportportal:
+    launch_name: "newa_demo1"
+    launch_description: "NEWA demo1 description"
+    suite_description: "color = {{ CONTEXT.color }}, city = {{ ENVIRONMENT.CITY }}"
 
 dimensions:
   cities:


### PR DESCRIPTION
Isolate reportportal configuration into separate branch in the newa recipe file.
Additionally, utilize Jinja template rendering for these newly added attributes.