### PR TITLE
Do not treat .Z.MAIN errata releases as ELS

### DIFF
--- a/newa/utils/helpers.py
+++ b/newa/utils/helpers.py
@@ -19,4 +19,6 @@ def get_url_basename(url: str) -> str:
 
 def els_release_check(release: str) -> bool:
     """Returns True if the release is ELS release"""
+    if '.Z.MAIN' in release:
+        return False
     return bool(re.search(r'(RHEL-7-ELS|\.Z\..*(AUS|TUS|E.S))', release))

--- a/tests/unit/test_els_release_check.py
+++ b/tests/unit/test_els_release_check.py
@@ -9,7 +9,7 @@ def test_els_release_check():
         ('RHEL-10.1.Z', False),
         ('RHEL-9.2.0.Z.EUS', True),
         ('RHEL-9.0.0.Z.E4S', True),
-        ('RHEL-8.10.0.Z.MAIN+EUS', True),
+        ('RHEL-8.10.0.Z.MAIN+EUS', False),
         ('RHEL-8.6.0.Z.AUS', True),
         ('RHEL-7-ELS', True),
         ]


### PR DESCRIPTION
## Summary by Sourcery

Adjust ELS release detection to exclude .Z.MAIN errata from being treated as ELS.

Bug Fixes:
- Prevent .Z.MAIN errata releases from being incorrectly classified as ELS.

Tests:
- Update unit tests to reflect the new ELS detection behavior for .Z.MAIN errata releases.