### PR TITLE
Add support for Jira event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ A couple of examples:
 when: EVENT is erratum
 when: EVENT is compose
 when: EVENT is RoG
+when: EVENT is jira
 when: EVENT is not erratum
 
 # Checking if errata number starts with (or contains or matches regexp) string "RHSA"
@@ -521,7 +522,7 @@ Enables YAML files rewrite when they already exist in state-dir.
 
 ### Subcommand `event`
 
-This subcommand is associated with a particular event (like an erratum) and it attempts to read details about it so that this data can be utilized in later parts of the workflow. While we are using erratum as an event example, other event types could be supported in the future (e.g. compose, build, GitLab MR etc.).
+This subcommand is associated with a particular event (like an erratum) and it attempts to read details about it so that this data can be utilized in later parts of the workflow. While we are using erratum as an event example, other event types could be supported in the future (e.g. compose, build, GitLab MR, Jira issue etc.).
 
 `event` subcommands reads event details either from a command line.
 ```shell
@@ -587,6 +588,29 @@ Example:
 ```
 $ newa event --erratum 12345
 $ newa event --prev-event jira ...
+```
+
+#### Option `--jira-issue`
+
+Directs NEWA to the `JIRA`-type event it should use, in particular a Jira issue key. Option can be used multiple times but each event will be processed individually. This event is not that useful for test scheduling at the moment. But you can use NEWA to create a pre-configure set of associated Jira issues.
+
+Example:
+```
+$ cat demodata/jira-jira-config.yaml
+issues:
+
+ - summary: "{{ JIRA.summary }} (review)"
+   description: "{{ JIRA.description }}"
+   type: task
+   id: tier_task
+   on_respin: close
+   links:
+     "blocks":
+       - "{{ JIRA.id }}"
+   fields:
+     Priority: "{{ JIRA.priority }}"
+
+$ newa event --jira-issue ABC-12345 jira --issue-config demodata/jira-jira-config.yaml
 ```
 
 #### Option `--rog-mr`

--- a/demodata/jira-jira-config.yaml
+++ b/demodata/jira-jira-config.yaml
@@ -1,0 +1,22 @@
+project: BASEQESEC
+
+transitions:
+  closed:
+    - Done
+    - Dropped
+    - Completed
+  dropped:
+    - Dropped
+
+issues:
+
+ - summary: "{{ JIRA.summary }} (results review)"
+   description: "{{ JIRA.description }}"
+   type: task
+   id: tier_task
+   on_respin: close
+   links:
+     "blocks":
+       - "{{ JIRA.id }}"
+   fields:
+     Priority: "{{ JIRA.priority }}"

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -476,6 +476,7 @@ class EventType(Enum):
     ERRATUM = 'erratum'
     COMPOSE = 'compose'
     ROG = 'rog'
+    JIRA = 'jira'
 
 
 class Arch(Enum):


### PR DESCRIPTION
## Summary by Sourcery

Add support for Jira events by introducing a new JIRA event type and wiring it through the CLI, event processing, and templating.

New Features:
- Add '--jira' option to the event subcommand to accept Jira issue keys
- Define JIRA in EventType and generate artifact jobs for Jira keys

Enhancements:
- Include Jira issue fields in the Jinja template processing through a JIRA object
- Assign issue_fields.id and throttle Jira API calls in the schedule command

Documentation:
- Update README to document 'when: EVENT is jira' and the '--jira' option
- Add sample demodata/jira-jira-config.yaml illustrating Jira event configuration