### PR TITLE
Prioritize existing recipe keys when merging dictionaries

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -837,7 +837,9 @@ class RecipeConfig(Cloneable, Serializable):
                 # we need to do a deep copy so we won't corrupt the original data
                 dest[key] = copy.deepcopy(src[key])  # type: ignore[literal-required]
             elif isinstance(dest[key], dict) and isinstance(src[key], dict):  # type: ignore[literal-required]
-                dest[key].update(src[key])  # type: ignore[literal-required]
+                # for dictionaries, existing keys (from CLI or fixtures) takes priority
+                dest[key] = dict(list(src[key].items()) +  # type: ignore[literal-required]
+                                 list(dest[key].items()))  # type: ignore[literal-required]
             elif isinstance(dest[key], list) and isinstance(src[key], list):  # type: ignore[literal-required]
                 dest[key].extend(src[key])  # type: ignore[literal-required]
             elif isinstance(dest[key], str) and isinstance(src[key], str):  # type: ignore[literal-required]


### PR DESCRIPTION
When merging dictionaries in a recipe , it seems more appropriate to prioritize existing values (specified from cmdline or through fixtures) rather then values obtained from dimensions.