### PR TITLE
Introduce short_sleep() function

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -49,7 +49,6 @@ HTTP_STATUS_CODES_OK = [200, 201]
 
 # common sleep times to avoid too frequest Jira API requests
 SHORT_SLEEP = 0.6
-LONG_SLEEP = 1.5
 
 STATEDIR_TOPDIR = Path('/var/tmp/newa')
 
@@ -67,6 +66,10 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 SerializableT = TypeVar('SerializableT', bound='Serializable')
 SettingsT = TypeVar('SettingsT', bound='Settings')
+
+
+def short_sleep() -> None:
+    time.sleep(SHORT_SLEEP)
 
 
 def yaml_parser() -> ruamel.yaml.YAML:
@@ -1603,7 +1606,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
         # try connection first
         try:
             conn.myself()
-            time.sleep(SHORT_SLEEP)
+            short_sleep()
             # read field map from Jira and store its simplified version
             fields = conn.fields()
             for f in fields:
@@ -1623,7 +1626,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                         board_id = boards[0].id
                     else:
                         raise Exception(f"Could not find Jira board with name '{self.board}'")
-                    time.sleep(SHORT_SLEEP)
+                    short_sleep()
                 else:
                     board_id = self.board
                 # fetch both states at once
@@ -1632,7 +1635,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                     s.id for s in sprints if s.originBoardId == board_id and s.state == 'active']
                 self.sprint_cache['future'] = [
                     s.id for s in sprints if s.originBoardId == board_id and s.state == 'future']
-                time.sleep(SHORT_SLEEP)
+                short_sleep()
 
         except jira.JIRAError as e:
             raise Exception('Could not authenticate to Jira. Wrong token?') from e

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -49,6 +49,7 @@ from . import (
     eval_test,
     get_url_basename,
     render_template,
+    short_sleep,
     yaml_parser,
     )
 
@@ -674,7 +675,7 @@ def cmd_jira(
                     'group',
                     None))
             ctx.logger.info("Initialized Jira handler")
-            time.sleep(1.5)
+            short_sleep()
 
             # All issue action from the configuration.
             issue_actions = config.issues[:]
@@ -907,7 +908,7 @@ def cmd_jira(
                         parent = processed_actions.get(action.parent_id, None)
 
                     # wait a bit to avoid too frequest Jira API requests
-                    time.sleep(1.5)
+                    short_sleep()
                     new_issue = jira_handler.create_issue(
                         action,
                         rendered_summary,
@@ -932,7 +933,7 @@ def cmd_jira(
                     processed_actions[action.id] = new_issue
 
                     # wait a bit to avoid too frequest Jira API requests
-                    time.sleep(1.5)
+                    short_sleep()
 
                     # If the old issue was reused, re-fresh it.
                     trigger_erratum_comment = jira_handler.refresh_issue(action, new_issue)


### PR DESCRIPTION
Avoid having sleep duration constants at multiple places and use just a single sleep for now.
Long >1 s sleep doesn't make sense anyway as the Jira API limit is on requests per second.