### PR TITLE
Pass Compose() object to COMPOSE variable

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -698,10 +698,11 @@ class RecipeConfig(Cloneable, Serializable):
             # check if there is a condition present and evaluate it
             condition = combination.get('when', '')
             if condition:
+                compose: Optional[str] = combination.get('compose', '')
                 # we will expose COMPOSE, ENVIRONMENT, CONTEXT to evaluate a condition
                 test_result = eval_test(
                     condition,
-                    COMPOSE=combination.get('compose', None),
+                    COMPOSE=Compose(compose) if compose else None,
                     ARCH=combination.get('arch', None),
                     ENVIRONMENT=combination.get('environment', None),
                     CONTEXT=combination.get('context', None),


### PR DESCRIPTION
Fixes inconsistency during config file processing where in earlier phases we use `COMPOSE` for `Compose` object while later it is a string.