### PR TITLE
Add support for recipe includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,13 @@ A recipe file is associated with a Jira issue through the `job_recipe` attribute
 
 Recipe configuration file enables users to describe a complex test matrix. This is achieved by using a set of parameters passed to each Testing Farm requests and parameterized tmt plans enabling runtime adjustments.
 
-A recipe file configuration is split into two sections. The first section is named `fixtures` and contains configuration that is relevant to all test jobs triggered by the recipe file.
+A recipe file configuration is split into three sections. The first section is named `fixtures` and contains configuration that is relevant to all test jobs triggered by the recipe file.
 
 The second section is named` dimensions` and it outlines how the test matrix looks like. Each dimension is identified by its name and defines a list of possible values, each value representing  a configuration snippet that would be used for the respective test job. `newa` does a Cartesian product of defined dimensions, building all possible combinations. Those will be saved for further execution.
 
-When mergine attributes from `fixtures` and `dimensions`, value from a particular `dimension` may override a value from `fixtures`. This is on purpose so that `fixtures` may provide sane defaults that could be possibly overriden (yes, bad naming). A recipe can also override `context` or `environment` value obtained from the `jira-` YAML file (e.g. specified in issue-config file). However, a recipe can't override a value that has been defined on a command line directly using `newa --context ...`, `newa --environment ...` or `newa schedule --fixture ...` options.
+The third section is called `includes` and contains a list of other recipe files. `fixtures` definitions from those files will be included and merged with `fixtures` definition of the current recipe file. Particular settings from definitions loaded later may override settings from definitions loaded earlier. Please note that `dimensions` are not loaded from `includes`.
+
+When merging attributes from `fixtures` and `dimensions`, value from a particular `dimension` may override a value from `fixtures`. This is on purpose so that `fixtures` may provide sane defaults that could be possibly overridden (yes, bad naming). A recipe can also override `context` or `environment` value obtained from the `jira-` YAML file (e.g. specified in issue-config file). However, a recipe can't override a value that has been defined on a command line directly using `newa --context ...`, `newa --environment ...` or `newa schedule --fixture ...` options.
 
 Example:
 Using the recipe file

--- a/demodata/recipe3-include1.yaml
+++ b/demodata/recipe3-include1.yaml
@@ -1,0 +1,5 @@
+fixtures:
+  environment:
+    PLANET: Earth
+  context:
+    navigate: yes

--- a/demodata/recipe3-include2.yaml
+++ b/demodata/recipe3-include2.yaml
@@ -1,0 +1,6 @@
+fixtures:
+  context:
+    reverse: yes
+  reportportal:
+    launch_name: "default_name"
+    launch_description: "default_description"

--- a/demodata/recipe3.yaml
+++ b/demodata/recipe3.yaml
@@ -1,0 +1,31 @@
+includes:
+  - demodata/recipe3-include1.yaml
+  - demodata/recipe3-include2.yaml
+
+fixtures:
+  tmt:
+    url: https://github.com/RedHatQE/newa.git
+    ref: main
+    path: demodata
+    plan: /plan1
+  reportportal:
+    launch_name: "newa_demo1"
+    launch_description: "NEWA demo1 description"
+    suite_description: "color = {{ CONTEXT.color }}, city = {{ ENVIRONMENT.CITY }}"
+    launch_attributes:
+      city: "{{ ENVIRONMENT.CITY }}"
+      color: "{{ CONTEXT.color }}"
+
+dimensions:
+  cities:
+    - environment:
+        CITY: Brno
+    - environment:
+        CITY: Boston
+      when: CONTEXT.color is match("blue")
+  colors:
+    - context:
+        color: red
+      when: ENVIRONMENT.CITY is not match("Brno")
+    - context:
+        color: blue

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1264,10 +1264,7 @@ def cmd_schedule(ctx: CLIContext, arch: list[str], fixtures: list[str]) -> None:
         if jira_job.erratum:
             initial_config['context'].update({'erratum': str(jira_job.erratum.id)})
 
