### PR TITLE
Wait for TF request completion in the report step

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -876,6 +876,13 @@ class TFRequest(Cloneable, Serializable):
             url=self.api,
             response_content=ResponseContentType.JSON)
 
+    def is_finished(self) -> bool:
+        self.fetch_details()
+        if self.details:
+            state: str = self.details['state']
+            return state in ['complete', 'error']
+        raise Exception(f'Could not fetch details for TF request {self.uuid}')
+
 
 @define
 class Execution(Cloneable, Serializable):
@@ -884,6 +891,7 @@ class Execution(Cloneable, Serializable):
     batch_id: str
     return_code: Optional[int] = None
     request_uuid: Optional[str] = None
+    request_api: Optional[str] = None
     artifacts_url: Optional[str] = None
     command: Optional[str] = None
 

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1398,12 +1398,14 @@ class CLIContext:
     state_dirpath: Path
     cli_environment: RecipeEnvironment = field(factory=dict)
     cli_context: RecipeContext = field(factory=dict)
+    commands_run: list[str] = field(factory=list)
     timestamp: str = ''
 
     def enter_command(self, command: str) -> None:
         self.logger.handlers[0].formatter = logging.Formatter(
             f'[%(asctime)s] [{command.ljust(8, " ")}] %(message)s',
             )
+        self.commands_run.append(command)
 
     def load_initial_erratum(self, filepath: Path) -> InitialErratum:
         erratum = InitialErratum.from_yaml_file(filepath)

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -3,7 +3,6 @@ import logging
 import multiprocessing
 import os.path
 import re
-import sys
 import time
 from functools import partial
 from pathlib import Path
@@ -705,7 +704,7 @@ def cmd_report(ctx: CLIContext, rp_project: str, rp_url: str) -> None:
 
     # before reporting check if all TF requests are finished
     # unless we have previously executed 'execute' subcommand
-    if 'execute' not in sys.argv:
+    if 'execute' not in ctx.commands_run:
         watchlist = []
         for execute_job in execute_jobs:
             uuid = getattr(getattr(execute_job, 'execution', None),


### PR DESCRIPTION
Wait for TF requests to completion when newa is issued only with the report step. This way we can re-run newa after the previous command has been terminated in the execute step for whatever reason.