### PR TITLE
Introduce Errata.is_els_release attribute

### DIFF
--- a/newa/models/artifacts.py
+++ b/newa/models/artifacts.py
@@ -90,6 +90,7 @@ class Erratum(Cloneable, Serializable):  # type: ignore[no-untyped-def]
     blocking_builds: list[str] = field(factory=list)
     blocking_errata: list['ErratumId'] = field(factory=list)
     components: list[str] = field(factory=list)
+    is_els_release: bool = field(default=False)
     people_assigned_to: Optional[str] = None
     people_package_owner: Optional[str] = None
     people_qe_group: Optional[str] = None

--- a/newa/services/errata_service.py
+++ b/newa/services/errata_service.py
@@ -12,6 +12,7 @@ except ModuleNotFoundError:
 from newa.models.artifacts import Erratum, ErratumContentType
 from newa.models.base import Arch
 from newa.models.events import Event, EventType
+from newa.utils.helpers import els_release_check
 from newa.utils.http import ResponseContentType, get_request, post_request
 from newa.utils.parsers import NSVCParser, NVRParser
 
@@ -98,7 +99,6 @@ class ErrataTool:
         On the other hand an errata with ASYNC release might result into one
         or more instances of erratum.
         """
-
         errata = []
 
         # In QE state there is are zero or more builds in an erratum, each
@@ -168,6 +168,7 @@ class ErrataTool:
                             info_json["revision"]),
                         summary=info_json["synopsis"],
                         release=release,
+                        is_els_release=els_release_check(release),
                         builds=builds,
                         blocking_builds=blocking_builds,
                         blocking_errata=[e.id for e in blocking_errata],

--- a/newa/utils/__init__.py
+++ b/newa/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility functions for newa."""
 
-from newa.utils.helpers import get_url_basename, short_sleep
+from newa.utils.helpers import els_release_check, get_url_basename, short_sleep
 from newa.utils.http import ResponseContentType, get_request, post_request
 from newa.utils.parsers import NSVCParser, NVRParser
 from newa.utils.templates import default_template_environment, eval_test, render_template
@@ -11,6 +11,7 @@ __all__ = [
     'NVRParser',
     'ResponseContentType',
     'default_template_environment',
+    'els_release_check',
     'eval_test',
     'get_request',
     'get_url_basename',

--- a/newa/utils/helpers.py
+++ b/newa/utils/helpers.py
@@ -1,6 +1,7 @@
 """Helper utility functions."""
 
 import os
+import re
 import time
 import urllib
 
@@ -14,3 +15,8 @@ def short_sleep() -> None:
 
 def get_url_basename(url: str) -> str:
     return os.path.basename(urllib.parse.urlparse(url).path)
+
+
+def els_release_check(release: str) -> bool:
+    """Returns True if the release is ELS release"""
+    return bool(re.search(r'(RHEL-7-ELS|\.Z\..*(AUS|TUS|E.S))', release))

--- a/tests/unit/test_els_release_check.py
+++ b/tests/unit/test_els_release_check.py
@@ -1,0 +1,17 @@
+from newa.utils.helpers import els_release_check
+
+
+def test_els_release_check():
+    # Test that not passing erratum loads the default errata config and excepts
+    matrix = [
+        ('RHEL-10.2.GA', False),
+        ('RHEL-9.7.0.Z.MAIN', False),
+        ('RHEL-10.1.Z', False),
+        ('RHEL-9.2.0.Z.EUS', True),
+        ('RHEL-9.0.0.Z.E4S', True),
+        ('RHEL-8.10.0.Z.MAIN+EUS', True),
+        ('RHEL-8.6.0.Z.AUS', True),
+        ('RHEL-7-ELS', True),
+        ]
+    for release, result in matrix:
+        assert els_release_check(release) == result


### PR DESCRIPTION
## Summary by Sourcery

Add support for identifying ELS releases by introducing a new helper function, adding an is_els_release field to the Erratum model, populating it in the errata service, and covering it with unit tests.

New Features:
- Introduce els_release_check helper to detect ELS releases
- Add is_els_release attribute to Erratum model and set it when fetching errata

Tests:
- Add unit tests for the els_release_check function