### PR TITLE
E2S, E6S: Change compose mapping

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -416,7 +416,7 @@ def apply_release_mapping(string: str,
     if not mapping:
         mapping = [
             r'\.GA$=',
-            r'\.Z\.?(MAIN)?(\+)?(AUS|EUS|E4S|TUS)?$=',
+            r'\.Z\.?(MAIN)?(\+)?(AUS|E.S|TUS)?$=',
             r'^rhel-=RHEL-',
             r'RHEL-10\.0\.BETA=RHEL-10-Beta',
             r'-candidate$=',


### PR DESCRIPTION
Closes #276

## Summary by Sourcery

Enhancements:
- Include E2S in the regex for compose mapping in apply_release_mapping