### PR TITLE
Refactor RoG related code

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -544,7 +544,7 @@ def cmd_event(
     if rog_urls:
         if not ctx.settings.rog_token:
             raise Exception('RoG token is not configured!')
-        rog_tool = RoGTool(ctx.settings.rog_token)
+        rog_tool = RoGTool(token=ctx.settings.rog_token)
         for url in rog_urls:
             mr = rog_tool.get_mr(url)
             compose_id = derive_compose(mr.build_target, compose_mapping, ctx.logger)


### PR DESCRIPTION
## Summary by Sourcery

Refactor RoGTool to support a configurable GitLab URL and leverage a connection factory, centralize MR URL parsing and pipeline job retrieval, and update the CLI to instantiate RoGTool with the new parameters.

Enhancements:
- Introduce `url` and `connection` fields in RoGTool with a default connection factory
- Extract MR URL parsing into a dedicated `parse_mr_project_and_number` method
- Add `get_mr_build_rpm_pipeline_job` to encapsulate pipeline job lookup logic
- Refactor `get_mr` to reuse helper methods for parsing and job retrieval
- Update CLI to pass both `url` and `token` when creating RoGTool