### PR TITLE
Add execute --restart-result option

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1667,6 +1667,7 @@ class CLIContext:
     cli_context: RecipeContext = field(factory=dict)
     timestamp: str = ''
     continue_execution: bool = False
+    restart_result: list[str] = field(factory=list)
 
     def enter_command(self, command: str) -> None:
         self.logger.handlers[0].formatter = logging.Formatter(


### PR DESCRIPTION
This option can be used to reschedule finished requests having the specified result. Implies --continue.