### PR TITLE
Add more sleeps after Jira calls

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1830,6 +1830,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
 
         try:
             jira_issue = self.connection.create_issue(data)
+            short_sleep()
             if fields is None:
                 fields = {}
             # always add NEWA label to fields
@@ -1903,8 +1904,10 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                     raise Exception(f'Unsupported Jira field type "{field_type}"')
 
             jira_issue.update(fields=fdata)
+            short_sleep()
             if transition_name:
                 self.connection.transition_issue(jira_issue.key, transition=transition_name)
+                short_sleep()
             return Issue(jira_issue.key,
                          group=self.group,
                          summary=summary,
@@ -1942,8 +1945,10 @@ class IssueHandler:  # type: ignore[no-untyped-def]
         if new_description:
             try:
                 self.get_details(issue).update(fields={"description": new_description})
+                short_sleep()
                 self.comment_issue(
                     issue, "NEWA refreshed issue ID.")
+                short_sleep()
             except jira.JIRAError as e:
                 raise Exception(f"Unable to modify issue {issue}!") from e
         return return_value
@@ -1974,6 +1979,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                         'value': self.group} if self.group else None,
                     })
             # if the transition has a format status.resolution close with resolution
+            short_sleep()
             if '.' in self.transitions.dropped[0]:
                 status, resolution = self.transitions.dropped[0].split('.', 1)
                 self.connection.transition_issue(issue.id,

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -857,6 +857,7 @@ def cmd_jira(
                 else:
                     # Find existing issues related to artifact_job and action
                     # If we are supposed to recreate closed issues, search only for opened ones
+                    short_sleep()
                     if recreate:
                         search_result = jira_handler.get_related_issues(
                             action, all_respins=True, closed=False)
@@ -1009,6 +1010,7 @@ def cmd_jira(
                         raise Exception(
                             f"Invalid respin action {action.on_respin} for {old_issues}!")
                     for old_issue in old_issues:
+                        short_sleep()
                         jira_handler.drop_obsoleted_issue(
                             old_issue, obsoleted_by=processed_actions[action.id])
                         ctx.logger.info(f"Old issue {old_issue} closed")


### PR DESCRIPTION
## Summary by Sourcery

Throttle Jira API requests by inserting short delays after key operations

Enhancements:
- Introduce short_sleep after Jira create_issue, update fields, transition_issue, and comment operations to mitigate rate limits
- Add short_sleep in the CLI fake ID generator loop to pace Jira search calls