### PR TITLE
Add support for Jira fields in issue-config file

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -607,12 +607,14 @@ def cmd_jira(
                     if action.parent_id:
                         parent = processed_actions.get(action.parent_id, None)
 
-                    new_issue = jira_handler.create_issue(action,
-                                                          rendered_summary,
-                                                          rendered_description,
-                                                          rendered_assignee,
-                                                          parent,
-                                                          group=config.group)
+                    new_issue = jira_handler.create_issue(
+                        action,
+                        rendered_summary,
+                        rendered_description,
+                        rendered_assignee,
+                        parent,
+                        group=config.group,
+                        fields=action.fields)
 
                     processed_actions[action.id] = new_issue
                     created_action_ids.append(action.id)


### PR DESCRIPTION
In issue-config file one can newly set
custom Jira fields. These fields has to
use names as listed at /rest/api/2/field

Example:
```
  - summary: My test epic"
    type: epic
    fields:
      Labels:
       - "CY24Q3"
      "Pool Team": "my_great_team"
      "Story Points": 0
```