### PR TITLE
Add basic support for issue-config file defaults

### DIFF
--- a/component-config.yaml.sample
+++ b/component-config.yaml.sample
@@ -12,11 +12,16 @@ transitions:
   passed:
     - Done
 
+defaults:
+   assignee: '{{ ERRATUM.people_assigned_to }}'
+#  fields:
+#    "Pool Team": "my_great_team"
+#    "Story Points": 0
+
 issues:
 
  - summary: "Errata Workflow Checklist {% if ERRATUM.respin_count > 0 %}(respin {{ ERRATUM.respin_count }}){% endif %}"
    description: "Task tracking particular respin of errata."
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: task
    id: errata_task
    parent_id: errata_epic
@@ -24,7 +29,6 @@ issues:
 
  - summary: "Testing ER#{{ ERRATUM.id }} {{ ERRATUM.summary }} ({{ERRATUM.release}})"
    description: "Epic tracking all work on errata related to a specific release."
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: epic
    id: errata_epic
    on_respin: keep
@@ -32,7 +36,6 @@ issues:
 
  - summary: "Errata filelist check"
    description: "Compare errata filelist with a previously released advisory"
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
    id: subtask_filelist
    parent_id: errata_task
@@ -40,25 +43,19 @@ issues:
 
  - summary: "SPEC file review"
    description: "Review changes made in the SPEC file"
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
-   id: subtask_spec
    parent_id: errata_task
    on_respin: close
 
  - summary: "rpminspect review"
    description: "Review rpminspect results in the CI Dashboard for all builds"
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
-   id: subtask_rpminspect
    parent_id: errata_task
    on_respin: close
 
  - summary: "regression testing"
    description: "Run automated tests"
-   assignee: '{{ ERRATUM.people_assigned_to }}'
    type: subtask
-   id: subtask_regression
    parent_id: errata_task
    on_respin: close
    auto_transition: True

--- a/tests/unit/data/issue-config-include-child1.yaml
+++ b/tests/unit/data/issue-config-include-child1.yaml
@@ -1,0 +1,24 @@
+project: CHILD1PROJECT
+
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+  processed:
+    - In Progress
+  passed:
+    - Closed.Done
+
+defaults:
+  assignee: child1
+  auto_transition: False
+  fields:
+    "Pool Team": "child1_team"
+    "Story Points": 1
+
+issues:
+ - summary: "Child1 issue"
+   description: "Child1 issue"
+   type: task
+   parent_id: parent

--- a/tests/unit/data/issue-config-include-child2.yaml
+++ b/tests/unit/data/issue-config-include-child2.yaml
@@ -1,0 +1,13 @@
+project: CHILD2PROJECT
+
+defaults:
+  assignee: child2
+  auto_transition: True
+  fields:
+    "Pool Team": "child2_team"
+
+issues:
+ - summary: "Child2 issue"
+   description: "Child2 issue"
+   type: task
+   parent_id: parent

--- a/tests/unit/data/issue-config-include-parent.yaml
+++ b/tests/unit/data/issue-config-include-parent.yaml
@@ -1,0 +1,17 @@
+include:
+  - tests/unit/data/issue-config-include-child1.yaml
+  - tests/unit/data/issue-config-include-child2.yaml
+
+defaults:
+  assignee: null
+  fields:
+    "Pool Team": "parents_team"
+
+issues:
+ - summary: "Parent issue"
+   description: "Parent issue"
+   type: epic
+   assignee: "me"
+   id: parent
+   fields:
+     "Story Points": 3

--- a/tests/unit/test_include.py
+++ b/tests/unit/test_include.py
@@ -1,0 +1,36 @@
+from newa import IssueConfig, IssueType
+
+c = IssueConfig.read_file('tests/unit/data/issue-config-include-parent.yaml')
+
+
+def test_include_on_defaults():
+    # issues come from all 3 files
+    assert len(c.issues) == 3
+    # project comes form child2
+    assert c.project == 'CHILD2PROJECT'
+    # transitions are defined in child1
+    assert 'Closed' in c.transitions.closed
+    # assignee is unset in parent
+    assert c.defaults.assignee is None
+    # auto_transition comes from child2
+    assert c.defaults.auto_transition is True
+    # default fields are defined
+    assert c.defaults.fields is not None
+    # Pool team comes from the parent
+    assert c.defaults.fields["Pool Team"] == "parents_team"
+    # Story points comes from the child1
+    assert c.defaults.fields["Story Points"] == 1
+
+
+def test_defaults_override_on_issue():
+    i = c.issues[0]
+    # 1st issue action overrides some defaults
+    assert i.type == IssueType.EPIC
+    assert i.assignee == 'me'
+    assert i.fields['Story Points'] == 3
+    assert i.fields["Pool Team"] == "parents_team"
+    # other issue action does not override defaults
+    i = c.issues[1]
+    assert i.type == IssueType.TASK
+    assert i.assignee is None
+    assert i.fields['Story Points'] == 1


### PR DESCRIPTION
Adds support for issue config file default settings. Such a settings is applied to individual actions defined under `issues` attribute.
Example:
```
defaults:
  assignee: null
  fields:
    "Pool Team": "my_great_team"
    "Story Points": 0
```
`defaults` are merged when defined in multiple (included) files.