### PR TITLE
Add 'summarize' subcommand supported by AI model

### DIFF
--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -56,6 +56,7 @@ from newa.models import (
 
 # Import all services
 from newa.services import (
+    AIService,
     ErrataTool,
     IssueHandler,
     JiraField,
@@ -88,6 +89,8 @@ __all__ = [
     'STATEDIR_TOPDIR',
     'TF_REQUEST_FINISHED_STATES',
     'UNDEFINED_COMPOSE',
+    # Services
+    'AIService',
     # Models - base
     'Arch',
     # Models - jobs
@@ -97,7 +100,6 @@ __all__ = [
     'Cloneable',
     # Models - artifacts
     'Compose',
-    # Services
     'ErrataTool',
     'Erratum',
     'ErratumCommentTrigger',

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -1,0 +1,221 @@
+"""Summarize command for NEWA CLI."""
+
+from typing import Any
+
+import click
+from jira import JIRA
+
+from newa import CLIContext, ExecuteJob
+from newa.cli.initialization import initialize_jira_connection, initialize_rp_connection
+from newa.cli.summarize_helpers import (
+    collect_launch_details,
+    format_jira_issue_details,
+    )
+from newa.cli.utils import initialize_state_dir
+from newa.services.ai_service import AIService
+
+
+def fetch_jira_issues_bulk(jira_client: JIRA, issue_keys: list[str]) -> dict[str, dict[str, Any]]:
+    """Fetch detailed information for multiple Jira issues in a single query.
+
+    Args:
+        jira_client: Authenticated Jira client
+        issue_keys: List of Jira issue keys (e.g., ['RHEL-12345', 'RHEL-67890'])
+
+    Returns:
+        Dictionary mapping issue key to issue details
+    """
+    if not issue_keys:
+        return {}
+
+    # Remove '???' entries if present
+    valid_keys = [k for k in issue_keys if k != '???']
+    if not valid_keys:
+        return {}
+
+    try:
+        # Build JQL query to fetch all issues at once
+        jql = f"key in ({','.join(valid_keys)})"
+        issues = jira_client.search_issues(jql, maxResults=len(valid_keys))
+
+        result = {}
+        for issue in issues:
+            # Extract component names
+            components = [
+                c.name for c in issue.fields.components] if issue.fields.components else []
+
+            # Extract version names
+            affects_versions = [
+                v.name for v in issue.fields.versions] if issue.fields.versions else []
+            fix_versions = [
+                v.name for v in issue.fields.fixVersions] if issue.fields.fixVersions else []
+
+            result[issue.key] = {
+                'key': issue.key,
+                'summary': issue.fields.summary,
+                'status': issue.fields.status.name,
+                'components': components,
+                'affects_versions': affects_versions,
+                'fix_versions': fix_versions,
+                }
+
+        return result
+    except Exception as e:
+        raise Exception(f'Failed to fetch Jira issues: {e}') from e
+
+
+def process_execute_job_for_summary(
+        ctx: CLIContext,
+        execute_job: ExecuteJob,
+        rp: Any,
+        jira_client: JIRA,
+        ai_service: AIService) -> None:
+    """Process a single execute job and add AI summary to its Jira issue.
+
+    Args:
+        ctx: CLI context
+        execute_job: The execute job to process
+        rp: ReportPortal service instance
+        jira_client: Authenticated Jira client
+        ai_service: AI service instance
+    """
+    jira_id = execute_job.jira.id
+
+    # Check if the execute job has ReportPortal launch metadata
+    if not execute_job.request.reportportal:
+        ctx.logger.debug(
+            f'Skipping {jira_id}: No ReportPortal launch metadata in execute job')
+        return
+
+    launch_uuid = execute_job.request.reportportal.get('launch_uuid')
+    if not launch_uuid:
+        ctx.logger.debug(f'Skipping {jira_id}: No launch_uuid in ReportPortal metadata')
+        return
+
+    ctx.logger.info(f'Processing {jira_id} with RP launch {launch_uuid}')
+
+    # Get launch info to convert UUID to ID
+    try:
+        launch_info = rp.get_launch_info(launch_uuid)
+        if not launch_info:
+            ctx.logger.warning(
+                f'Could not find launch {launch_uuid} in ReportPortal project '
+                f'{ctx.settings.rp_project}')
+            return
+        launch_id = launch_info['id']
+    except Exception as e:
+        ctx.logger.error(f'Error getting launch info for {launch_uuid}: {e}')
+        return
+
+    # Collect launch details
+    ctx.logger.info(f'Collecting data from RP launch {launch_id}')
+    output_lines, all_jira_issues = collect_launch_details(
+        rp, ctx.settings.rp_url, ctx.settings.rp_project, launch_id, ctx.logger)
+
+    # Fetch and format Jira issue details
+    if all_jira_issues:
+        ctx.logger.info(f'Fetching details for {len(all_jira_issues)} Jira issues')
+        jira_issues_data = fetch_jira_issues_bulk(jira_client, list(all_jira_issues))
+        output_lines.extend(format_jira_issue_details(jira_issues_data))
+
+    # Combine all output into a single string for AI processing
+    user_message = '\n'.join(output_lines)
+
+    # Query AI model
+    ctx.logger.info(f'Querying AI model for summary of RP launch {launch_uuid}')
+    try:
+        ai_summary = ai_service.query_ai_model(user_message)
+    except Exception as e:
+        ctx.logger.error(f'Error querying AI model: {e}')
+        return
+
+    # Add comment to Jira issue
+    ctx.logger.info(f'Adding AI summary comment to {jira_id}')
+    try:
+        comment = f"NEWA AI-generated ReportPortal launch summary:\n\n{ai_summary}"
+        jira_client.add_comment(
+            jira_id,
+            comment,
+            visibility={
+                'type': 'group',
+                'value': execute_job.jira.group}
+            if execute_job.jira.group else None)
+        ctx.logger.info(f'Successfully added AI summary to {jira_id}')
+    except Exception as e:
+        ctx.logger.error(f'Error adding comment to Jira issue {jira_id}: {e}')
+
+
+@click.command(name='summarize')
+@click.pass_obj
+def cmd_summarize(ctx: CLIContext) -> None:
+    """
+    Generate AI summaries of ReportPortal launches and update Jira issues.
+
+    This command:
+    1. Loads execute jobs from state directory
+    2. For each job with ReportPortal launch metadata:
+       - Collects test execution data from ReportPortal
+       - Generates AI summary using configured AI service
+       - Updates the corresponding Jira issue with the summary
+    """
+    ctx.enter_command('summarize')
+
+    # Initialize state directory
+    initialize_state_dir(ctx)
+
+    # Load execute jobs
+    all_execute_jobs = list(ctx.load_execute_jobs(filter_actions=True))
+    if not all_execute_jobs:
+        ctx.logger.warning('Warning: There are no execute jobs to summarize')
+        return
+
+    # Check AI configuration
+    if not ctx.settings.ai_api_url or not ctx.settings.ai_api_token:
+        ctx.logger.error(
+            'AI API URL and token must be configured in newa.conf [ai] section or '
+            'via NEWA_AI_API_URL and NEWA_AI_API_TOKEN environment variables')
+        return
+
+    # Initialize services
+    rp = initialize_rp_connection(ctx) if ctx.settings.rp_url else None
+    if not rp:
+        ctx.logger.error('ReportPortal URL must be configured to use summarize command')
+        return
+
+    jira_connection = initialize_jira_connection(ctx)
+
+    ai_service = AIService(
+        api_url=ctx.settings.ai_api_url,
+        api_token=ctx.settings.ai_api_token,
+        model=ctx.settings.ai_api_model)
+
+    # Track processed launch UUIDs to avoid duplicate summaries
+    processed_launches: set[str] = set()
+
+    # Process each execute job
+    for execute_job in all_execute_jobs:
+        try:
+            # Check if launch has already been processed
+            if execute_job.request.reportportal:
+                launch_uuid = execute_job.request.reportportal.get('launch_uuid')
+                if launch_uuid and launch_uuid in processed_launches:
+                    ctx.logger.debug(
+                        f'Skipping {execute_job.jira.id}: RP launch {launch_uuid} '
+                        'already processed')
+                    continue
+
+            process_execute_job_for_summary(
+                ctx, execute_job, rp, jira_connection, ai_service)
+
+            # Mark launch as processed
+            if execute_job.request.reportportal:
+                launch_uuid = execute_job.request.reportportal.get('launch_uuid')
+                if launch_uuid:
+                    processed_launches.add(launch_uuid)
+
+        except Exception as e:
+            ctx.logger.error(
+                f'Error processing execute job {execute_job.id}: {e}')
+            continue
+
+    ctx.logger.info('Summarize command completed')

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -16,6 +16,7 @@ from newa.cli.commands.jira_cmd import cmd_jira
 from newa.cli.commands.list_cmd import cmd_list
 from newa.cli.commands.report_cmd import cmd_report
 from newa.cli.commands.schedule_cmd import cmd_schedule
+from newa.cli.commands.summarize_cmd import cmd_summarize
 from newa.cli.constants import NEWA_DEFAULT_CONFIG
 from newa.cli.utils import get_state_dir
 
@@ -205,3 +206,4 @@ main.add_command(cmd_schedule)
 main.add_command(cmd_execute)
 main.add_command(cmd_report)
 main.add_command(cmd_cancel)
+main.add_command(cmd_summarize)

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -1,0 +1,260 @@
+"""Helper functions for the Summarize command."""
+
+import logging
+import re
+import textwrap
+from typing import Any, Optional
+
+from newa import ReportPortal
+
+# Test item type mapping for ReportPortal
+TEST_ITEM_TYPE_MAPPING = {
+    "Product bugs": "pb001",
+    "Automation bugs": "ab001",
+    "System issues": "si001",
+    "Not a defect": "nd001",
+    "To Investigate": "ti001",
+    }
+
+
+def extract_jira_issues_from_comment(comment: str) -> list[str]:
+    """Extract Jira issue IDs from comment text.
+
+    Parses URLs like https://issues.redhat.com/browse/RHEL-12345
+    Returns a list of issue IDs (e.g., ['RHEL-12345'])
+    """
+    if not comment:
+        return []
+
+    pattern = r'https://issues\.redhat\.com/browse/(RHEL-\d+)'
+    return re.findall(pattern, comment)
+
+
+def get_launch_test_items_data(
+        rp: ReportPortal,
+        launch_id: int,
+        item_type: str,
+        logger: Optional[logging.Logger] = None) -> dict[str, Any]:
+    """Extract test items data from ReportPortal launch with pagination support.
+
+    Returns a dictionary with:
+    - 'count': number of items
+    - 'issues': dict mapping issue_id -> comment (for backward compatibility)
+    - 'failures': list of individual test failures with their details
+    """
+    # Fetch all pages of test items
+    all_content = []
+    page_number = 1
+    total_pages = 1
+
+    while page_number <= total_pages:
+        test_items = rp.get_request(
+            '/item',
+            {
+                'filter.eq.launchId': str(launch_id),
+                'page.size': '1024',
+                'page.number': str(page_number),
+                'filter.eq.issueType': TEST_ITEM_TYPE_MAPPING[item_type],
+                })
+
+        if not test_items or not test_items.get('content'):
+            break
+
+        all_content.extend(test_items['content'])
+
+        # Update pagination info from response
+        page_info = test_items.get('page', {})
+        total_pages = page_info.get('totalPages', 1)
+        total_elements = page_info.get('totalElements', len(all_content))
+
+        # Log pagination info on first page
+        if page_number == 1 and total_pages > 1 and logger:
+            logger.info(
+                f'{item_type}: Fetching {total_elements} items across {total_pages} pages')
+
+        page_number += 1
+
+    if not all_content:
+        return {'count': 0, 'issues': {}, 'failures': []}
+
+    count = len(all_content)
+
+    if item_type == 'To Investigate':
+        return {'count': count, 'issues': {}, 'failures': []}
+
+    issues = {}
+    failures = []
+
+    for i in all_content:
+        issue = i.get('issue', {})
+        comment = issue.get('comment', '')
+
+        # Collect issue IDs from external system issues
+        issue_ids = [ext['ticketId'] for ext in issue.get('externalSystemIssues', [])]
+
+        # Also parse Jira issues from comment text
+        jira_issues_from_comment = extract_jira_issues_from_comment(comment)
+        issue_ids.extend(jira_issues_from_comment)
+
+        # Store individual failure
+        failures.append({
+            'name': i.get('name', 'Unknown'),
+            'comment': comment,
+            'issue_ids': issue_ids or ['???'],
+            })
+
+        # Store issues with their comments (for backward compatibility)
+        if issue_ids:
+            for issue_id in issue_ids:
+                if issue_id not in issues:
+                    issues[issue_id] = comment
+        else:
+            # No issue ID found
+            issues['???'] = comment
+
+    return {'count': count, 'issues': issues, 'failures': failures}
+
+
+def format_launch_test_items(item_type: str, data: dict[str, Any]) -> list[str]:
+    """Format test items data for a given item type.
+
+    Args:
+        item_type: Type of test item (e.g., 'Product bugs')
+        data: Dictionary with 'count', 'issues', and 'failures' keys
+
+    Returns:
+        List of formatted lines
+    """
+    output: list[str] = []
+
+    if data['count'] == 0:
+        return output
+
+    if item_type == 'To Investigate':
+        output.append(f'{item_type}: {data["count"]}')
+        return output
+
+    output.append(f'{item_type}:')
+
+    # Print individual failures
+    for failure in data.get('failures', []):
+        issue_keys = ', '.join(failure['issue_ids'])
+        output.append(f'{4 * " "}{failure["name"]} [{issue_keys}]: {failure["comment"]}')
+
+    return output
+
+
+def format_jira_issue_details(jira_issues_data: dict[str, dict[str, Any]]) -> list[str]:
+    """Format detailed information for Jira issues.
+
+    Args:
+        jira_issues_data: Dictionary mapping issue key to issue details
+
+    Returns:
+        List of formatted lines
+    """
+    if not jira_issues_data:
+        return []
+
+    output = [
+        '=' * 80,
+        'Jira Issue Details:',
+        '=' * 80,
+        '',
+        ]
+
+    for issue_key in sorted(jira_issues_data.keys()):
+        issue = jira_issues_data[issue_key]
+        components = ", ".join(issue["components"]) if issue["components"] else "None"
+        affects = ", ".join(issue["affects_versions"]) if issue["affects_versions"] else "None"
+        fix = ", ".join(issue["fix_versions"]) if issue["fix_versions"] else "None"
+        output.extend([
+            f'Issue: {issue["key"]}',
+            f'Summary: {issue["summary"]}',
+            f'Status: {issue["status"]}',
+            f'Component: {components}',
+            f'Affects Version/s: {affects}',
+            f'Fix Version/s: {fix}',
+            '',
+            ])
+
+    return output
+
+
+def format_statistics(launch_details: dict[str, Any], all_data: dict[str, dict[str, Any]]) -> str:
+    """Format one-line statistics summary for the launch.
+
+    Args:
+        launch_details: Launch details from ReportPortal API
+        all_data: Dictionary containing test items data for all issue types
+
+    Returns:
+        Formatted statistics string
+    """
+    stats = launch_details.get('statistics', {}).get('executions', {})
+
+    total = stats.get('total', 0)
+    passed = stats.get('passed', 0)
+    product_bugs_count = all_data.get('Product bugs', {}).get('count', 0)
+    automation_bugs_count = all_data.get('Automation bugs', {}).get('count', 0)
+    system_issues_count = all_data.get('System issues', {}).get('count', 0)
+    to_investigate = all_data.get('To Investigate', {}).get('count', 0)
+
+    return (f'Test statistics: Total: {total}, Passed: {passed}, '
+            f'Product bugs: {product_bugs_count}, Automation bugs: {automation_bugs_count}, '
+            f'System issues: {system_issues_count}, To investigate: {to_investigate}')
+
+
+def collect_launch_details(
+        rp: ReportPortal,
+        rp_url: str,
+        rp_project: str,
+        launch_id: int,
+        logger: Optional[logging.Logger] = None) -> tuple[list[str], set[str]]:
+    """Collect details for a ReportPortal launch.
+
+    First reads all data, then formats it.
+
+    Returns:
+        Tuple of (formatted output lines, set of Jira issue keys)
+    """
+    output = []
+
+    # Read launch details
+    launch_details = rp.get_request(f'/launch/{launch_id}')
+
+    if not launch_details:
+        output.append(f'Error: Could not retrieve launch details for launch ID {launch_id}')
+        return output, set()
+
+    # Read test items data for all item types
+    all_data = {}
+    all_jira_issues = set()
+    for item_type in TEST_ITEM_TYPE_MAPPING:
+        all_data[item_type] = get_launch_test_items_data(rp, launch_id, item_type, logger)
+        # Collect Jira issue keys (excluding '???')
+        for issue_key in all_data[item_type]['issues']:
+            if issue_key != '???':
+                all_jira_issues.add(issue_key)
+
+    # Print launch header
+    attrs = ", ".join([f'{a["key"]}={a["value"]}' for a in launch_details["attributes"]])
+    # Extract first line of description
+    description = launch_details.get('description', '') or ''
+    description_first_line = description.replace('<br>', '\n').split('\n')[0]
+
+    output.extend([
+        f'Launch name: {launch_details["name"]}',
+        f'URL: {rp_url}/ui/#{rp_project}/launches/all/{launch_id}',
+        f'Attributes:  {attrs}',
+        f'Description: {textwrap.indent(description_first_line, 2 * " ")}',
+        format_statistics(launch_details, all_data),
+        '',
+        ])
+
+    # Print test items for all item types
+    for item_type in TEST_ITEM_TYPE_MAPPING:
+        output.extend(format_launch_test_items(item_type, all_data[item_type]))
+        output.append('')
+
+    return output, all_jira_issues

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -53,6 +53,9 @@ class Settings:  # type: ignore[no-untyped-def]
     tf_token: str = ''
     tf_recheck_delay: str = ''
     rog_token: str = ''
+    ai_api_url: str = ''
+    ai_api_token: str = ''
+    ai_api_model: str = ''
 
     def get(self, key: str, default: str = '') -> str:
         return str(getattr(self, key, default))
@@ -145,6 +148,19 @@ class Settings:  # type: ignore[no-untyped-def]
                 cp,
                 'rog/token',
                 'NEWA_ROG_TOKEN'),
+            ai_api_url=_get(
+                cp,
+                'ai/api_url',
+                'NEWA_AI_API_URL'),
+            ai_api_token=_get(
+                cp,
+                'ai/api_token',
+                'NEWA_AI_API_TOKEN'),
+            ai_api_model=_get(
+                cp,
+                'ai/api_model',
+                'NEWA_AI_API_MODEL',
+                'gemini-2.0-flash-exp'),
             )
 
 

--- a/newa/services/__init__.py
+++ b/newa/services/__init__.py
@@ -1,11 +1,13 @@
 """Services for external integrations."""
 
+from newa.services.ai_service import AIService
 from newa.services.errata_service import ErrataTool
 from newa.services.jira_service import IssueHandler, JiraField, JiraIssueLinkType
 from newa.services.reportportal_service import ReportPortal
 from newa.services.rog_service import RoGTool
 
 __all__ = [
+    'AIService',
     'ErrataTool',
     'IssueHandler',
     'JiraField',

--- a/newa/services/ai_service.py
+++ b/newa/services/ai_service.py
@@ -1,0 +1,126 @@
+"""AI service for generating ReportPortal launch summaries."""
+
+import json
+from typing import Any, Optional
+
+import requests
+
+try:
+    from attrs import define
+except ModuleNotFoundError:
+    from attr import define
+
+
+# System prompt for AI model
+# fmt: off
+# ruff: noqa: E501
+SYSTEM_PROMPT = """
+You are a software tester providing summary report from test execution stored in individual ReportPortal launches. For each RP launch you start with a header containing launch name, URL, atrributes, description and test statistics. Then you state whether the review is complete or not, depending on the value of To investigate test failures. If the review is complete and all tests passed, mention it. If the review is not complete, add an action item to finish the review and state how many test failures needs to be reviewed. Then you prepare a summary of individual test failure categories. You do that by inspecting comments from testers made to individual test failures. Each failure is assigned to a category: Product bug, Automation bug, System issue or Not a defect. Individual failure are in the form: test name, Jira issue keys, reviewer's comment.
+
+When presenting the summary of test failure categories, use descriptive category names such as "Product bugs related test failures", "Automation bugs related test failures", "System issues related test failures", and "Not a defect related test failures" instead of just the category names. Do not include a heading like "Summary of test failure categories" - present the categories directly. Skip any categories that have no test failures.
+
+For each category, group test failures by their associated bug/issue. When multiple tests fail due to the same bug, mention the bug once along with the number of failing tests (e.g., "RHEL-12345 (3 failing tests): description of the bug"). Do not list individual test names when they share the same bug. Product bugs are the most important ones and should be tracked in the Jira bug tracking system. Automation bugs or System issues should ideally link either a Jira issue or a merge-request URL while the Jira issue may be using other project than RHEL.
+
+When mentioning Jira issues in your summary, include the issue status and the fix version (from the "Fix Version/s" field) if available. Use "will be fixed in" wording when the status is not Closed or Done but Fix Version/s is set, and use "fixed in" for Closed or Done issues. For example: "RHEL-12345 [Status: In Progress, will be fixed in RHEL-10.0.0] (3 failing tests): description of the bug" or "RHEL-67890 [Status: Closed, fixed in RHEL-9.6.0]: description". If no fix version is set, omit that part (e.g., "RHEL-11111 [Status: New]").
+
+When a test failure is not associated with any bug (marked as "???"), state that the test is missing a product bug and add a corresponding action item to track it. If some test failures are missing Jira issues or those Jira issues are reported for a different RHEL major release, do mention it in your summary as an action item. You can learn Jira issues details in the listing at the end of the report but do not include this listing in your summary.
+
+If there are any action items, they should be listed at the end of the report under "Action items" heading. If there are no action items, do not include the "Action items" section at all.
+
+For the summary report, use simple formatting so that the output can be directly copied to a Jira comment.
+""".strip()
+# fmt: on
+
+
+@define
+class AIService:
+    """Service for interacting with AI models for generating summaries."""
+
+    api_url: str
+    api_token: str
+    model: str
+
+    def query_ai_model(self, user_message: str, system_prompt: Optional[str] = None) -> str:
+        """Query the AI model with the given prompts.
+
+        Args:
+            user_message: The user message/input data
+            system_prompt: The system prompt for the AI (defaults to SYSTEM_PROMPT)
+
+        Returns:
+            The AI model's response text
+        """
+        if system_prompt is None:
+            system_prompt = SYSTEM_PROMPT
+
+        if not self.api_url:
+            raise Exception("AI API URL is not configured")
+
+        if not self.api_token:
+            raise Exception("AI API token is not configured")
+
+        # Detect API type based on URL
+        is_gemini = 'generativelanguage.googleapis.com' in self.api_url
+
+        payload: dict[str, Any]
+        if is_gemini:
+            # Google Gemini API format
+            # API key is passed as URL parameter
+            # Support both full URL (with model embedded) and base URL + model
+            if '/models/' in self.api_url and ':generateContent' in self.api_url:
+                # Full URL provided - use as-is (backward compatible)
+                url_with_key = f"{self.api_url}?key={self.api_token}"
+            else:
+                # Base URL provided - construct full URL with model
+                base_url = self.api_url.rstrip('/')
+                url_with_key = f"{base_url}/models/{self.model}:generateContent?key={self.api_token}"
+            headers = {
+                "Content-Type": "application/json",
+                }
+
+            # Combine system prompt and user message for Gemini
+            combined_message = f"{system_prompt}\n\nThe report is below.\n\n{user_message}"
+
+            payload = {
+                "contents": [{
+                    "parts": [{
+                        "text": combined_message,
+                        }],
+                    }],
+                }
+        else:
+            # OpenAI-compatible API format
+            url_with_key = self.api_url
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_token}",
+                }
+
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                    ],
+                }
+
+        try:
+            response = requests.post(url_with_key, headers=headers, json=payload, timeout=60)
+            response.raise_for_status()
+
+            result = response.json()
+
+            # Extract response based on API type
+            if is_gemini:
+                return str(result['candidates'][0]['content']['parts'][0]['text'])
+            return str(result['choices'][0]['message']['content'])
+        except requests.exceptions.HTTPError as e:
+            error_msg = f"Error querying AI model: {e}"
+            try:
+                error_detail = response.json()
+                error_msg += f"\nResponse body: {json.dumps(error_detail, indent=2)}"
+            except Exception:
+                error_msg += f"\nResponse text: {response.text}"
+            raise Exception(error_msg) from e
+        except Exception as e:
+            raise Exception(f"Error querying AI model: {e}") from e


