### PR TITLE
Print environment when checking request status

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -517,7 +517,9 @@ def worker(ctx: CLIContext, schedule_file: Path) -> None:
         time.sleep(delay)
         tf_request.fetch_details()
         state = tf_request.details['state']
-        log(f'TF reqest {tf_request.uuid} state: {state}')
+        envs = ','.join([f"{e['os']['compose']}/{e['arch']}"
+                         for e in tf_request.details['environments_requested']])
+        log(f'TF request {tf_request.uuid} envs: {envs} state: {state}')
         finished = state in ['complete', 'error']
 
     log(f'finished with result: {tf_request.details["result"]["overall"]}')


### PR DESCRIPTION
Adds system compose and architecture to the log output when checking TF request status.
```
[2024-08-02 11:33:48,172] [execute ] schedule-134485-RHEL-10.0.BETA-BASEQESEC-1086-REQ-2.2.yaml: TF reqest fb8f20e7-f76a-4bb1-9d56-01eef9e99f8d envs: RHEL-10-Beta-Nightly/s390x state: running
```