### PR TITLE
Error out when RP launch name is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ Example:
 newa --prev-state-dir execute -R REQ-1.2.1 -R REQ-2.2.2 report
 ```
 
-#### Option `--restart-result`
+#### Option `--restart-result`, `-r`
 This option can be used to reschedule NEWA request that have ended with a particular result - `passed, failed, error`. For example, `--restart-result error`. Result can be either `passed`, `failed` or `error` where 'error' means that test execution hasn't been finished correctly. This option can be used multiple times. Implies `--continue`.
 
 

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1388,6 +1388,7 @@ def sanitize_restart_result(ctx: CLIContext, results: list[str]) -> list[Request
                     'Example: --restart-request REQ-1.2.1'),
               )
 @click.option('--restart-result',
+              '-r',
               default=[],
               multiple=True,
               help=('Restart finished TF jobs having the specified result. '

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1515,7 +1515,9 @@ def cmd_execute(
 
         # otherwise we proceed with launch creation
         # get additional launch details from the first schedule job
-        launch_name = schedule_jobs[0].request.reportportal['launch_name']
+        launch_name = schedule_jobs[0].request.reportportal['launch_name'].strip()
+        if not launch_name:
+            raise Exception("RP launch name is not configured")
         launch_attrs = schedule_jobs[0].request.reportportal.get(
             'launch_attributes', {})
         launch_attrs.update({'newa_statedir': str(ctx.state_dirpath)})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ include = [
 platforms = ["linux"]
 
 [tool.hatch.envs.dev]
+dev-mode = true
 description = "Development environment"
 dependencies = [
     "autopep8",


### PR DESCRIPTION
## Summary by Sourcery

Validate the presence of a ReportPortal launch name and abort if unset, add a shorthand `-r` for the `--restart-result` option, update documentation to reflect the alias, and enable dev-mode in the development environment configuration

Bug Fixes:
- Error out when a blank ReportPortal launch name is encountered

Enhancements:
- Add `-r` shorthand flag for the `--restart-result` option

Build:
- Enable dev-mode in the Hatch development environment configuration

Documentation:
- Document the new `-r` alias for `--restart-result` in README