### PR TITLE
Fix Testing Farm integration

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -313,12 +313,14 @@ class Arch(Enum):
     S390X = 's390x'
     PPC64LE = 'ppc64le'
     MULTI = 'multi'
+    SRPMS = 'SRPMS'  # just to ease errata processing
 
     @classmethod
     def architectures(cls: type[Arch],
                       preset: Optional[list[Arch]] = None) -> list[Arch]:
 
-        _all = [Arch(a) for a in Arch.__members__.values() if a != Arch.MULTI]
+        _exclude = [Arch.MULTI, Arch.SRPMS]
+        _all = [Arch(a) for a in Arch.__members__.values() if a not in _exclude]
 
         if not preset:
             return [Arch('x86_64')]
@@ -695,10 +697,10 @@ class RecipeConfig(Cloneable, Serializable):
                 # we will expose COMPOSE, ENVIRONMENT, CONTEXT to evaluate a condition
                 test_result = eval_test(
                     condition,
-                    COMPOSE=combination['compose'],
-                    ARCH=combination['arch'],
-                    ENVIRONMENT=combination['environment'],
-                    CONTEXT=combination['context'],
+                    COMPOSE=combination.get('compose', None),
+                    ARCH=combination.get('arch', None),
+                    ENVIRONMENT=combination.get('environment', None),
+                    CONTEXT=combination.get('context', None),
                     **(jinja_vars if jinja_vars else {}))
                 if not test_result:
                     continue

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -671,6 +671,8 @@ class RecipeConfig(Cloneable, Serializable):
                 dest[key].update(src[key])  # type: ignore[literal-required]
             elif isinstance(dest[key], list) and isinstance(src[key], list):  # type: ignore[literal-required]
                 dest[key].extend(src[key])  # type: ignore[literal-required]
+            elif isinstance(dest[key], str) and isinstance(src[key], str):  # type: ignore[literal-required]
+                dest[key] = src[key]  # type: ignore[literal-required]
             else:
                 raise Exception(f"Don't know how to merge record type '{key}'")
 

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -847,7 +847,8 @@ class Execution(Cloneable, Serializable):
     """ A test job execution """
 
     batch_id: str
