### PR TITLE
Store newa_req ID as context

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -975,6 +975,8 @@ class Request(Cloneable, Serializable):
             command += [
                 '--tmt-environment',
                 f"""'TMT_PLUGIN_REPORT_REPORTPORTAL_EXCLUDE_VARIABLES="{rp_test_param_filter}"'"""]
+        # newa request ID
+        command += ['-c', f"""'newa_req="{self.id}"'"""]
         # process context
         if self.context:
             for k, v in self.context.items():


### PR DESCRIPTION
Storing REQ ID will help to identify identical request in RP after rescheduling.