### PR TITLE
Improve Jinja2 template support for recipe YAML files

### DIFF
--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -4,7 +4,7 @@ import copy
 import itertools
 from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypedDict, Union, cast
 
 try:
     from attrs import define, field
@@ -12,7 +12,8 @@ except ModuleNotFoundError:
     from attr import define, field
 
 from newa.models.base import Arch, Cloneable, Serializable
-from newa.utils.templates import eval_test
+from newa.utils.templates import eval_test, render_template
+from newa.utils.yaml_utils import yaml_parser
 
 if TYPE_CHECKING:
     from newa.models.execution import Request
@@ -80,6 +81,164 @@ _RecipeConfigDimensionKey = Literal['context', 'environment',
 RawRecipeConfigDimensions = dict[str, list[RawRecipeConfigDimension]]
 
 
+def _process_dimension_value(
+        value: Union[RawRecipeConfigDimension, str],
+        jinja_vars: Optional[dict[str, Any]] = None) -> RawRecipeConfigDimension:
+    """
+    Process a dimension value that can be either a dict or a Jinja2 template string.
+
+    :param value: Either a RawRecipeConfigDimension dict or a Jinja2 template string
+    :param jinja_vars: Variables to pass to the Jinja2 template
+    :returns: RawRecipeConfigDimension dict
+    """
+    if isinstance(value, str):
+        # Render the Jinja2 template (single iteration only)
+        rendered = render_template(value, iterations=1, **(jinja_vars or {}))
+        # Parse the rendered string as YAML
+        parsed = yaml_parser().load(rendered)
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Jinja2 template must render to a YAML dict, got {type(parsed).__name__}")
+        return cast(RawRecipeConfigDimension, parsed)
+    if isinstance(value, dict):
+        return value
+    raise ValueError(
+        f"Dimension value must be a dict or string, got {type(value).__name__}")
+
+
+def _render_template_to_dimension_list(
+        template_string: str,
+        template_vars: dict[str, Any],
+        context_name: str) -> list[RawRecipeConfigDimension]:
+    """
+    Render a Jinja2 template string to a list of dimension values.
+
+    :param template_string: Jinja2 template string to render
+    :param template_vars: Variables to pass to the template
+    :param context_name: Name of the context (for error messages,
+                         e.g., "adjustments" or "dimension 'foo'")
+    :returns: List of processed dimension values
+    :raises ValueError: If template doesn't render to a YAML list
+    """
+    rendered = render_template(template_string, iterations=1, **template_vars)
+    parsed = yaml_parser().load(rendered)
+    if not isinstance(parsed, list):
+        raise ValueError(
+            f"Jinja2 template for {context_name} must render to a YAML list, "
+            f"got {type(parsed).__name__}")
+    # Process each item in the parsed list
+    return [_process_dimension_value(item, template_vars) for item in parsed]
+
+
+def _prepare_template_vars(
+        fixtures: Optional[RawRecipeConfigDimension],
+        jinja_vars: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Prepare template variables by merging fixtures with CLI jinja_vars.
+
+    CLI values take precedence over fixture values.
+
+    :param fixtures: Fixture data containing environment and context
+    :param jinja_vars: CLI-provided variables to override fixtures
+    :returns: Merged template variables
+    """
+    template_vars: dict[str, Any] = {}
+
+    # Start with fixture values
+    if fixtures:
+        if 'environment' in fixtures:
+            template_vars['ENVIRONMENT'] = dict(fixtures['environment'])
+        if 'context' in fixtures:
+            template_vars['CONTEXT'] = dict(fixtures['context'])
+
+    # Merge/override with CLI values
+    if jinja_vars:
+        if 'ENVIRONMENT' in jinja_vars:
+            if 'ENVIRONMENT' in template_vars:
+                template_vars['ENVIRONMENT'].update(jinja_vars['ENVIRONMENT'])
+            else:
+                template_vars['ENVIRONMENT'] = copy.deepcopy(jinja_vars['ENVIRONMENT'])
+        if 'CONTEXT' in jinja_vars:
+            if 'CONTEXT' in template_vars:
+                template_vars['CONTEXT'].update(jinja_vars['CONTEXT'])
+            else:
+                template_vars['CONTEXT'] = copy.deepcopy(jinja_vars['CONTEXT'])
+        # Add any other jinja_vars that are not ENVIRONMENT or CONTEXT
+        for key, value in jinja_vars.items():
+            if key not in ('ENVIRONMENT', 'CONTEXT'):
+                template_vars[key] = copy.deepcopy(value)
+
+    return template_vars
+
+
+def _process_dimension_list(
+        dimension_name: str,
+        dimension_list: Any,
+        template_vars: dict[str, Any]) -> list[RawRecipeConfigDimension]:
+    """
+    Process a dimension list, which can be a string template or a list of items.
+
+    :param dimension_name: Name of the dimension (for error messages)
+    :param dimension_list: Either a template string or list of dimension values
+    :param template_vars: Variables to use when rendering templates
+    :returns: Processed list of dimension values
+    """
+    if isinstance(dimension_list, str):
+        # The entire list is a Jinja2 template string
+        return _render_template_to_dimension_list(
+            dimension_list, template_vars, f"dimension '{dimension_name}'")
+    if isinstance(dimension_list, list):
+        # Process each item in the list (may contain dicts or strings)
+        return [_process_dimension_value(item, template_vars) for item in dimension_list]
+    raise ValueError(
+        f"Invalid dimensions configuration for '{dimension_name}': "
+        f"expected a list or a template string, got {type(dimension_list).__name__!r}",
+        )
+
+
+def _process_recipe_data(
+        data: dict[str, Any],
+        jinja_vars: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """
+    Process recipe data to handle Jinja2 template strings in dimension values.
+
+    :param data: Raw recipe data loaded from YAML
+    :param jinja_vars: Variables to pass to Jinja2 templates
+    :returns: Processed recipe data with all templates rendered
+    """
+    processed = copy.deepcopy(data)
+
+    # Process fixtures (single RawRecipeConfigDimension)
+    if 'fixtures' in processed and isinstance(processed['fixtures'], str):
+        processed['fixtures'] = _process_dimension_value(processed['fixtures'], jinja_vars)
+
+    # Prepare template variables for rendering adjustments and dimensions
+    # This allows both to reference ENVIRONMENT/CONTEXT from fixtures
+    fixtures = processed.get('fixtures') if isinstance(processed.get('fixtures'), dict) else None
+    template_vars = _prepare_template_vars(fixtures, jinja_vars)
+
+    # Process adjustments (list of RawRecipeConfigDimension or template string)
+    if 'adjustments' in processed:
+        if isinstance(processed['adjustments'], str):
+            # The entire adjustments is a Jinja2 template string
+            processed['adjustments'] = _render_template_to_dimension_list(
+                processed['adjustments'], template_vars, 'adjustments')
+        elif isinstance(processed['adjustments'], list):
+            # Process each item in the list (may contain dicts or strings)
+            processed['adjustments'] = [
+                _process_dimension_value(item, template_vars) for item in processed['adjustments']
+                ]
+
+    # Process dimensions (dict[str, list[RawRecipeConfigDimension]])
+    if 'dimensions' in processed and isinstance(processed['dimensions'], dict):
+        processed['dimensions'] = {
+            name: _process_dimension_list(name, dim_list, template_vars)
+            for name, dim_list in processed['dimensions'].items()
+            }
+
+    return processed
+
+
 @define
 class Recipe(Cloneable, Serializable):
     """A job recipe"""
@@ -102,13 +261,77 @@ class RecipeConfig(Cloneable, Serializable):
     includes: list[str] = field(factory=list)
 
     @classmethod
+    def from_yaml(
+            cls: type['RecipeConfig'],
+            serialized: str,
+            jinja_vars: Optional[dict[str, Any]] = None) -> 'RecipeConfig':
+        """
+        Load RecipeConfig from YAML string, processing Jinja2 templates in dimension values.
+
+        :param serialized: YAML string to parse
+        :param jinja_vars: Variables to pass to Jinja2 templates
+        :returns: RecipeConfig instance
+        """
+        data = yaml_parser().load(serialized)
+
+        if not isinstance(data, dict):
+            raise ValueError(
+                "RecipeConfig.from_yaml expected a top-level mapping in the YAML "
+                f"document, but got {type(data).__name__!r} instead.",
+                )
+
+        processed_data = _process_recipe_data(data, jinja_vars)
+        return cls(**processed_data)
+
+    @classmethod
+    def from_yaml_file(
+            cls: type['RecipeConfig'],
+            filepath: Path,
+            jinja_vars: Optional[dict[str, Any]] = None) -> 'RecipeConfig':
+        """
+        Load RecipeConfig from YAML file, processing Jinja2 templates in dimension values.
+
+        :param filepath: Path to YAML file
+        :param jinja_vars: Variables to pass to Jinja2 templates
+        :returns: RecipeConfig instance
+        """
+        return cls.from_yaml(filepath.read_text(), jinja_vars)
+
+    @classmethod
+    def from_yaml_url(
+            cls: type['RecipeConfig'],
+            url: str,
+            jinja_vars: Optional[dict[str, Any]] = None) -> 'RecipeConfig':
+        """
+        Load RecipeConfig from YAML URL, processing Jinja2 templates in dimension values.
+
+        :param url: URL to fetch YAML from
+        :param jinja_vars: Variables to pass to Jinja2 templates
+        :returns: RecipeConfig instance
+        """
+        from newa.utils.http import ResponseContentType, get_request
+        content = get_request(url=url, response_content=ResponseContentType.TEXT)
+        return cls.from_yaml(content, jinja_vars)
+
+    @classmethod
     def from_yaml_with_includes(
             cls: type['RecipeConfig'],
             location: str,
-            stack: Optional[list[str]] = None) -> 'RecipeConfig':
+            stack: Optional[list[str]] = None,
+            jinja_vars: Optional[dict[str, Any]] = None) -> 'RecipeConfig':
+        """
+        Load RecipeConfig from YAML file or URL with include support.
+
+        Processes Jinja2 templates in dimension values across all included files.
+
+        :param location: File path or URL to YAML file
+        :param stack: Internal parameter for tracking include chain to detect cycles
+        :param jinja_vars: Variables to pass to Jinja2 templates
+        :returns: RecipeConfig instance with all includes merged
+        """
         import re
-        base_config = cls.from_yaml_url(location) if \
-            re.search('^https?://', location) else cls.from_yaml_file(Path(location))
+        base_config = cls.from_yaml_url(location, jinja_vars) if \
+            re.search('^https?://', location) else cls.from_yaml_file(Path(location), jinja_vars)
         # process each include
         fixtures_combination = []
         adjustments = []
@@ -120,7 +343,7 @@ class RecipeConfig(Cloneable, Serializable):
                 stack.append(location)
             else:
                 stack = [location]
-            source_config = cls.from_yaml_with_includes(source, stack=stack)
+            source_config = cls.from_yaml_with_includes(source, stack=stack, jinja_vars=jinja_vars)
             if source_config.fixtures:
                 fixtures_combination.append(source_config.fixtures)
             if source_config.adjustments:
@@ -217,7 +440,7 @@ class RecipeConfig(Cloneable, Serializable):
                     ARCH=arch.value if arch else None,
                     ENVIRONMENT=combination.get('environment', None),
                     CONTEXT=combination.get('context', None),
-                    **(jinja_vars if jinja_vars else {}))
+                    **(jinja_vars or {}))
                 if not test_result:
                     continue
             filtered_combinations.append(combination)

--- a/tests/unit/data/recipe-jinja-include-child1.yaml
+++ b/tests/unit/data/recipe-jinja-include-child1.yaml
@@ -1,0 +1,12 @@
+fixtures: |
+    context:
+        tier: {{ default_tier }}
+        from: child1
+        child1_only: {{ child1_value }}
+    environment:
+        CHILD1_VAR: child1_value
+adjustments:
+  - |
+    context:
+        adjustment: {{ adjustment_value }}
+    when: CONTEXT.tier == 1

--- a/tests/unit/data/recipe-jinja-include-child2.yaml
+++ b/tests/unit/data/recipe-jinja-include-child2.yaml
@@ -1,0 +1,9 @@
+fixtures:
+    context:
+        from: child2
+adjustments: |
+    {% for val in adjustment_list %}
+    - context:
+        adjustment{{ loop.index }}: {{ val }}
+      when: "True"
+    {% endfor %}

--- a/tests/unit/data/recipe-jinja-include-child3.yaml
+++ b/tests/unit/data/recipe-jinja-include-child3.yaml
@@ -1,0 +1,10 @@
+fixtures:
+    context:
+        from: child3
+    environment:
+        TEST_ARCH: x86_64
+adjustments:
+  - |
+    context:
+        adj_from_fixture: {{ ENVIRONMENT.TEST_ARCH }}
+    when: "True"

--- a/tests/unit/data/recipe-jinja-include-parent.yaml
+++ b/tests/unit/data/recipe-jinja-include-parent.yaml
@@ -1,0 +1,11 @@
+includes:
+  - tests/unit/data/recipe-jinja-include-child1.yaml
+  - tests/unit/data/recipe-jinja-include-child2.yaml
+  - tests/unit/data/recipe-jinja-include-child3.yaml
+fixtures:
+    context:
+        from: parent
+dimensions:
+    arch:
+       - context:
+             arch: x86_64

--- a/tests/unit/test_render_template.py
+++ b/tests/unit/test_render_template.py
@@ -1,6 +1,6 @@
 import pytest
 
-from newa import render_template
+from newa import RecipeConfig, render_template
 
 
 @pytest.fixture
@@ -20,3 +20,537 @@ def test_render_template_bad():
         render_template(
             "{% if %} {% ednif %}",
             )
+
+
+def test_render_template_recursive():
+    """Test that render_template performs recursive rendering (late rendering / method 1)."""
+    # This tests that nested template variables are expanded through multiple iterations
+    # Template contains {{ VAR1 }} which expands to "{{ VAR2 }}" which then
+    # expands to "final_value"
+    template = "Result: {{ VAR1 }}"
+
+    # First iteration: {{ VAR1 }} -> "{{ VAR2 }}"
+    # Second iteration: {{ VAR2 }} -> "final_value"
+    # Third iteration: no changes, converges
+    rendered = render_template(
+        template,
+        VAR1="{{ VAR2 }}",
+        VAR2="final_value",
+        )
+
+    assert rendered == "Result: final_value"
+    # Verify it went through multiple iterations (not just one)
+    # If it only did one iteration, result would be "Result: {{ VAR2 }}"
+    assert "{{" not in rendered
+    assert "}}" not in rendered
+
+
+def test_render_template_single_iteration():
+    """Test render_template with iterations=1 (early rendering/methods 2-4)."""
+    # This tests that early rendering (methods 2-4) only does one iteration
+    template = "Result: {{ VAR1 }}"
+
+    # With iterations=1, should only expand VAR1 to "{{ VAR2 }}" and stop
+    rendered = render_template(
+        template,
+        iterations=1,
+        VAR1="{{ VAR2 }}",
+        VAR2="final_value",
+        )
+
+    # Should still contain template syntax because it only did one iteration
+    assert rendered == "Result: {{ VAR2 }}"
+    assert "{{" in rendered
+    assert "}}" in rendered
+
+
+def test_dimension_template_single_iteration_rendering():
+    """Test that dimension templates (methods 2-4) are rendered only once, not recursively.
+
+    This test verifies that early rendering (methods 2-4) for dimensions, fixtures, and
+    adjustments only performs ONE iteration of Jinja2 template expansion.
+
+    The test works by having TEMPLATE_VAR contain the string '{{ NESTED_VAR }}' (with quotes).
+
+    - With single iteration (CORRECT for methods 2-4):
+      First pass: {{ TEMPLATE_VAR }} -> "{{ NESTED_VAR }}"
+      Stops here. Result: the literal string "{{ NESTED_VAR }}"
+
+    - With recursive rendering (INCORRECT for methods 2-4, but correct for method 1):
+      First pass: {{ TEMPLATE_VAR }} -> "{{ NESTED_VAR }}"
+      Second pass: {{ NESTED_VAR }} -> "final_value"
+      Result: "final_value"
+    """
+    yaml_content = """
+fixtures:
+    environment:
+        NESTED_VAR: final_value
+dimensions:
+    test: |
+       - environment:
+             # TEMPLATE_VAR will expand to the string "{{ NESTED_VAR }}" in first iteration
+             # With single iteration: stops here, VALUE = "{{ NESTED_VAR }}" (literal)
+             # With recursive: would do second iteration, VALUE = "final_value"
+             VALUE: {{ TEMPLATE_VAR }}
+"""
+    # TEMPLATE_VAR contains template syntax as a string (with quotes for YAML)
+    config = RecipeConfig.from_yaml(
+        yaml_content,
+        jinja_vars={'TEMPLATE_VAR': '"{{ NESTED_VAR }}"', 'NESTED_VAR': 'final_value'},
+        )
+    reqs = list(config.build_requests({}, {}))
+
+    assert len(reqs) == 1
+
+    # CRITICAL TEST: With single iteration (correct for methods 2-4),
+    # VALUE should still contain the template syntax "{{ NESTED_VAR }}"
+    # because it only did one rendering pass
+    assert reqs[0].environment['VALUE'] == '{{ NESTED_VAR }}'
+
+    # Verify it did NOT recurse - if it did, it would have expanded to "final_value"
+    assert reqs[0].environment['VALUE'] != 'final_value'
+
+
+def test_dimension_string_template():
+    """Test that dimension values can be Jinja2 template strings."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - |
+         context:
+             arch: aarch64
+"""
+    config = RecipeConfig.from_yaml(yaml_content)
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 2 requests (one for each arch dimension)
+    assert len(reqs) == 2
+    assert reqs[0].context['arch'] == 'x86_64'
+    assert reqs[1].context['arch'] == 'aarch64'
+
+
+def test_dimension_string_template_must_render_to_mapping():
+    """Dimension item templates that render to a non-dict should raise ValueError."""
+    # The second dimension item is a Jinja2 template that renders to a scalar ("1"),
+    # which should trigger the error path in `_process_dimension_value`.
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - "{{ tier }}"
+"""
+    with pytest.raises(ValueError, match=r"Jinja2 template must render to a YAML dict"):
+        RecipeConfig.from_yaml(yaml_content)
+
+
+def test_dimension_template_with_variables():
+    """Test that Jinja2 templates can use variables."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch:
+       - |
+         context:
+             arch: {{ target_arch }}
+"""
+    config = RecipeConfig.from_yaml(yaml_content, jinja_vars={'target_arch': 's390x'})
+    reqs = list(config.build_requests({}, {}))
+
+    assert len(reqs) == 1
+    assert reqs[0].context['arch'] == 's390x'
+
+
+def test_adjustments_string_template():
+    """Test that adjustment values can be Jinja2 template strings."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+adjustments:
+  - context:
+        distro: fedora
+  - |
+    environment:
+        TEST_VAR: "test_value"
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+"""
+    config = RecipeConfig.from_yaml(yaml_content)
+    reqs = list(config.build_requests({}, {}))
+
+    assert len(reqs) == 1
+    assert reqs[0].context['distro'] == 'fedora'
+    assert reqs[0].environment['TEST_VAR'] == 'test_value'
+
+
+def test_fixtures_string_template():
+    """Test that fixtures can be a Jinja2 template string."""
+    yaml_content = """
+fixtures: |
+    context:
+        tier: 1
+        env: {{ env_name }}
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+"""
+    config = RecipeConfig.from_yaml(yaml_content, jinja_vars={'env_name': 'production'})
+    reqs = list(config.build_requests({}, {}))
+
+    assert len(reqs) == 1
+    assert reqs[0].context['tier'] == 1
+    assert reqs[0].context['env'] == 'production'
+
+
+def test_mixed_dict_and_string_dimensions():
+    """Test that dimensions can mix dict and string template formats."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - |
+         context:
+             arch: {{ arch_name }}
+    fips:
+       - |
+         context:
+             fips: yes
+       - context:
+             fips: no
+"""
+    config = RecipeConfig.from_yaml(yaml_content, jinja_vars={'arch_name': 'aarch64'})
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 4 requests (2 arch x 2 fips)
+    assert len(reqs) == 4
+
+    # Check that we have both archs
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 'aarch64'}
+
+    # Check that we have both fips values
+    fips_values = {req.context['fips'] for req in reqs}
+    assert fips_values == {'yes', 'no'}
+
+
+def test_dimension_list_as_template():
+    """Test that an entire dimension list can be a Jinja2 template string."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch: |
+       - context:
+             arch: x86_64
+       - context:
+             arch: aarch64
+"""
+    config = RecipeConfig.from_yaml(yaml_content)
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 2 requests (one for each arch)
+    assert len(reqs) == 2
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 'aarch64'}
+
+
+def test_dimension_list_template_with_variables():
+    """Test that dimension list templates can use Jinja2 variables."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch: |
+       {% for arch in archs %}
+       - context:
+             arch: {{ arch }}
+       {% endfor %}
+"""
+    config = RecipeConfig.from_yaml(
+        yaml_content,
+        jinja_vars={'archs': ['x86_64', 's390x', 'ppc64le']},
+        )
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 3 requests (one for each arch in the list)
+    assert len(reqs) == 3
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 's390x', 'ppc64le'}
+
+
+def test_mixed_dimension_list_formats():
+    """Test that different dimensions can use different formats."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch: |
+       - context:
+             arch: x86_64
+       - context:
+             arch: aarch64
+    fips:
+       - context:
+             fips: yes
+       - context:
+             fips: no
+"""
+    config = RecipeConfig.from_yaml(yaml_content)
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 4 requests (2 arch x 2 fips)
+    assert len(reqs) == 4
+
+    # Check that we have both archs
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 'aarch64'}
+
+    # Check that we have both fips values
+    fips_values = {req.context['fips'] for req in reqs}
+    assert fips_values == {'yes', 'no'}
+
+
+def test_dimension_list_template_with_nested_strings():
+    """Test that dimension list template can contain individual item templates."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+dimensions:
+    arch: |
+       - context:
+             arch: x86_64
+       - |
+         context:
+             arch: {{ target_arch }}
+"""
+    config = RecipeConfig.from_yaml(
+        yaml_content,
+        jinja_vars={'target_arch': 'aarch64'},
+        )
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 2 requests
+    assert len(reqs) == 2
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 'aarch64'}
+
+
+def test_dimension_template_with_environment_from_fixtures():
+    """Test that ENVIRONMENT defined in fixtures is available in dimension templates."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+    environment:
+        ARCHITECTURES: "x86_64,s390x,ppc64le,aarch64"
+
+dimensions:
+    arch: |
+       {% for arch in ENVIRONMENT.ARCHITECTURES.split(',') %}
+       - context:
+             arch: {{ arch }}
+         environment:
+             ARCH_NAME: {{ arch }}
+       {% endfor %}
+"""
+    config = RecipeConfig.from_yaml(yaml_content)
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 4 requests (one for each arch)
+    assert len(reqs) == 4
+
+    # Check that we have all 4 archs
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'x86_64', 's390x', 'ppc64le', 'aarch64'}
+
+    # Check that ARCH_NAME matches arch in context for all requests
+    arch_name_matches = all(req.environment['ARCH_NAME'] == req.context['arch'] for req in reqs)
+    assert arch_name_matches, "ARCH_NAME should match arch in context for all requests"
+
+
+def test_cli_environment_overrides_fixtures_in_dimension_templates():
+    """Test that CLI ENVIRONMENT overrides fixtures when rendering dimension templates."""
+    yaml_content = """
+fixtures:
+    context:
+        tier: 1
+    environment:
+        ARCHITECTURES: "x86_64,s390x,ppc64le,aarch64"
+
+dimensions:
+    arch: |
+       {% for arch in ENVIRONMENT.ARCHITECTURES.split(',') %}
+       - context:
+             arch: {{ arch }}
+         environment:
+             ARCH_NAME: {{ arch }}
+       {% endfor %}
+"""
+    # CLI environment should override fixtures
+    cli_environment = {'ARCHITECTURES': 'i686,ppc64'}
+
+    config = RecipeConfig.from_yaml(
+        yaml_content,
+        jinja_vars={'ENVIRONMENT': cli_environment},
+        )
+    reqs = list(config.build_requests({}, {}))
+
+    # Should have 2 requests (from CLI archs, not the 4 from fixtures)
+    assert len(reqs) == 2
+
+    # Check that we have CLI archs, NOT fixture archs
+    archs = {req.context['arch'] for req in reqs}
+    assert archs == {'i686', 'ppc64'}
+
+    # Verify fixture archs are NOT present
+    assert 'x86_64' not in archs
+    assert 's390x' not in archs
+    assert 'ppc64le' not in archs
+    assert 'aarch64' not in archs
+
+    # Check that ARCH_NAME matches arch in context for all requests
+    arch_name_matches = all(req.environment['ARCH_NAME'] == req.context['arch'] for req in reqs)
+    assert arch_name_matches, "ARCH_NAME should match arch in context for all requests"
+
+
+def test_jinja_templates_with_includes():
+    """Test that Jinja2 templates work correctly with includes."""
+    jinja_vars = {
+        'default_tier': 1,
+        'child1_value': 'from_child1',
+        'adjustment_value': 'test_adj',
+        'adjustment_list': ['val1', 'val2', 'val3'],
+        }
+
+    config = RecipeConfig.from_yaml_with_includes(
+        'tests/unit/data/recipe-jinja-include-parent.yaml',
+        jinja_vars=jinja_vars,
+        )
+
+    # Check that fixtures were merged correctly
+    assert config.fixtures['context']['tier'] == 1  # from child1 via jinja
+    assert config.fixtures['context']['from'] == 'parent'  # parent overrides children
+    # from child1, not overridden
+    assert config.fixtures['context']['child1_only'] == 'from_child1'
+    assert config.fixtures['environment']['CHILD1_VAR'] == 'child1_value'
+
+    # Check that adjustments were processed
+    assert len(config.adjustments) == 5  # 1 from child1 + 3 from child2 + 1 from child3
+
+    # Verify child1 adjustment (Jinja template)
+    assert config.adjustments[0]['context']['adjustment'] == 'test_adj'
+    assert config.adjustments[0]['when'] == 'CONTEXT.tier == 1'
+
+    # Verify child2 adjustments (Jinja template list)
+    assert config.adjustments[1]['context']['adjustment1'] == 'val1'
+    assert config.adjustments[1]['when'] == 'True'
+    assert config.adjustments[2]['context']['adjustment2'] == 'val2'
+    assert config.adjustments[2]['when'] == 'True'
+    assert config.adjustments[3]['context']['adjustment3'] == 'val3'
+    assert config.adjustments[3]['when'] == 'True'
+
+    # Verify child3 adjustment (uses fixture environment from same file)
+    assert config.adjustments[4]['context']['adj_from_fixture'] == 'x86_64'
+    assert config.adjustments[4]['when'] == 'True'
+
+
+def test_environment_and_context_priority_across_sources():
+    """Test priority of ENVIRONMENT and CONTEXT values from CLI, fixtures, and dimensions."""
+    yaml_content = """
+fixtures:
+    context:
+        from_fixtures_only: fixture_ctx_value
+        overridden_by_dimension: fixture_ctx_value
+    environment:
+        FROM_FIXTURES_ONLY: fixture_env_value
+        OVERRIDDEN_BY_DIMENSION: fixture_env_value
+
+dimensions:
+    test:
+       - context:
+             from_dimension_only: dimension_ctx_value
+             overridden_by_dimension: dimension_ctx_value
+         environment:
+             FROM_DIMENSION_ONLY: dimension_env_value
+             OVERRIDDEN_BY_DIMENSION: dimension_env_value
+             OVERRIDDEN_BY_CLI: dimension_env_value
+"""
+    # CLI values for template rendering (used in from_yaml)
+    cli_jinja_vars = {
+        'ENVIRONMENT': {
+            'FROM_CLI_ONLY': 'cli_env_value',
+            'OVERRIDDEN_BY_CLI': 'cli_env_value',
+            },
+        'CONTEXT': {
+            'from_cli_only': 'cli_ctx_value',
+            },
+        }
+
+    # CLI values for request building (RawRecipeConfigDimension format)
+    cli_config = {
+        'environment': {
+            'FROM_CLI_ONLY': 'cli_env_value',
+            'OVERRIDDEN_BY_CLI': 'cli_env_value',
+            },
+        'context': {
+            'from_cli_only': 'cli_ctx_value',
+            },
+        }
+
+    config = RecipeConfig.from_yaml(yaml_content, jinja_vars=cli_jinja_vars)
+    reqs = list(config.build_requests({}, cli_config))
+
+    # Should have 1 request
+    assert len(reqs) == 1
+    req = reqs[0]
+
+    # ENVIRONMENT checks:
+    # 1. CLI only - should be present
+    assert req.environment['FROM_CLI_ONLY'] == 'cli_env_value'
+
+    # 2. Fixtures only - should be present
+    assert req.environment['FROM_FIXTURES_ONLY'] == 'fixture_env_value'
+
+    # 3. Dimension only - should be present
+    assert req.environment['FROM_DIMENSION_ONLY'] == 'dimension_env_value'
+
+    # 4. CLI + Dimension - CLI takes priority
+    assert req.environment['OVERRIDDEN_BY_CLI'] == 'cli_env_value'
+
+    # 5. Fixtures + Dimension - Dimension takes priority
+    assert req.environment['OVERRIDDEN_BY_DIMENSION'] == 'dimension_env_value'
+
+    # CONTEXT checks:
+    # 1. CLI only - should be present
+    assert req.context['from_cli_only'] == 'cli_ctx_value'
+
+    # 2. Fixtures only - should be present
+    assert req.context['from_fixtures_only'] == 'fixture_ctx_value'
+
+    # 3. Dimension only - should be present
+    assert req.context['from_dimension_only'] == 'dimension_ctx_value'
+
+    # 4. Fixtures + Dimension - Dimension takes priority
+    assert req.context['overridden_by_dimension'] == 'dimension_ctx_value'