-    return_code: int
+    return_code: Optional[int] = None
+    request_uuid: Optional[str] = None
     artifacts_url: Optional[str] = None
 
     def fetch_details(self) -> None:

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -508,7 +508,8 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
             jira_request_mapping[jira_id] = {}
             jira_launch_mapping[jira_id] = RawRecipeReportPortalConfigDimension(
                 launch_name=execute_job.request.reportportal['launch_name'],
-                launch_description=execute_job.request.reportportal['launch_description'])
+                launch_description=execute_job.request.reportportal.get(
+                    'launch_description', None))
             # jira_launch_mapping[jira_id] = execute_job.request.reportportal['launch_name']
         # for each Jira and request ID we build a list of RP launches
         jira_request_mapping[jira_id][request_id] = rp.find_launches_by_attr(

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -554,8 +554,9 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
             ctx.logger.info(f'RP launch urls: {" ".join(launch_urls)}')
             try:
                 joined_urls = '\n'.join(launch_urls)
-                jira_connection.add_comment(jira_id,
-                                            f"NEWA has imported test results to\n{joined_urls}")
+                description = description.replace('<br>', '\n')
+                jira_connection.add_comment(
+                    jira_id, f"NEWA has imported test results to\n{joined_urls}\n\n{description}")
                 ctx.logger.info(
                     f'Jira issue {jira_id} was updated with a RP launch URL')
             except jira.JIRAError as e:

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -378,15 +378,15 @@ def cmd_schedule(ctx: CLIContext, arch: str) -> None:
         for request in requests:
             # before yaml export render all fields as Jinja templates
             for attr in ("reportportal", "tmt", "testingfarm", "environment", "context"):
-                if getattr(request, attr, None):
-                    for (key, value) in getattr(request, attr).items():
-                        getattr(request, attr)[key] = render_template(
-                            value,
-                            ERRATUM=jira_job.erratum,
-                            COMPOSE=jira_job.compose,
-                            CONTEXT=request.context,
-                            ENVIRONMENT=request.environment,
-                            )
+                mapping = getattr(request, attr, {})
+                for (key, value) in mapping.items():
+                    mapping[key] = render_template(
+                        value,
+                        ERRATUM=jira_job.erratum,
+                        COMPOSE=jira_job.compose,
+                        CONTEXT=request.context,
+                        ENVIRONMENT=request.environment,
+                        )
 
             # export schedule_job yaml
             schedule_job = ScheduleJob(

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -549,7 +549,7 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
                 else:
                     launch_list = [merged_launch]
             # report results back to Jira
-            launch_urls = [rp.get_launch_url(launch) for launch in launch_list]
+            launch_urls = [rp.get_launch_url(str(launch)) for launch in launch_list]
             ctx.logger.info(f'RP launch urls: {" ".join(launch_urls)}')
             try:
                 joined_urls = '\n'.join(launch_urls)

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -73,8 +73,13 @@ def default_state_dir() -> Path:
     '--conf-file',
     default='$HOME/.newa',
     )
+@click.option(
+    '--debug',
+    is_flag=True,
+    default=False,
+    )
 @click.pass_context
-def main(click_context: click.Context, state_dir: str, conf_file: str) -> None:
+def main(click_context: click.Context, state_dir: str, conf_file: str, debug: bool) -> None:
     ctx = CLIContext(
         settings=Settings.load(Path(os.path.expandvars(conf_file))),
         logger=logging.getLogger(),
@@ -82,6 +87,8 @@ def main(click_context: click.Context, state_dir: str, conf_file: str) -> None:
         )
     click_context.obj = ctx
 
+    if debug:
+        ctx.logger.setLevel(logging.DEBUG)
     ctx.logger.info(f'Using state directory {ctx.state_dirpath}')
     if not ctx.state_dirpath.exists():
         ctx.logger.debug(f'State directory {ctx.state_dirpath} does not exist, creating...')

--- a/tests/unit/data/sample_recipe.yaml
+++ b/tests/unit/data/sample_recipe.yaml
@@ -4,6 +4,8 @@ fixtures:
         ref: main
         path: demodata
         plan: /plan/plan1
+    testingfarm:
+        cli_args: "-c trigger=newa"
     context:
         tier: 1
     environment:

--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -8,6 +8,7 @@ def test_arch_ok():
     intersect = Arch.architectures(subset)
 
     assert len(arch_list) == 4
-    assert all(Arch(n) in arch_list for n in Arch.__members__.values() if n != Arch.MULTI)
+    assert all(Arch(n) in arch_list for n in Arch.__members__.values()
+               if n not in [Arch.MULTI, Arch.SRPMS])
     assert set(default_list) == {Arch.X86_64}
     assert set(subset) == set(intersect)

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -12,5 +12,6 @@ def test_recipeconfig_ok():
     assert all('arch' in r.context for r in reqs)
     assert all('fips' in r.context for r in reqs)
     assert all('FIPS' in r.environment for r in reqs)
+    assert all(r.testingfarm['cli_args'] == "-c trigger=newa" for r in reqs)
     # Assert recipe id uniqueness
     assert len(reqs) == len({r.id for r in reqs})


### PR DESCRIPTION
This is a collection of changes I had to make in order to make the execution in Testing Farm truly work for a container advisory. It is not always split into multiple commits as I was not always able to identify all the changes need to fix something prior fixing something else.

The list of changes includes:
- Before exporting a `Recipe` class to YAML for scheduling render multiple values as Jinja templates
- Introduce `testingfarm` attribute to the `Recipe` class.
- Fix `Arch` object conversion from YAML
- Add `cli_args` handling
- Extend `build_requests()` function with `jinja_vars` argument optionally storing additional variables used for Jinja template rendering (might be necessary for `when` evaluation). 
- Add merging of dimensions having type `str`
- Improve `ExecuteJob` logging
- Handle missing RP `launch_description`
- Added SRPMS to Arch to simplify advisory processing
- Fixed passing undefined variables to Jinja
- Enable debug logging
- Fix unreliable Jira search which may return extra issues