### PR TITLE
Expose 'revision' field of Erratum

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -689,6 +689,8 @@ class ErrataTool:
                         content_type=content_type,
                         respin_count=int(
                             info_json["respin_count"]),
+                        revision=int(
+                            info_json["revision"]),
                         summary=info_json["synopsis"],
                         release=release,
                         builds=builds,
@@ -779,6 +781,7 @@ class Erratum(Cloneable, Serializable):  # type: ignore[no-untyped-def]
     people_package_owner: Optional[str] = None
     people_qe_group: Optional[str] = None
     people_devel_group: Optional[str] = None
+    revision: Optional[int] = field(repr=False, default=0)
 
 
 @define

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -40,7 +40,9 @@ def _mock_errata_tool(monkeypatch):
                 "qe_group": "group1@domain.com",
                 "devel_group": "group2@domain.com",
                 },
-            "respin_count": "1"}
+            "respin_count": "1",
+            "revision": "2",
+            }
 
     def mock_et_fetch_releases(self, id: str):
         """ Return a meaningful json with releases/builds """

--- a/tests/unit/test_eval_test.py
+++ b/tests/unit/test_eval_test.py
@@ -4,6 +4,7 @@ event = Event(type_=EventType.ERRATUM, id='foo')
 erratum = Erratum(id='12345',
                   content_type='rpm',
                   respin_count=1,
+                  # Intentionally ommiting 'revision'
                   summary='test errata',
                   people_assigned_to='user',
                   release='RHEL-9.4.0',


### PR DESCRIPTION
If builds change in NEW_FILES the respin_count isn't incremented

Errata didn't leave NEW_FILES, builds where changed:

```
  "revision": 2,
  "status": "NEW_FILES",
  "respin_count": 0,
```

## Summary by Sourcery

Enhancements:
- Expose the 'revision' field on Erratum by parsing it from info_json and including it in the data class