### PR TITLE
Modify closed issue handling

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -270,6 +270,9 @@ def cmd_jira(ctx: CLIContext, issue_config: str) -> None:
                 # However, it might happen that we encounter an issue that is new but its
                 # original parent has been replaced by a newly created issue. In such a case
                 # we have to re-create the issue as well and drop the old one.
+                #
+                # TODO: we may want to distinguish issues that are Dropped and Done
+                # and do not re-create issues that are Done (i.e. completed)
                 is_new = False
                 if jira.newa_id(action) in jira_issue["description"] \
                     and (not action.parent_id

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -266,7 +266,6 @@ def cmd_jira(ctx: CLIContext, issue_config: str, recreate: bool) -> None:
             else:
                 search_result = jira.get_related_issues(action, all_respins=True, closed=True)
 
-            print(search_result)
             # Issues related to the curent respin and previous one(s).
             new_issues: list[Issue] = []
             old_issues: list[Issue] = []
@@ -286,7 +285,6 @@ def cmd_jira(ctx: CLIContext, issue_config: str, recreate: bool) -> None:
                          or action.parent_id not in created_action_ids):
                     is_new = True
 
-                print(jira_issue)
                 if is_new:
                     new_issues.append(
                         Issue(
@@ -308,9 +306,9 @@ def cmd_jira(ctx: CLIContext, issue_config: str, recreate: bool) -> None:
 
             # Unless we want recreate closed issues we would stop processing
             # if new_issues are closed as it means they are already processed by a user
-            if not recreate:
-                opened_issues = [i for i in new_issues if i.closed]
-                closed_issues = [i for i in new_issues if not i.closed]
+            if new_issues and (not recreate):
+                opened_issues = [i for i in new_issues if not i.closed]
+                closed_issues = [i for i in new_issues if i.closed]
                 # if there are no opened new issues we are done processing
                 if not opened_issues:
                     closed_ids = ', '.join([i.id for i in closed_issues])


### PR DESCRIPTION
Modify how closed issues are handled. Previously, only opened issues were taken into account and therefore we always ended up with an open issue. That didn't work well for tasks that have been previously "completed" by a user as they were restarted.
This is now changed in the following way:
 - Closed issues are also taken into account and new issue is not created if  matching but closed issue exists
 - Creation of new issues can be enabled through `jira --recreate` option
 - An issue is considered "old" when its parent issue has been re-created and therefore even the issue would be re-created. Previously, this worked only for subtasks but now it works also for other issue types.