### PR TITLE
Fix -z build targets

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -413,6 +413,7 @@ def apply_release_mapping(string: str,
             r'RHEL-10\.0\.BETA=RHEL-10-Beta',
             r'-candidate$=',
             r'-draft$=',
+            r'-z$=',
             r'$=-Nightly',
             # ugly hack to narrow weird TF compose naming for RHEL-7
             r'RHEL-7-ELS-Nightly=RHEL-7.9-ZStream',

--- a/tests/unit/test_release_mapping.py
+++ b/tests/unit/test_release_mapping.py
@@ -17,6 +17,7 @@ def test_release_mapping():
         # build target mapping
         ('rhel-10.1-candidate', 'RHEL-10.1-Nightly'),
         ('rhel-9.7.0-draft', 'RHEL-9.7.0-Nightly'),
+        ('rhel-10.1-z-draft', 'RHEL-10.1-Nightly'),
         ]
     for release, distro in matrix:
         assert cli.apply_release_mapping(release) == distro


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add regex to remove '-z' suffix in apply_release_mapping to fix '-z' build target handling