### PR TITLE
Add Compose.prev_major and Compose.prev_minor

### DIFF
--- a/tests/unit/test_compose.py
+++ b/tests/unit/test_compose.py
@@ -1,0 +1,21 @@
+from newa import UNDEFINED_COMPOSE, Compose
+
+
+def test_compose():
+    def test(compose_id: str, prev_major: str, prev_minor: str):
+        c = Compose(compose_id)
+        assert (c.prev_major == prev_major)
+        assert (c.prev_minor == prev_minor)
+    # Checking various combinations
+    test('foo', UNDEFINED_COMPOSE, UNDEFINED_COMPOSE)
+    test('RHEL-', UNDEFINED_COMPOSE, UNDEFINED_COMPOSE)
+    test('RHEL-6', UNDEFINED_COMPOSE, UNDEFINED_COMPOSE)
+    test('RHEL-8.10.0-updates-20250811.3', 'RHEL-7-LatestUpdated', 'RHEL-8.9.0-Nightly')
+    test('RHEL-9.0.0-Nightly', 'RHEL-8-Nightly', UNDEFINED_COMPOSE)
+    test('RHEL-9.7.0-Nightly', 'RHEL-8-Nightly', 'RHEL-9.6.0-Nightly')
+    test('RHEL-9-Nightly', 'RHEL-8-Nightly', UNDEFINED_COMPOSE)
+    test('RHEL-10.1-Nightly', 'RHEL-9-Nightly', 'RHEL-10.0-Nightly')
+    test('RHEL-10.0-Nightly', 'RHEL-9-Nightly', UNDEFINED_COMPOSE)
+    test('Fedora', UNDEFINED_COMPOSE, UNDEFINED_COMPOSE)
+    test('Fedora-42-Updated', 'Fedora-41-Updated', UNDEFINED_COMPOSE)
+    test('Fedora-Rawhide-Nightly', UNDEFINED_COMPOSE, UNDEFINED_COMPOSE)


### PR DESCRIPTION
## Summary by Sourcery

Add prev_minor and prev_major properties to Compose to derive previous compose IDs based on distribution and version rules, introduce a placeholder for undefined versions, and include unit tests for these methods

New Features:
- Add Compose.prev_minor property to compute the previous minor compose identifier
- Add Compose.prev_major property to compute the previous major compose identifier

Enhancements:
- Introduce UNDEFINED_COMPOSE constant to represent undefined compose values

Tests:
- Add unit tests covering various prev_major and prev_minor scenarios for RHEL and Fedora composes