### PR TITLE
Change demodata usage of Erratum.srpms

### DIFF
--- a/demodata/jira-errata-config.yaml
+++ b/demodata/jira-errata-config.yaml
@@ -18,7 +18,7 @@ issues:
    on_respin: keep
 
  - summary: "Errata respin {{ ERRATUM.respin_count }}"
-   description: "{{ ERRATUM.srpms }}"
+   description: "{{ ERRATUM.builds|join(' ') }}"
    assignee: '{{ ERRATUM.people_assigned_to }}'
    type: task
    id: errata_task


### PR DESCRIPTION
It was replaced with .builds and as it is a list it is more readable if values are joined.