### PR TITLE
Add support for issue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ issues:
      - report
    fields:
      Sprint: active
+   links:
+     "is blocked by":
+       - ABC-1234
+       - ABC-3456
 ```
 
 Individual settings are described below.
@@ -261,6 +265,7 @@ The following options are available:
    - `report` - Adds a comment when automated tests results are reported by NEWA.
  - `when`: A condition that restricts when an item should be used. See "In-config tests" section for examples.
  - `fields`: A dictionary identifying additional Jira issue fields that should be set for the issue. Currently, fields Reporter, Sprint, Status, Component/s and other fields having type "number", "string", "option", "list/select" should be supported.
+ - `links`: A dictionary identifying required link relations to a list of other Jira issues.
 
 ### `NEWA_COMMENT_FOOTER` environment variable
 

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -812,6 +812,24 @@ def cmd_jira(
                                 ROG=artifact_job.rog,
                                 CONTEXT=action.context,
                                 ENVIRONMENT=action.environment)
+                rendered_links: dict[str, list[str]] = {}
+                if action.links:
+                    for relation in action.links:
+                        rendered_links[relation] = []
+                        for linked_key in action.links[relation]:
+                            if isinstance(linked_key, str):
+                                rendered_links[relation].append(render_template(
+                                    linked_key,
+                                    EVENT=artifact_job.event,
+                                    ERRATUM=artifact_job.erratum,
+                                    COMPOSE=artifact_job.compose,
+                                    ROG=artifact_job.rog,
+                                    CONTEXT=action.context,
+                                    ENVIRONMENT=action.environment))
+                            else:
+                                # Log or raise error for non-string linked_key
+                                raise Exception(
+                                    f"Linked issue key '{linked_key}' must be a string")
 
                 # Detect that action has parent available (if applicable), if we went trough the
                 # actions already and parent was not found, we abort.
@@ -938,7 +956,8 @@ def cmd_jira(
                         group=config.group,
                         transition_passed=transition_passed,
                         transition_processed=transition_processed,
-                        fields=rendered_fields)
+                        fields=rendered_fields,
+                        links=rendered_links)
 
                     processed_actions[action.id] = new_issue
                     created_action_ids.append(action.id)


### PR DESCRIPTION
## Summary by Sourcery

Add support for defining and creating Jira issue links in NEWA

New Features:
- Add a `links` attribute to `IssueAction` and extend `create_issue` to accept and process links definitions
- Update CLI to render link templates and forward link relations when generating issues

Enhancements:
- Fetch and cache Jira issue link types on connection initialization for inward/outward mapping

Documentation:
- Document the `links` configuration option in README with example usage