### PR TITLE
Add jira --no-newa-id option

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,15 @@ issues:
 $ newa ... jira --issue-config issue-config.yaml --map-issue errata_epic=RHEL-12345 ...
 ```
 
+#### Option `--no-newa-id`
+
+With this option NEWA won't search for any existing Jira issues and also won't update newly created ones with special identifier in Description that would help NEWA to find the issue again in the future. Use carefully, this always leads to new issues "invisible" to NEWA in future invocations.
+
+Example:
+```
+$ newa ... jira --issue-config issue-config.yaml --no-newa-id
+```
+
 #### Option `--recreate`
 
 By default, NEWA won't create a new Jira issue if a matching one but closed is found. With this option, NEWA will created a new Jira issue instead.

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1816,6 +1816,7 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                      action: IssueAction,
                      summary: str,
                      description: str,
+                     use_newa_id: bool = True,
                      assignee_email: str | None = None,
                      parent: Issue | None = None,
                      group: Optional[str] = None,
@@ -1824,11 +1825,12 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                      fields: Optional[dict[str, str | float | list[str]]] = None,
                      links: Optional[dict[str, list[str]]] = None) -> Issue:
         """ Create issue """
-
+        if use_newa_id:
+            description = f"{self.newa_id(action)}\n\n{description}"
         data = {
             "project": {"key": self.project},
             "summary": summary,
-            "description": f"{self.newa_id(action)}\n\n{description}",
+            "description": description,
             }
         if assignee_email and self.get_user_name(assignee_email):
             data |= {"assignee": {"name": self.get_user_name(assignee_email)}}
@@ -1862,11 +1864,12 @@ class IssueHandler:  # type: ignore[no-untyped-def]
             short_sleep()
             if fields is None:
                 fields = {}
-            # always add NEWA label to fields
-            if "Labels" in fields and isinstance(fields['Labels'], list):
-                fields['Labels'].append(IssueHandler.newa_label)
-            else:
-                fields['Labels'] = [IssueHandler.newa_label]
+            # add NEWA label unless not using newa id
+            if use_newa_id:
+                if "Labels" in fields and isinstance(fields['Labels'], list):
+                    fields['Labels'].append(IssueHandler.newa_label)
+                else:
+                    fields['Labels'] = [IssueHandler.newa_label]
             # populate fdata with configuration provided by the user
             fdata: dict[str, str | float | list[Any] | dict[str, Any]] = {}
             transition_name: Optional[str] = None

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -590,6 +590,12 @@ def cmd_event(
           'Example: --map-issue jira_epic=RHEL-123456'),
     )
 @click.option(
+    '--no-newa-id',
+    is_flag=True,
+    default=False,
+    help='Do not update issue with newa identifier and ignore any existing ones.',
+    )
+@click.option(
     '--recreate',
     is_flag=True,
     default=False,
@@ -625,6 +631,7 @@ def cmd_jira(
         ctx: CLIContext,
         issue_config: str,
         map_issue: list[str],
+        no_newa_id: bool,
         recreate: bool,
         issue: str,
         prev_issue: bool,
@@ -909,7 +916,8 @@ def cmd_jira(
                     new_issues.append(mapped_issue)
 
                 # otherwise we need to search for the issue in Jira
-                else:
+                # unless newa id is not supposed to be used
+                elif not no_newa_id:
                     # Find existing issues related to artifact_job and action
                     # If we are supposed to recreate closed issues, search only for opened ones
                     short_sleep()
@@ -985,11 +993,12 @@ def cmd_jira(
                     # wait a bit to avoid too frequest Jira API requests
                     short_sleep()
                     new_issue = jira_handler.create_issue(
-                        action,
-                        rendered_summary,
-                        rendered_description,
-                        rendered_assignee,
-                        parent,
+                        action=action,
+                        summary=rendered_summary,
+                        description=rendered_description,
+                        use_newa_id=not no_newa_id,
+                        assignee_email=rendered_assignee,
+                        parent=parent,
                         group=config.group,
                         transition_passed=transition_passed,
                         transition_processed=transition_processed,


### PR DESCRIPTION
## Summary by Sourcery

Introduce a `--no-newa-id` option to the Jira command to bypass any NEWA identifier lookups or updates, integrate the flag through the issue creation flow, and update documentation accordingly

New Features:
- Add `--no-newa-id` CLI flag to disable NEWA identifier lookup and injection in Jira operations

Enhancements:
- Propagate the `--no-newa-id` option through the Jira command to skip searching for or updating issues with a NEWA ID
- Modify the `create_issue` method to conditionally prepend the NEWA identifier based on the flag

Documentation:
- Document the `--no-newa-id` option and its behavior in the README