### PR TITLE
Workaround for Jira error 401

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1740,68 +1740,80 @@ class IssueHandler:  # type: ignore[no-untyped-def]
 
         try:
             jira_issue = self.connection.create_issue(data)
-            if fields is None:
-                fields = {}
-            # always add NEWA label to fields
-            if "Labels" in fields and isinstance(fields['Labels'], list):
-                fields['Labels'].append(IssueHandler.newa_label)
+        except jira.JIRAError as e:
+            # Sometimes Jira may return error 401 while actually creating the ticket
+            msg = str(e)
+            r = re.search(
+                r"jira.exceptions.JIRAError: JiraError HTTP 401 url: https://[^\n]+"
+                f"({self.project}-[0-9]+)", msg)
+            if r:
+                jira_issue = self.connection.issue(r.group(1))
             else:
-                fields['Labels'] = [IssueHandler.newa_label]
-            # populate fdata with configuration provided by the user
-            fdata: dict[str, str | float | list[Any] | dict[str, Any]] = {}
-            transition_name: Optional[str] = None
-            for field in fields:
+                raise Exception("Unable to create issue!") from e
 
-                # skip Reporter field as that one was processed previously
-                if field == 'Reporter':
+        if fields is None:
+            fields = {}
+        # always add NEWA label to fields
+        if "Labels" in fields and isinstance(fields['Labels'], list):
+            fields['Labels'].append(IssueHandler.newa_label)
+        else:
+            fields['Labels'] = [IssueHandler.newa_label]
+        # populate fdata with configuration provided by the user
+        fdata: dict[str, str | float | list[Any] | dict[str, Any]] = {}
+        transition_name: Optional[str] = None
+        for field in fields:
+
+            # skip Reporter field as that one was processed previously
+            if field == 'Reporter':
+                continue
+
+            field_id = IssueHandler.field_map[field].id_
+            field_type = IssueHandler.field_map[field].type_
+            field_items = IssueHandler.field_map[field].items
+            value = fields[field]
+            # to ease processing set field_values to be always a list of strings
+            if isinstance(value, (float, int, str)):
+                field_values = [str(value)]
+            elif isinstance(value, list):
+                field_values = list(map(str, value))
+            else:
+                raise Exception(f'Unsupported Jira field conversion for {type(value)}')
+            # there is extra handling for Sprint as it should be an integer, maybe
+            # wrong custom field definition
+            if field == 'Sprint':
+                if not value:
                     continue
-
-                field_id = IssueHandler.field_map[field].id_
-                field_type = IssueHandler.field_map[field].type_
-                field_items = IssueHandler.field_map[field].items
-                value = fields[field]
-                # to ease processing set field_values to be always a list of strings
-                if isinstance(value, (float, int, str)):
-                    field_values = [str(value)]
-                elif isinstance(value, list):
-                    field_values = list(map(str, value))
+                if value == 'active':
+                    sprint_id = self.sprint_cache['active'][0]
+                elif value == 'future':
+                    sprint_id = self.sprint_cache['future'][0]
+                elif isinstance(value, (int, str)):
+                    sprint_id = int(value)
                 else:
-                    raise Exception(f'Unsupported Jira field conversion for {type(value)}')
-                # there is extra handling for Sprint as it should be an integer, maybe
-                # wrong custom field definition
-                if field == 'Sprint':
-                    if not value:
-                        continue
-                    if value == 'active':
-                        sprint_id = self.sprint_cache['active'][0]
-                    elif value == 'future':
-                        sprint_id = self.sprint_cache['future'][0]
-                    elif isinstance(value, (int, str)):
-                        sprint_id = int(value)
-                    else:
-                        raise Exception(
-                            f"Invalid 'Sprint' value '{value}', "
-                            "should be 'active', 'future' or sprintID")
-                    fdata[field_id] = sprint_id
-                # now we need to distinguish different types of fields and values
-                elif field_type == 'string':
-                    fdata[field_id] = field_values[0]
-                elif field_type == 'number':
-                    fdata[field_id] = float(field_values[0])
-                elif field_type == 'array':
-                    if field_items == 'string':
-                        fdata[field_id] = field_values
-                    elif field_items == 'option':
-                        fdata[field_id] = [{"value": v} for v in field_values]
-                    else:
-                        raise Exception(f'Unsupported Jira field item {field_items}')
-                elif field_type == 'priority':
-                    fdata[field_id] = {"name": field_values[0]}
-                elif field_type == 'status':
-                    transition_name = field_values[0]
+                    raise Exception(
+                        f"Invalid 'Sprint' value '{value}', "
+                        "should be 'active', 'future' or sprintID")
+                fdata[field_id] = sprint_id
+            # now we need to distinguish different types of fields and values
+            elif field_type == 'string':
+                fdata[field_id] = field_values[0]
+            elif field_type == 'number':
+                fdata[field_id] = float(field_values[0])
+            elif field_type == 'array':
+                if field_items == 'string':
+                    fdata[field_id] = field_values
+                elif field_items == 'option':
+                    fdata[field_id] = [{"value": v} for v in field_values]
                 else:
-                    raise Exception(f'Unsupported Jira field type {field_type}')
+                    raise Exception(f'Unsupported Jira field item {field_items}')
+            elif field_type == 'priority':
+                fdata[field_id] = {"name": field_values[0]}
+            elif field_type == 'status':
+                transition_name = field_values[0]
+            else:
+                raise Exception(f'Unsupported Jira field type {field_type}')
 
+        try:
             jira_issue.update(fields=fdata)
             if transition_name:
                 self.connection.transition_issue(jira_issue.key, transition=transition_name)
@@ -1812,7 +1824,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                          transition_passed=transition_passed,
                          transition_processed=transition_processed)
         except jira.JIRAError as e:
-            raise Exception("Unable to create issue!") from e
+            raise Exception(f"Unable to update issue {jira_issue.key}") from e
 
     def refresh_issue(self, action: IssueAction, issue: Issue) -> bool:
         """ Update NEWA identifier of issue.


### PR DESCRIPTION
Sometimes Jira returns error 401 during issue creation, although the issue had been created.

09:21:15 [2025-04-10 09:21:15,300] [jira    ] Processing ew_update
09:21:18 Traceback (most recent call last):
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/newa/__init__.py", line 1742, in create_issue
09:21:18     jira_issue = self.connection.create_issue(data)
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/client.py", line 1866, in create_issue
09:21:18     return self.issue(raw_issue_json["key"])
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/client.py", line 1810, in issue
09:21:18     issue.find(id, params=params)
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/resources.py", line 263, in find
09:21:18     self._find_by_url(url, params)
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/resources.py", line 279, in _find_by_url
09:21:18     self._load(url, params=params)
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/resources.py", line 451, in _load
09:21:18     r = self._session.get(url, headers=headers, params=params)
09:21:18   File "/home/jnode-ewa/.local/lib/python3.9/site-packages/requests/sessions.py", line 602, in get
09:21:18     return self.request("GET", url, **kwargs)
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/resilientsession.py", line 247, in request
09:21:18     elif raise_on_error(response, **processed_kwargs):
09:21:18   File "/opt/newa/lib64/python3.9/site-packages/jira/resilientsession.py", line 72, in raise_on_error
09:21:18     raise JIRAError(
09:21:18 jira.exceptions.JIRAError: JiraError HTTP 401 url: https://mydomain.com/rest/api/2/issue/PROJECT-4041
09:21:18 	text:
09:21:18 <html>
09:21:18
09:21:18 <head>
09:21:18     <title>Unauthorized (401)</title>

This patch tries to parse the newly created issue key from the error message and if it is present, proceed further with this key.