### PR TITLE
Add plan name to Jira issue

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1913,7 +1913,8 @@ def cmd_report(ctx: CLIContext) -> None:
                     'state': job.execution.state,
                     'result': str(job.execution.result),
                     'uuid': job.execution.request_uuid,
-                    'url': job.execution.artifacts_url}
+                    'url': job.execution.artifacts_url,
+                    'plan': job.request.tmt.get('plan', None)}
                 if job.execution.result != RequestResult.PASSED:
                     all_tests_passed = False
                 if job.execution.state not in ['complete', 'error', 'canceled']:
@@ -1939,6 +1940,8 @@ def cmd_report(ctx: CLIContext) -> None:
                 # would hit description length limit. Therefore using plain text
                 launch_description += "<br>{id}: {state}, {result}".format(**results[req])
                 jira_description += "\n[{id}|{url}]: {state}, {result}".format(**results[req])
+                if results[req]['plan']:
+                    jira_description += f", {results[req]['plan']}"
             # finish launch just in case it hasn't been finished already
             # and update description with more detailed results
             rp.finish_launch(launch_uuid)


### PR DESCRIPTION
## Summary by Sourcery

Include test plan names in Jira issue descriptions for enhanced traceability

Enhancements:
- Add `plan` field to result data for each request
- Append the plan name to Jira issue description entries when available