### PR TITLE
Refactor 'schedule' subcommand

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -47,6 +47,7 @@ from . import (
     Recipe,
     RecipeConfig,
     ReportPortal,
+    Request,
     RequestResult,
     RoGTool,
     ScheduleJob,
@@ -1447,6 +1448,206 @@ def cmd_jira(
                 job_recipe, jira_none_id)
 
 
+def _determine_architectures(
+        ctx: CLIContext,
+        arch_options: list[str],
+        jira_job: JiraJob,
+        compose: Optional[str]) -> list[Arch]:
+    """Determine which architectures to use for scheduling."""
+    if arch_options:
+        return Arch.architectures([Arch(a.strip()) for a in arch_options])
+
+    if jira_job.erratum and jira_job.erratum.archs:
+        return jira_job.erratum.archs
+
+    return Arch.architectures(compose=compose)
+
+
+def _prepare_initial_config(
+        ctx: CLIContext,
+        jira_job: JiraJob,
+        compose: Optional[str]) -> RawRecipeConfigDimension:
+    """Prepare initial configuration from jira_job."""
+    initial_config = RawRecipeConfigDimension(
+        compose=compose,
+        environment=jira_job.recipe.environment or {},
+        context=jira_job.recipe.context or {})
+
+    # Add erratum context if testing erratum
+    if jira_job.erratum:
+        initial_config['context'].update({'erratum': str(jira_job.erratum.id)})
+
+    ctx.logger.debug(f'Initial config: {initial_config})')
+    return initial_config
+
+
+def _process_fixtures(
+        ctx: CLIContext,
+        fixtures: list[str],
+        cli_config: RawRecipeConfigDimension) -> None:
+    """Process command-line fixtures and update cli_config in place."""
+    if not fixtures:
+        return
+
+    for fixture in fixtures:
+        r = re.fullmatch(r'([^\s=]+)=([^=]*)', fixture)
+        if not r:
+            raise Exception(
+                f"Fixture {fixture} does not having expected format 'name=value'")
+
+        fixture_name, fixture_value = r.groups()
+        fixture_config = cli_config
+
+        # Descend through keys to the lowest level
+        while '.' in fixture_name:
+            prefix, suffix = fixture_name.split('.', 1)
+            fixture_config = fixture_config.setdefault(prefix, {})  # type: ignore [misc]
+            fixture_name = suffix
+
+        # Parse the input as yaml to enable lists and dicts
+        value = yaml_parser().load(fixture_value)
+        fixture_config[fixture_name] = value  # type: ignore[literal-required]
+
+    ctx.logger.debug(f'CLI config modified through --fixture: {cli_config})')
+
+
+def _configure_recipe(
+        ctx: CLIContext,
+        config: RecipeConfig,
+        architectures: list[Arch],
+        recipe_url: str) -> None:
+    """Configure recipe with architecture and reportportal defaults."""
+    # Extend dimensions with system architecture but do not override existing settings
+    if 'arch' not in config.dimensions:
+        config.dimensions['arch'] = []
+        for architecture in architectures:
+            config.dimensions['arch'].append({'arch': architecture})
+
+    # If RP launch name is not specified in the recipe, set it based on the recipe filename
+    if not config.fixtures.get('reportportal', None):
+        config.fixtures['reportportal'] = RawRecipeReportPortalConfigDimension()
+
+    # Populate default for config.fixtures['reportportal']['launch_name']
+    if ((config.fixtures['reportportal'] is not None) and
+            (not config.fixtures['reportportal'].get('launch_name', None))):
+        config.fixtures['reportportal']['launch_name'] = os.path.splitext(
+            get_url_basename(recipe_url))[0]
+
+
+def _render_request_attributes(
+        request: Request,
+        jinja_vars: dict[str, Any]) -> None:
+    """Render request attributes as Jinja templates in place."""
+    for attr in ("reportportal", "tmt", "testingfarm", "environment", "context", "compose"):
+        # compose value is a string, not dict
+        if attr == 'compose':
+            value = getattr(request, attr, '')
+            new_value = render_template(str(value), **jinja_vars)
+            if new_value:
+                setattr(request, attr, new_value)
+        else:
+            # getattr(request, attr) could also be None due to 'attr' being None
+            mapping = getattr(request, attr, {}) or {}
+            for (key, value) in mapping.items():
+                # launch_attributes is a dict
+                if key == 'launch_attributes':
+                    for (k, v) in value.items():
+                        mapping[key][k] = render_template(str(v), **jinja_vars)
+                else:
+                    mapping[key] = render_template(str(value), **jinja_vars)
+
+
+def _prepare_jinja_vars_for_request(
+        jira_job: JiraJob,
+        request: Request,
+        issue_fields: Any) -> dict[str, Any]:
+    """Prepare Jinja template variables for request rendering."""
+    jinja_vars: dict[str, Any] = {
+        'EVENT': jira_job.event,
+        'ERRATUM': jira_job.erratum,
+        'COMPOSE': jira_job.compose,
+        'ROG': jira_job.rog,
+        'CONTEXT': request.context,
+        'ENVIRONMENT': request.environment,
+        'ISSUE': issue_fields}
+
+    if request.arch:
+        jinja_vars['ARCH'] = request.arch.value
+
+    return jinja_vars
+
+
+def _get_issue_fields_for_jira(
+        ctx: CLIContext,
+        jira_job: JiraJob) -> Any:
+    """Get Jira issue fields if available, otherwise return empty dict."""
+    if jira_job.jira.id and (not jira_job.jira.id.startswith(JIRA_NONE_ID)):
+        jira_connection = initialize_jira_connection(ctx)
+        issue_fields = jira_connection.issue(jira_job.jira.id).fields
+        issue_fields.id = jira_job.jira.id
+        short_sleep()
+        return issue_fields
+    return {}
+
+
+def _process_jira_job(
+        ctx: CLIContext,
+        jira_job: JiraJob,
+        arch_options: list[str],
+        fixtures: list[str],
+        no_reportportal: bool) -> None:
+    """Process a single jira_job and create schedule jobs."""
+    # Determine compose and architectures
+    compose = jira_job.compose.id if jira_job.compose else None
+    architectures = _determine_architectures(ctx, arch_options, jira_job, compose)
+
+    # Prepare initial and CLI configs
+    initial_config = _prepare_initial_config(ctx, jira_job, compose)
+    cli_config = RawRecipeConfigDimension(
+        environment=ctx.cli_environment,
+        context=ctx.cli_context)
+    ctx.logger.debug(f'CLI config: {cli_config})')
+
+    # Process fixtures
+    _process_fixtures(ctx, fixtures, cli_config)
+
+    # Load and configure recipe
+    config = RecipeConfig.from_yaml_with_includes(jira_job.recipe.url)
+    _configure_recipe(ctx, config, architectures, jira_job.recipe.url)
+
+    # Build requests
+    jinja_vars: dict[str, Any] = {
+        'EVENT': jira_job.event,
+        'ERRATUM': jira_job.erratum,
+        }
+    requests = list(config.build_requests(initial_config, cli_config, jinja_vars))
+    ctx.logger.info(f'{len(requests)} requests have been generated')
+
+    # Get Jira issue fields
+    issue_fields = _get_issue_fields_for_jira(ctx, jira_job)
+
+    # Create ScheduleJob for each request
+    for request in requests:
+        # Clear reportportal attribute when --no-reportportal
+        if no_reportportal:
+            request.reportportal = None
+
+        # Prepare Jinja variables and render request attributes
+        jinja_vars = _prepare_jinja_vars_for_request(jira_job, request, issue_fields)
+        _render_request_attributes(request, jinja_vars)
+
+        # Create and save schedule job
+        schedule_job = ScheduleJob(
+            event=jira_job.event,
+            erratum=jira_job.erratum,
+            compose=jira_job.compose,
+            rog=jira_job.rog,
+            jira=jira_job.jira,
+            recipe=jira_job.recipe,
+            request=request)
+        ctx.save_schedule_job(schedule_job)
+
+
 @main.command(name='schedule')
 @click.option('--arch',
               default=[],
@@ -1475,9 +1676,18 @@ def cmd_schedule(
         arch: list[str],
         fixtures: list[str],
         no_reportportal: bool) -> None:
+    """
+    Schedule subcommand - creates schedule jobs from jira jobs.
+
+    This command processes jira jobs and generates schedule jobs by:
+    1. Determining architectures to test
+    2. Preparing configuration from recipe and command-line options
+    3. Building test requests with Jinja template rendering
+    4. Creating and saving schedule job YAML files
+    """
     ctx.enter_command('schedule')
 
-    # ensure state dir is present and initialized
+    # Ensure state dir is present and initialized
     initialize_state_dir(ctx)
 
     if ctx.settings.newa_clear_on_subcommand:
@@ -1495,140 +1705,9 @@ def cmd_schedule(
         ctx.logger.warning('Warning: There are no jira jobs to schedule')
         return
 
+    # Process each jira job
     for jira_job in jira_jobs:
-
-        # prepare parameters based on the recipe from recipe.url
-        # generate all relevant test request using the recipe data
-        # prepare a list of Request objects
-
-        # would it be OK not to pass compose to TF? I guess so
-        compose = jira_job.compose.id if jira_job.compose else None
-        if arch:
-            architectures = Arch.architectures(
-                [Arch(a.strip()) for a in arch])
-        else:
-            architectures = jira_job.erratum.archs if (
-                jira_job.erratum and jira_job.erratum.archs) else Arch.architectures(
-                compose=compose)
-
-        # prepare cli_config and initial config copying it from jira_job
-        initial_config = RawRecipeConfigDimension(
-            compose=compose,
-            environment=jira_job.recipe.environment or {},
-            context=jira_job.recipe.context or {})
-        ctx.logger.debug(f'Initial config: {initial_config})')
-        cli_config = RawRecipeConfigDimension(environment=ctx.cli_environment,
-                                              context=ctx.cli_context)
-        ctx.logger.debug(f'CLI config: {cli_config})')
-        if fixtures:
-            for fixture in fixtures:
-                r = re.fullmatch(r'([^\s=]+)=([^=]*)', fixture)
-                if not r:
-                    raise Exception(
-                        f"Fixture {fixture} does not having expected format 'name=value'")
-                fixture_name, fixture_value = r.groups()
-                fixture_config = cli_config
-                # descent through keys to the lowest level
-                while '.' in fixture_name:
-                    prefix, suffix = fixture_name.split('.', 1)
-                    fixture_config = fixture_config.setdefault(prefix, {})  # type: ignore [misc]
-                    fixture_name = suffix
-                # now we are at the lowest level
-                # Is it beneficial to parse the input as yaml?
-                # It enables us to define list and dicts but there might be drawbacks as well
-                value = yaml_parser().load(fixture_value)
-                fixture_config[fixture_name] = value  # type: ignore[literal-required]
-            ctx.logger.debug(f'CLI config modified through --fixture: {cli_config})')
-
-        # when testing erratum, add special context erratum=XXXX
-        if jira_job.erratum:
-            initial_config['context'].update({'erratum': str(jira_job.erratum.id)})
-
-        config = RecipeConfig.from_yaml_with_includes(jira_job.recipe.url)
-        # extend dimensions with system architecture but do not override existing settings
-        if 'arch' not in config.dimensions:
-            config.dimensions['arch'] = []
-            for architecture in architectures:
-                config.dimensions['arch'].append({'arch': architecture})
-        # if RP launch name is not specified in the recipe, set it based on the recipe filename
-        if not config.fixtures.get('reportportal', None):
-            config.fixtures['reportportal'] = RawRecipeReportPortalConfigDimension()
-        # Populate default for config.fixtures['reportportal']['launch_name']
-        # Although config.fixtures['reportportal'] is not None, though linter still complaints
-        # so we repeat the condition once more
-        if ((config.fixtures['reportportal'] is not None) and
-                (not config.fixtures['reportportal'].get('launch_name', None))):
-            config.fixtures['reportportal']['launch_name'] = os.path.splitext(
-                get_url_basename(jira_job.recipe.url))[0]
-        # build requests
-        jinja_vars: dict[str, Any] = {
-            'EVENT': jira_job.event,
-            'ERRATUM': jira_job.erratum,
-            }
-
-        requests = list(config.build_requests(initial_config, cli_config, jinja_vars))
-        ctx.logger.info(f'{len(requests)} requests have been generated')
-
-        # make Jira issue fields available to Jinja templates as well
-        if jira_job.jira.id and (not jira_job.jira.id.startswith(JIRA_NONE_ID)):
-            jira_connection = initialize_jira_connection(ctx)
-            issue_fields = jira_connection.issue(jira_job.jira.id).fields
-            issue_fields.id = jira_job.jira.id
-            short_sleep()
-        else:
-            issue_fields = {}
-
-        # create ScheduleJob object for each request
-        for request in requests:
-            # clear reportportal attribute when --no-reportportal
-            if no_reportportal:
-                request.reportportal = None
-            # prepare dict for Jinja template rendering
-            jinja_vars = {
-                'EVENT': jira_job.event,
-                'ERRATUM': jira_job.erratum,
-                'COMPOSE': jira_job.compose,
-                'ROG': jira_job.rog,
-                'CONTEXT': request.context,
-                'ENVIRONMENT': request.environment,
-                'ISSUE': issue_fields}
-            if request.arch:
-                jinja_vars['ARCH'] = request.arch.value
-            # before yaml export render all fields as Jinja templates
-            for attr in (
-                    "reportportal",
-                    "tmt",
-                    "testingfarm",
-                    "environment",
-                    "context",
-                    "compose"):
-                # compose value is a string, not dict
-                if attr == 'compose':
-                    value = getattr(request, attr, '')
-                    new_value = render_template(str(value), **jinja_vars)
-                    if new_value:
-                        setattr(request, attr, new_value)
-                else:
-                    # getattr(request, attr) could also be None due to 'attr' being None
-                    mapping = getattr(request, attr, {}) or {}
-                    for (key, value) in mapping.items():
-                        # launch_attributes is a dict
-                        if key == 'launch_attributes':
-                            for (k, v) in value.items():
-                                mapping[key][k] = render_template(str(v), **jinja_vars)
-                        else:
-                            mapping[key] = render_template(str(value), **jinja_vars)
-
-            # export schedule_job yaml
-            schedule_job = ScheduleJob(
-                event=jira_job.event,
-                erratum=jira_job.erratum,
-                compose=jira_job.compose,
-                rog=jira_job.rog,
-                jira=jira_job.jira,
-                recipe=jira_job.recipe,
-                request=request)
-            ctx.save_schedule_job(schedule_job)
+        _process_jira_job(ctx, jira_job, arch, fixtures, no_reportportal)
 
 
 @main.command(name='cancel')


### PR DESCRIPTION
Summary of Changes

  The original cmd_schedule function (182 lines, 1450-1632) has been refactored into 8 smaller, focused helper functions plus
   a simplified main function:

  New Helper Functions (lines 1450-1647):

  1. _determine_architectures() - Determines which system architectures to use for scheduling
  2. _prepare_initial_config() - Prepares initial configuration from jira_job
  3. _process_fixtures() - Processes command-line fixtures and updates CLI config
  4. _configure_recipe() - Configures recipe with architecture and ReportPortal defaults
  5. _render_request_attributes() - Renders request attributes as Jinja templates
  6. _prepare_jinja_vars_for_request() - Prepares Jinja template variables for request rendering
  7. _get_issue_fields_for_jira() - Retrieves Jira issue fields if available
  8. _process_jira_job() - Main orchestrator that processes a single jira_job

  Refactored cmd_schedule() function (lines 1673-1709):

  - Now only 37 lines (down from 182!)
  - Clear separation of concerns
  - Added comprehensive docstring explaining the workflow
  - Simple loop that calls _process_jira_job() for each job

Assisted by: Claude AI

## Summary by Sourcery

Refactor the 'schedule' subcommand to improve clarity and maintainability by extracting core logic into modular helper functions and simplifying the main command workflow.

Enhancements:
- Extract eight focused helper functions to handle architecture determination, initial configuration, fixture processing, recipe configuration, request rendering, Jinja variable preparation, Jira issue retrieval, and per-job processing
- Simplify cmd_schedule to a concise loop that delegates to _process_jira_job and add a comprehensive docstring describing its workflow
- Add Request import and enhance logging for debug visibility