### PR DESCRIPTION
Changes Made

  1. Configuration Updates (newa/models/settings.py:56-57, 150-157)

  - Added ai_api_url and ai_api_token fields to the Settings model
  - Configuration can be set via:
    - [ai] section in newa.conf file
    - Environment variables: NEWA_AI_API_URL and NEWA_AI_API_TOKEN

  2. New AI Service Module (newa/services/ai_service.py)

  - Created AIService class for AI model interactions
  - Supports both OpenAI-compatible APIs and Google Gemini APIs
  - Auto-detects API type based on URL
  - Uses the same system prompt as the PoC script for consistency

  3. Helper Functions (newa/cli/summarize_helpers.py)

  - collect_launch_details(): Collects test data from ReportPortal launches
  - get_launch_test_items_data(): Extracts test failures by category (Product bugs, Automation bugs, System issues, etc.)
  - format_* functions: Format data for AI consumption and human readability
  - extract_jira_issues_from_comment(): Parses Jira issue references from test comments

  4. Summarize Command (newa/cli/commands/summarize_cmd.py)

  - New summarize subcommand that:
    - Loads execute jobs from the newa-state directory
    - Filters jobs with ReportPortal launch metadata
    - Collects test execution data from ReportPortal
    - Fetches related Jira issue details
    - Generates AI summaries using the configured AI service
    - Posts summaries as Jira comments (respecting group visibility settings)

  5. CLI Integration (newa/cli/main.py:19, 209)

  - Registered the new summarize command in the main CLI

  6. Documentation (README.md)

  - Added [ai] section to config file example
  - Added environment variables documentation
  - Added complete summarize subcommand documentation with usage examples

  Usage

  Configuration Example (newa.conf or ~/.newa):

  [ai]
  api_url = https://api.openai.com/v1/chat/completions
  api_token = sk-your-api-token-here

  Running the Command:

  # Process previous state directory
  newa --prev-state-dir summarize

  # As part of complete workflow
  newa event --compose CentOS-Stream-9 jira --issue-config config.yaml schedule execute report summarize

Assisted-by: Claude AI

## Summary by Sourcery

Add an AI-powered summarize subcommand that generates ReportPortal launch summaries and posts them to related Jira issues, configurable via new AI settings.

New Features:
- Introduce ai_api_url and ai_api_token settings, configurable via config file or environment variables for connecting to an external AI API.
- Add an AIService abstraction that supports both OpenAI-compatible and Google Gemini APIs for generating text summaries.
- Add a summarize CLI subcommand that reads execute jobs, collects ReportPortal and Jira data, and posts AI-generated summaries as comments to Jira issues.

Enhancements:
- Provide helper utilities to extract and format ReportPortal launch data and Jira issue details for AI consumption and human-readable output.
- Export AIService from the services package and register the summarize command in the main CLI entrypoint.

Documentation:
- Document the new [ai] configuration section, its environment variables, and the usage of the summarize subcommand in the README, including example workflows.