### PR TITLE
Add support for i686

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -495,6 +495,7 @@ class EventType(Enum):
 class Arch(Enum):
     """ Available system architectures """
 
+    I686 = 'i686'
     X86_64 = 'x86_64'
     AARCH64 = 'aarch64'
     S390X = 's390x'
@@ -509,7 +510,7 @@ class Arch(Enum):
                       preset: Optional[list[Arch]] = None,
                       compose: Optional[str] = None) -> list[Arch]:
 
-        _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH]
+        _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH, Arch.I686]
         _all = [Arch(a) for a in Arch.__members__.values() if a not in _exclude]
         _default = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'aarch64']]
         _default_rhel7 = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'ppc64']]


### PR DESCRIPTION
## Summary by Sourcery

Add support for the i686 architecture by introducing a new Arch member and updating the architecture selection logic to omit it by default.

New Features:
- Add I686 architecture constant to Arch enum

Enhancements:
- Exclude I686 from the default architecture list in architectures()