### PR TITLE
Add support for --action-id-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,17 @@ $ newa event --erratum 12345
 $ newa event --prev-event jira ...
 ```
 
+#### Option `--action-id-filter`
+
+Instructs NEWA to process only a subset of issue-config actions, depending on whether the issue-config action id matches the provided regular expression.
+This option has an effect across all NEWA subcommands so users can use this option to limit requests that would be cancelled, executed, reported etc.
+Use with caution.
+
+Example:
+```
+$ newa --action-id-filter '(epic|tier1).*' event --compose CentOS-Stream-10 jira --issue-config all-tier-config.yaml schedule execute report
+```
+
 #### Option `--jira-issue`
 
 Directs NEWA to the `JIRA`-type event it should use, in particular a Jira issue key. Option can be used multiple times but each event will be processed individually. This event is not that useful for test scheduling at the moment. But you can use NEWA to create a pre-configure set of associated Jira issues.


### PR DESCRIPTION
## Summary by Sourcery

Enable users to limit NEWA processing to a subset of actions by adding a regex-based action ID filter that is applied across job loading, processing, and reporting.

New Features:
- Add `--action-id-filter` CLI option to process only actions matching a provided regular expression

Enhancements:
- Extend job loaders (Jira, Schedule, Execute) to skip jobs based on the action ID filter
- Introduce `skip_action` helper in CLIContext to centralize action ID filtering logic
- Add `action_id` field to Issue model and propagate it when creating issues
- Include action IDs in CLI output next to issue identifiers
- Factor out job filepath construction into dedicated `get_*_filepath` methods

Documentation:
- Document the new `--action-id-filter` option and its usage in README