### PR TITLE
Reimplement recipe dimension merging and priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ See the example above.
 
 #### environment
 
-Defines environment varibles that will be set when sheduling a recipe.
-This definition takes priority over environment definition in a recipe so better
-avoid defining identical variable in both places.
+Defines environment variables that will be set when sheduling a recipe. Variable value may be overriden by the recipe.
 Environment definition is not inherited by child Jira issues.
 
 Example:
@@ -145,9 +143,7 @@ Example:
 
 #### context
 
-Defines custom `tmt` context setting that will be set when scheduling a recipe.
-This definition takes priority over context definition in a recipe so better
-avoid defining identical context dimension in both places.
+Defines custom `tmt` context setting that will be set when scheduling a recipe. Context value may be overriden by the recipe.
 Context definition is not inherited by child Jira issues.
 
 Example:
@@ -273,7 +269,9 @@ Recipe configuration file enables users to describe a complex test matrix. This 
 
 A recipe file configuration is split into two sections. The first section is named `fixtures` and contains configuration that is relevant to all test jobs triggered by the recipe file.
 
-The second section is named` dimensions` and it outlines how the test matrix looks like. Each dimension is identified by its name and defines a list of possible values, each value representing  a configuration snippet that would be used for the respective test job. `newa` does a Cartesian product of defined dimensions, building all possible combinations.
+The second section is named` dimensions` and it outlines how the test matrix looks like. Each dimension is identified by its name and defines a list of possible values, each value representing  a configuration snippet that would be used for the respective test job. `newa` does a Cartesian product of defined dimensions, building all possible combinations. Those will be saved for further execution.
+
+When mergine attributes from `fixtures` and `dimensions`, value from a particular `dimension` may override a value from `fixtures`. This is on purpose so that `fixtures` may provide sane defaults that could be possibly overriden (yes, bad naming). A recipe can also override `context` or `environment` value obtained from the `jira-` YAML file (e.g. specified in issue-config file). However, a recipe can't override a value that has been defined on a command line directly using `newa --context ...`, `newa --environment ...` or `newa schedule --fixture ...` options.
 
 Example:
 Using the recipe file
@@ -498,6 +496,7 @@ $ newa --extract-state-dir https://path/to/some/newa-run-1234.tar.gz list
 #### Option `--context, -c`
 
 Allows custom `tmt` context definition on a cmdline. Such a context can be used in issue-config YAML file through Jinja template through `CONTEXT.<name>`. Option can be used multiple times.
+Such a CLI definition has the highest priority and the value won't be overriden in NEWA issue-config or recipe file.
 
 Example:
 ```
@@ -507,6 +506,7 @@ $ newa -c foo=bar event --compose Fedora-40 ...
 #### Option `--environment, -e`
 
 Allows custom `tmt` environment variable definition on a cmdline. Such a variable can be used in issue-config YAML file through Jinja template through `ENVIRONMENT.<name>`. Option can be used multiple times.
+Such a CLI definition has the highest priority and the value won't be overriden in NEWA issue-config or recipe file.
 
 Example:
 ```

--- a/tests/unit/data/sample_recipe.yaml
+++ b/tests/unit/data/sample_recipe.yaml
@@ -9,7 +9,8 @@ fixtures:
     context:
         tier: 1
     environment:
-        DESCRIPTION: "This is a test recipe"
+        DESCRIPTION: "fixtures description"
+    compose: Fedora-fix
 dimensions:
     arch:
        - context:
@@ -25,3 +26,5 @@ dimensions:
              fips: no
          environment:
              FIPS: "FIPS NOT ENABLED"
+             DESCRIPTION: "dimensions description"
+         compose: Fedora-dim

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -5,7 +5,7 @@ from newa import RecipeConfig
 
 def test_recipeconfig_ok():
     config = RecipeConfig.from_yaml_file(Path('tests/unit/data/sample_recipe.yaml').absolute())
-    reqs = list(config.build_requests({}))
+    reqs = list(config.build_requests({}, {}))
 
     # Check generated requests are correct
     assert len(reqs) == 4
@@ -15,3 +15,47 @@ def test_recipeconfig_ok():
     assert all(r.testingfarm['cli_args'] == "-c trigger=newa" for r in reqs)
     # Assert recipe id uniqueness
     assert len(reqs) == len({r.id for r in reqs})
+
+
+def test_dimension_override():
+    config = RecipeConfig.from_yaml_file(Path('tests/unit/data/sample_recipe.yaml').absolute())
+    reqs = list(config.build_requests(initial_config={}, cli_config={}))
+
+    assert reqs[0].environment['DESCRIPTION'] == "fixtures description"
+    assert reqs[0].compose == "Fedora-fix"
+    assert reqs[-1].environment['DESCRIPTION'] == "dimensions description"
+    assert reqs[-1].compose == "Fedora-dim"
+
+
+def test_initial_config_override():
+    config = RecipeConfig.from_yaml_file(Path('tests/unit/data/sample_recipe.yaml').absolute())
+    reqs = list(
+        config.build_requests(
+            initial_config={
+                'environment': {
+                    'DESCRIPTION': 'initial'},
+                'compose': 'Fedora-init'},
+            cli_config={}))
+
+    assert reqs[0].environment['DESCRIPTION'] == "fixtures description"
+    assert reqs[0].compose == "Fedora-fix"
+    assert reqs[-1].environment['DESCRIPTION'] == "dimensions description"
+    assert reqs[-1].compose == "Fedora-dim"
+    assert all(r.environment['DESCRIPTION'] != "initial" for r in reqs)
+    assert all(r.compose != "Fedora-init" for r in reqs)
+
+
+def test_cli_config_override():
+    config = RecipeConfig.from_yaml_file(Path('tests/unit/data/sample_recipe.yaml').absolute())
+    reqs = list(
+        config.build_requests(
+            initial_config={
+                'environment': {
+                    'DESCRIPTION': 'initial'}},
+            cli_config={
+                'environment': {
+                    'DESCRIPTION': 'cli description'},
+                'compose': 'Fedora-cli'}))
+
+    assert all(r.environment['DESCRIPTION'] == "cli description" for r in reqs)
+    assert all(r.compose == "Fedora-cli" for r in reqs)


### PR DESCRIPTION
The former implementation was not consistent in which definition has a priority. In general, CLI definition should have a priority, however at the same time a user must be able to override settings inherrited from the previous NEWA command's YAML, like a 'compose'.
That was not possible due to a fact that CLI definitions and YAML definitios have been merged prio building recipe combinations.

This commit changes this behavior by separating CLI definition and YAML definition. While YAML definition enters the recipe configuration alghorithm as an initial_config which can be modified by the recipe, values provided on CLI are provided separately and the very end when building combinations and therefore have a priority.

Such a change should enable user to define overrides on command line while at the same time be able to adjust tmt/TF job configuration in a recipe.