### PR TITLE
Fix mapping being None

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -378,7 +378,8 @@ def cmd_schedule(ctx: CLIContext, arch: str) -> None:
         for request in requests:
             # before yaml export render all fields as Jinja templates
             for attr in ("reportportal", "tmt", "testingfarm", "environment", "context"):
-                mapping = getattr(request, attr, {})
+                # getattr(request, attr) could also be None due to 'attr' being None
+                mapping = getattr(request, attr, {}) or {}
                 for (key, value) in mapping.items():
                     mapping[key] = render_template(
                         value,


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/usr/bin/newa", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1690, in invoke
    rv.append(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/newa/cli.py", line 382, in cmd_schedule
    for (key, value) in mapping.items():
AttributeError: 'NoneType' object has no attribute 'items'
```