### PR TITLE
[WIP] Use RoG token for gitlab.com API GET requests

### DIFF
--- a/newa/cli.py
+++ b/newa/cli.py
@@ -1421,7 +1421,7 @@ def cmd_jira(
             # Mode 1: Using issue-config file
             # we are reading the issue config again for each artifact
             # because later we modify some objects
-            config = IssueConfig.read_file(os.path.expandvars(issue_config))
+            config = IssueConfig.read_file(os.path.expandvars(issue_config), ctx=ctx)
             issue_mapping = _parse_issue_mapping(map_issue, config)
 
             # Initialize Jira handler
@@ -1612,7 +1612,7 @@ def _process_jira_job(
     _process_fixtures(ctx, fixtures, cli_config)
 
     # Load and configure recipe
-    config = RecipeConfig.from_yaml_with_includes(jira_job.recipe.url)
+    config = RecipeConfig.from_yaml_with_includes(jira_job.recipe.url, ctx)
     _configure_recipe(ctx, config, architectures, jira_job.recipe.url)
 
     # Build requests


### PR DESCRIPTION
For URLs starting with https://gitlab.com/api/ use configured RoG API token.

Currently, in order to be able to fetch a file from gitlab.com one has to tranform the URL into the following format:

  https://gitlab.com/api/v4/projects/<project_id>/repository/files/<path_to_file>/raw?ref=main

where:

 - project path like redhat/rhel/tests/pkgname has to be URL encoded, i.e. redhat%2Frhel%2Ftests%2Fsetroubleshoot-plugins
 - file path has to be also URL encoded, i.e. path%2Fto%2Ffile
 - non-default branch has to be specified as well

## Summary by Sourcery

Introduce support for using the RoG API token for GitLab.com GET requests and propagate the CLIContext through HTTP and YAML loading functions.

Enhancements:
- Add optional CLIContext parameter to generic get_request and various from_yaml methods to pass settings.
- Automatically include PRIVATE-TOKEN header for URLs targeting https://gitlab.com/api/ when a RoG token is configured in the context.
- Propagate the new ctx argument through RecipeConfig and IssueConfig loading methods and their CLI call sites.