### PR TITLE
Increase short_sleep and Issue warning when there are no jobs

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -2061,8 +2061,8 @@ class ReportPortal:
         launch_info = self.get_launch_info(launch_uuid)
         empty = bool(not launch_info.get('statistics', {}).get('executions', {}))
         if logger and empty:
-            logger.warn(f'WARN: Launch {launch_uuid} seems to be empty. '
-                        '`tmt` reportportal plugin may not be enabled or configured properly.')
+            logger.warning(f'WARN: Launch {launch_uuid} seems to be empty. '
+                           '`tmt` reportportal plugin may not be enabled or configured properly.')
         return empty
 
     def get_request(self,

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -48,7 +48,7 @@ from requests_kerberos import HTTPKerberosAuth
 HTTP_STATUS_CODES_OK = [200, 201]
 
 # common sleep times to avoid too frequest Jira API requests
-SHORT_SLEEP = 0.6
+SHORT_SLEEP = 1
 
 STATEDIR_TOPDIR = Path('/var/tmp/newa')
 

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1094,7 +1094,7 @@ def cmd_schedule(ctx: CLIContext, arch: list[str], fixtures: list[str]) -> None:
     jira_jobs = list(ctx.load_jira_jobs('jira-'))
 
     if not jira_jobs:
-        ctx.logger.warn('Warning: There are no jira jobs to schedule')
+        ctx.logger.warning('Warning: There are no jira jobs to schedule')
         return
 
     for jira_job in jira_jobs:
@@ -1278,7 +1278,7 @@ def sanitize_restart_result(ctx: CLIContext, results: list[str]) -> list[Request
                        for job in execute_jobs]
     # do not print warning about missing results if these are results we want reschedule
     if (RequestResult.NONE in current_results) and (RequestResult.NONE not in sanitized):
-        ctx.logger.warn('WARN: Some requests do not have a known result yet.')
+        ctx.logger.warning('WARN: Some requests do not have a known result yet.')
     # error out if no test results matches required ones
     if not set(current_results).intersection(sanitized):
         ctx.logger.error(
@@ -1368,7 +1368,7 @@ def cmd_execute(
         for child in ctx.state_dirpath.iterdir()
         if child.name.startswith('schedule-')]
     if not schedule_list:
-        ctx.logger.warn('Warning: There are no previously scheduled jobs to execute')
+        ctx.logger.warning('Warning: There are no previously scheduled jobs to execute')
         return
 
     # initialize RP connection
@@ -1705,7 +1705,7 @@ def cmd_report(ctx: CLIContext) -> None:
     all_execute_jobs = list(ctx.load_execute_jobs('execute-'))
 
     if not all_execute_jobs:
-        ctx.logger.warn('Warning: There are no previously executed jobs to report')
+        ctx.logger.warning('Warning: There are no previously executed jobs to report')
         return
 
     # initialize RP connection

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1362,11 +1362,13 @@ def cmd_execute(
     # check if we have sufficient TF CLI version
     check_tf_cli_version(ctx)
 
+    def _get_schedule_list() -> list[tuple[CLIContext, Path]]:
+        return [(ctx, ctx.state_dirpath / child.name)
+                for child in ctx.state_dirpath.iterdir()
+                if child.name.startswith('schedule-')]
+
     # read a list of files to be scheduled just to check there are any
-    schedule_list = [
-        (ctx, ctx.state_dirpath / child.name)
-        for child in ctx.state_dirpath.iterdir()
-        if child.name.startswith('schedule-')]
+    schedule_list = _get_schedule_list()
     if not schedule_list:
         ctx.logger.warning('Warning: There are no previously scheduled jobs to execute')
         return
@@ -1502,10 +1504,7 @@ def cmd_execute(
                     f"Erratum {job.erratum.id} was updated with a comment about {jira_id}")
 
     # re-read a list of files to be scheduled as they could have been updated with RP launch info
-    schedule_list = [
-        (ctx, ctx.state_dirpath / child.name)
-        for child in ctx.state_dirpath.iterdir()
-        if child.name.startswith('schedule-')]
+    schedule_list = _get_schedule_list()
 
     worker_pool = multiprocessing.Pool(workers if workers > 0 else len(schedule_list))
     for _ in worker_pool.starmap(worker, schedule_list):


### PR DESCRIPTION
## Summary by Sourcery

Increase the global sleep interval and make the schedule, execute, and report commands safer by warning and exiting early when there are no jobs to process.

Enhancements:
- Increase SHORT_SLEEP constant from 0.6 to 1 second to reduce API request frequency
- Add warning and early return in cmd_schedule when no Jira jobs are available
- Add warning and early return in cmd_execute when no scheduled jobs exist
- Add warning and early return in cmd_report when no executed jobs are found
- Convert job-loading generators to lists for emptiness checks in related commands