### PR TITLE
Add service check for RP and ET

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -633,6 +633,15 @@ class ErrataTool:
             krb=True,
             response_content=ResponseContentType.JSON)
 
+    def fetch_system_info(self) -> JSON:
+        return get_request(
+            url=urllib.parse.urljoin(
+                self.url,
+                "/system_info.json"),
+            # not using krb=True due to an authentization error/bug, we did auth already
+            # krb=True,
+            response_content=ResponseContentType.JSON)
+
     def fetch_blocking_errata(self, erratum_id: str) -> JSON:
         return get_request(
             url=urllib.parse.urljoin(
@@ -641,6 +650,15 @@ class ErrataTool:
             # not using krb=True due to an authentization error/bug, we did auth already
             # krb=True,
             response_content=ResponseContentType.JSON)
+
+    def check_connection(self, et_url: str, logger: logging.Logger) -> None:
+        try:
+            et_system_info = self.fetch_system_info()
+            logger.debug(f"ErrataTool system version is={et_system_info['errata_version']}")
+            if not et_system_info:
+                raise Exception("Could not get ErrataTool system version info.")
+        except Exception as e:
+            raise Exception(f"ErrataTool is not available at {et_url}.") from e
 
     def get_errata(self, event: Event, process_blocking_errata: bool = True) -> list[Erratum]:
         """
@@ -2262,6 +2280,24 @@ class ReportPortal:
     def get_launch_url(self, launch_uuid: str) -> str:
         return urllib.parse.urljoin(
             self.url, f"/ui/#{Q(self.project)}/launches/all/{Q(launch_uuid)}")
+
+    def get_current_user_info(self) -> JSON:
+        url = urllib.parse.urljoin(
+            self.url, "/api/users")
+        headers = {"Authorization": f"bearer {self.token}", "Content-Type": "application/json"}
+        req = requests.get(url, headers=headers)
+        if req.status_code in HTTP_STATUS_CODES_OK:
+            return req.json()
+        return None
+
+    def check_connection(self, rp_url: str, logger: logging.Logger) -> None:
+        try:
+            rp_user_info = self.get_current_user_info()
+            logger.debug(f"ReportPortal user is={rp_user_info['id']}")
+            if not rp_user_info:
+                raise Exception("Could not get ReportPortal user info.")
+        except Exception as e:
+            raise Exception(f"ReportPortal is not available at {rp_url}.") from e
 
     def check_for_empty_launch(self, launch_uuid: str,
                                logger: Optional[logging.Logger] = None) -> bool:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,14 +63,20 @@ def _mock_errata_tool(monkeypatch):
         """ Return empty json for blocking errata """
         return {}
 
+    def mock_et_fetch_system_info(self):
+        """ Return dictionary with information about ErrataTool system """
+        return {
+            "errata_version": "v1.5.3",
+            }
+
     # TODO in the future we might want to do more complex patching of the class
     # methods, but this will suffice for now
     monkeypatch.setenv("NEWA_ET_URL", "https://fake.erratatool.com")
-    # We want to make sure we don't make requests to errata tool
     monkeypatch.setattr(newa, 'get_request', mock_get_request)
     monkeypatch.setattr(newa.ErrataTool, 'fetch_info', mock_et_fetch_info)
     monkeypatch.setattr(newa.ErrataTool, 'fetch_releases', mock_et_fetch_releases)
     monkeypatch.setattr(newa.ErrataTool, 'fetch_blocking_errata', mock_et_fetch_blocking_errata)
+    monkeypatch.setattr(newa.ErrataTool, 'fetch_system_info', mock_et_fetch_system_info)
 
 
 # TODO There's still not much logic to test in cli. These test is just a stub to


### PR DESCRIPTION
Closes #274

## Summary by Sourcery

Add service availability checks for ReportPortal and ErrataTool by enhancing client classes and centralizing connection initialization in the CLI, and update tests to accommodate the new verification methods.

New Features:
- Add initialize_rp_connection and initialize_et_connection functions to centralize and validate ReportPortal and ErrataTool connections from CLI
- Add check_connection methods in ErrataTool and ReportPortal clients to verify service availability

Enhancements:
- Replace inline client instantiation in multiple CLI commands with the new initializer functions
- Add fetch_system_info to ErrataTool and get_current_user_info to ReportPortal for connection validation

Tests:
- Update unit tests to mock ErrataTool.fetch_system_info for the service check