### PR TITLE
Convert value to string prior calling render_template()

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -750,7 +750,7 @@ def cmd_schedule(ctx: CLIContext, arch: list[str]) -> None:
                 # compose value is a string, not dict
                 if attr == 'compose':
                     value = getattr(request, attr, '')
-                    new_value = render_template(value, **jinja_vars)
+                    new_value = render_template(str(value), **jinja_vars)
                     if new_value:
                         setattr(request, attr, new_value)
                 else:
@@ -760,9 +760,9 @@ def cmd_schedule(ctx: CLIContext, arch: list[str]) -> None:
                         # launch_attributes is a dict
                         if key == 'launch_attributes':
                             for (k, v) in value.items():
-                                mapping[key][k] = render_template(v, **jinja_vars)
+                                mapping[key][k] = render_template(str(v), **jinja_vars)
                         else:
-                            mapping[key] = render_template(value, **jinja_vars)
+                            mapping[key] = render_template(str(value), **jinja_vars)
 
             # export schedule_job yaml
             schedule_job = ScheduleJob(


### PR DESCRIPTION
Fixes an issue when value from yaml is parsed as number, not string.
```
Traceback (most recent call last):
  File "/usr/bin/newa", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1690, in invoke
    rv.append(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/newa/cli.py", line 765, in cmd_schedule
    mapping[key] = render_template(value, **jinja_vars)
  File "/usr/lib/python3.9/site-packages/newa/__init__.py", line 115, in render_template
    return environment.from_string(template).render(**variables).strip()
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 941, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 629, in compile
    source = self._generate(source, name, filename, defer_init=defer_init)
  File "/usr/lib/python3.9/site-packages/jinja2/environment.py", line 586, in _generate
    return generate(
  File "/usr/lib/python3.9/site-packages/jinja2/compiler.py", line 83, in generate
    raise TypeError("Can't compile non template nodes")
TypeError: Can't compile non template nodes
```