### PR TITLE
Fix default architecture handling for compose

### DIFF
--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -5,6 +5,7 @@ def test_arch_ok():
     arch_list = Arch.architectures([Arch.MULTI])
     noarch_list = Arch.architectures([Arch.NOARCH])
     default_list = Arch.architectures()
+    exp_default_list = [Arch.X86_64, Arch.S390X, Arch.PPC64LE, Arch.AARCH64]
     subset = [Arch.X86_64, Arch.S390X]
     intersect = Arch.architectures(subset)
 
@@ -12,5 +13,5 @@ def test_arch_ok():
     assert all(Arch(n) in arch_list for n in Arch.__members__.values()
                if n not in [Arch.MULTI, Arch.SRPMS, Arch.NOARCH])
     assert set(arch_list) == set(noarch_list)
-    assert set(default_list) == {Arch.X86_64}
+    assert set(default_list) == set(exp_default_list)
     assert set(subset) == set(intersect)


### PR DESCRIPTION
Previously, `Architectures` was not populated as a list of `Arch` objects when loaded from erratum.
This was not consisted with other assignments. This is now unified.
In addition, change the default `architectures()` return value to a full set of architectures.