### PR TITLE
Add support for ppc64 architecture on RHEL-7

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -499,25 +499,33 @@ class Arch(Enum):
     AARCH64 = 'aarch64'
     S390X = 's390x'
     PPC64LE = 'ppc64le'
+    PPC64 = 'ppc64'
     NOARCH = 'noarch'
     MULTI = 'multi'
     SRPMS = 'SRPMS'  # just to ease errata processing
 
     @classmethod
     def architectures(cls: type[Arch],
-                      preset: Optional[list[Arch]] = None) -> list[Arch]:
+                      preset: Optional[list[Arch]] = None,
+                      compose: Optional[str] = None) -> list[Arch]:
 
         _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH]
         _all = [Arch(a) for a in Arch.__members__.values() if a not in _exclude]
+        _default = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'aarch64']]
+        _default_rhel7 = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'ppc64']]
 
+        if compose and re.match('^rhel-7', compose, flags=re.IGNORECASE):
+            default = _default_rhel7
+        else:
+            default = _default
         if not preset:
-            return _all
+            return default
         # 'noarch' should be tested on all architectures
         if Arch('noarch') in preset:
-            return _all
+            return default
         # 'multi' is given for container advisories
         if Arch('multi') in preset:
-            return _all
+            return default
         return list(set(_all).intersection(set(preset)))
 
 

--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1229,7 +1229,8 @@ def cmd_schedule(ctx: CLIContext, arch: list[str], fixtures: list[str]) -> None:
                 [Arch(a.strip()) for a in arch])
         else:
             architectures = jira_job.erratum.archs if (
-                jira_job.erratum and jira_job.erratum.archs) else Arch.architectures()
+                jira_job.erratum and jira_job.erratum.archs) else Arch.architectures(
+                compose=compose)
 
         # prepare cli_config and initial config copying it from jira_job
         initial_config = RawRecipeConfigDimension(

--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -4,14 +4,17 @@ from newa import Arch
 def test_arch_ok():
     arch_list = Arch.architectures([Arch.MULTI])
     noarch_list = Arch.architectures([Arch.NOARCH])
+    noarch_list_rhel7 = Arch.architectures([Arch.NOARCH], compose='RHEL-7')
     default_list = Arch.architectures()
+    default_list_rhel7 = Arch.architectures(compose='rhel-7.9')
     exp_default_list = [Arch.X86_64, Arch.S390X, Arch.PPC64LE, Arch.AARCH64]
     subset = [Arch.X86_64, Arch.S390X]
     intersect = Arch.architectures(subset)
 
     assert len(arch_list) == 4
-    assert all(Arch(n) in arch_list for n in Arch.__members__.values()
-               if n not in [Arch.MULTI, Arch.SRPMS, Arch.NOARCH])
+    assert all(Arch(n) in default_list for n in ['x86_64', 's390x', 'ppc64le', 'aarch64'])
+    assert all(Arch(n) in default_list_rhel7 for n in ['x86_64', 's390x', 'ppc64le', 'ppc64'])
     assert set(arch_list) == set(noarch_list)
+    assert set(default_list_rhel7) == set(noarch_list_rhel7)
     assert set(default_list) == set(exp_default_list)
     assert set(subset) == set(intersect)


### PR DESCRIPTION
## Summary by Sourcery

Add support for the ppc64 architecture on RHEL-7 by extending the architecture enum, adapting default selections in Arch.architectures based on compose version, and updating the CLI to forward compose context.

New Features:
- Add PPC64 as a supported architecture

Enhancements:
- Introduce an optional compose parameter to Arch.architectures to select RHEL-7–specific defaults
- Define RHEL-7 default architecture set including PPC64 alongside existing arches
- Pass compose context into CLI scheduling command when resolving target architectures