### PR TITLE
Update execute_job with artifacts_url when known

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1302,6 +1302,13 @@ def worker(ctx: CLIContext, schedule_file: Path) -> None:
         tf_request.fetch_details()
         if tf_request.details:
             state = tf_request.details['state']
+            # if we don't know artifacts_url yet, try to get it now
+            if not execute_job.execution.artifacts_url:
+                url = tf_request.details.get('run', {}).get('artifacts', None)
+                if url:
+                    # store execute_job updated with artifacts_url
+                    execute_job.execution.artifacts_url = url
+                    ctx.save_execute_job('execute-', execute_job)
             envs = ','.join([f"{e['os']['compose']}/{e['arch']}"
                              for e in tf_request.details['environments_requested']])
             log(f'TF request {tf_request.uuid} envs: {envs} state: {state}')


### PR DESCRIPTION
When TF is initiated, `artifacts_url` is not yet known. This change updates `execute_job` with `artifacts_url` when it becomes known so that commands like `newa list` can present it to a user.