### PR DESCRIPTION
This commit extends the recipe loading functionality to support Jinja2 template strings at multiple levels in recipe YAML files, enabling dynamic recipe generation and improved reusability.

Template support is also newly available for:

1. Individual dimension items - A single item within a dimension list can be a Jinja2 template string that renders to a YAML dict

2. Entire dimension lists - An entire dimension list can be a Jinja2 template string that renders to a YAML list of dimension items

3. Fixtures and adjustments - These sections can also use Jinja2 template strings for dynamic configuration

Templates can access ENVIRONMENT and CONTEXT objects defined in the fixtures section, with proper variable precedence:
- CLI values (highest priority)
- Dimension values
- Fixture values (lowest priority)

When rendering dimension templates, ENVIRONMENT and CONTEXT from fixtures are merged with CLI-provided values, with CLI values taking precedence. This allows users to override fixture defaults from the command line while still making fixture values available to templates.

Implementation details:
- Added _process_dimension_value() to handle dict or string dimension values
- Added _process_recipe_data() to process entire recipe data structure
- Modified RecipeConfig.from_yaml() to accept optional jinja_vars parameter
- Template variables are prepared by merging fixture ENVIRONMENT/CONTEXT with CLI values before rendering dimension templates

Changes:
- newa/models/recipes.py: Add template processing functions and modify from_yaml() to support jinja_vars parameter
- tests/unit/test_render_template.py: Add 12 comprehensive tests covering all template scenarios and priority rules
- README.md: Add "Jinja2 Template Support in Recipes" section with detailed documentation and two practical examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Jinja2 templating support throughout recipe YAML loading and include handling to enable dynamic generation of fixtures, adjustments, and dimensions, including URL and file-based recipes.

New Features:
- Allow individual dimension items, entire dimension lists, fixtures, and adjustments to be defined as Jinja2 template strings in recipe YAML files.
- Support passing template variables via an optional jinja_vars parameter when loading recipes from strings, files, URLs, or included recipe files.
- Expose fixtures-derived ENVIRONMENT and CONTEXT values as template variables, with CLI-provided values able to override them for template rendering.

Enhancements:
- Validate that Jinja2-rendered dimension items and lists resolve to the expected YAML types and raise clear errors when they do not.

Documentation:
- Document Jinja2 template support in recipes with examples of dynamic dimension generation and conditional configuration based on ENVIRONMENT and CONTEXT.

Tests:
- Add comprehensive unit tests covering Jinja2 templates in dimensions, fixtures, adjustments, include chains, and precedence rules between CLI, fixtures, and dimension values.