### PR TITLE
Add support for story jira issue type

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1480,7 +1480,7 @@ class IssueType(Enum):
     EPIC = 'epic'
     TASK = 'task'
     SUBTASK = 'subtask'
-
+    STORY = 'story'
 
 class OnRespinAction(Enum):
     # TODO: what's the default? It would simplify the class a bit.
@@ -1897,6 +1897,10 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                 "issuetype": {"name": "Epic"},
                 IssueHandler.field_map["Epic Name"].id_: data["summary"],
                 }
+        elif action.type == IssueType.STORY:
+            data |= {"issuetype": {"name": "Story"}}
+            if parent:
+                data |= {IssueHandler.field_map["Epic Link"].id_: parent.id}
         elif action.type == IssueType.TASK:
             data |= {"issuetype": {"name": "Task"}}
             if parent:

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -1482,6 +1482,7 @@ class IssueType(Enum):
     SUBTASK = 'subtask'
     STORY = 'story'
 
+
 class OnRespinAction(Enum):
     # TODO: what's the default? It would simplify the class a bit.
     KEEP = 'keep'


### PR DESCRIPTION
Add a support for `story` type of a jira issue.

Fixes #252

## Summary by Sourcery

Add support for the 'Story' Jira issue type, including enum entry and creation logic with optional epic linkage.

New Features:
- Add 'Story' issue type to IssueType enum
- Handle creation of 'Story' issues and link them to a parent epic if provided