-        if re.search('^https?://', jira_job.recipe.url):
-            config = RecipeConfig.from_yaml_url(jira_job.recipe.url)
-        else:
-            config = RecipeConfig.from_yaml_file(Path(jira_job.recipe.url))
+        config = RecipeConfig.from_yaml_with_includes(jira_job.recipe.url)
         # extend dimensions with system architecture but do not override existing settings
         if 'arch' not in config.dimensions:
             config.dimensions['arch'] = []

--- a/tests/unit/data/recipe-include-child1.yaml
+++ b/tests/unit/data/recipe-include-child1.yaml
@@ -1,0 +1,7 @@
+fixtures:
+    context:
+        tier: 2
+        trigger: weekly
+    environment:
+        DESCRIPTION: "child1 description"
+        LAST_CHILD: 1

--- a/tests/unit/data/recipe-include-child2.yaml
+++ b/tests/unit/data/recipe-include-child2.yaml
@@ -1,0 +1,8 @@
+includes:
+  - tests/unit/data/recipe-include-child3.yaml
+fixtures:
+    context:
+        trigger: nightly
+    environment:
+        DESCRIPTION: "child2 description"
+        LAST_CHILD: 2

--- a/tests/unit/data/recipe-include-child3.yaml
+++ b/tests/unit/data/recipe-include-child3.yaml
@@ -1,0 +1,3 @@
+fixtures:
+    context:
+        verbosity: 99

--- a/tests/unit/data/recipe-include-parent.yaml
+++ b/tests/unit/data/recipe-include-parent.yaml
@@ -1,0 +1,14 @@
+includes:
+  - tests/unit/data/recipe-include-child1.yaml
+  - tests/unit/data/recipe-include-child2.yaml
+fixtures:
+    context:
+        tier: 0
+    environment:
+        DESCRIPTION: "parent description"
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - context:
+             arch: aarch64

--- a/tests/unit/test_include.py
+++ b/tests/unit/test_include.py
@@ -1,9 +1,11 @@
-from newa import IssueConfig, IssueType
+from newa import IssueConfig, IssueType, RecipeConfig
 
 c = IssueConfig.read_file('tests/unit/data/issue-config-include-parent.yaml')
+r = RecipeConfig.from_yaml_with_includes('tests/unit/data/recipe-include-parent.yaml')
+print(r)
 
 
-def test_include_on_defaults():
+def test_issue_config_include_on_defaults():
     # issues come from all 3 files
     assert len(c.issues) == 3
     # project comes form child2
@@ -22,7 +24,7 @@ def test_include_on_defaults():
     assert c.defaults.fields["Story Points"] == 1
 
 
-def test_defaults_override_on_issue():
+def test_issue_config_defaults_override_on_issue():
     i = c.issues[0]
     # 1st issue action overrides some defaults
     assert i.type == IssueType.EPIC
@@ -34,3 +36,16 @@ def test_defaults_override_on_issue():
     assert i.type == IssueType.TASK
     assert i.assignee is None
     assert i.fields['Story Points'] == 1
+
+
+def test_recipe_include():
+    # LAST_CHILD comes from child2
+    assert r.fixtures["environment"]["LAST_CHILD"] == 2
+    # DESCRIPTION comes from parent
+    assert r.fixtures["environment"]["DESCRIPTION"] == "parent description"
+    # tier comes from parent
+    assert r.fixtures["context"]["tier"] == 0
+    # trigger comes from child1
+    assert r.fixtures["context"]["trigger"] == "nightly"
+    # verbosity comes from child3
+    assert r.fixtures["context"]["verbosity"] == 99


### PR DESCRIPTION
Enable recipe file includes by introducing an `includes` field, implementing recursive loading and merging of fixtures from multiple recipe files, updating the CLI loader, and documenting the feature with examples.

New Features:
- Add support for `includes` in recipe configurations to combine fixtures from external recipe files
- Implement RecipeConfig.from_yaml_with_includes to recursively load and merge included recipes with recursion detection

Enhancements:
- Extract and reuse merge_combination_data as its own method in RecipeConfig
- Refactor build_requests to leverage the new merge_combination_data implementation

Documentation:
- Document the new `includes` section in the recipe config README
- Add sample demodata YAML files demonstrating the use of recipe includes