### PR TITLE
Make AI system prompt configurable in summarize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ NEWA_ROG_TOKEN
 NEWA_AI_API_URL
 NEWA_AI_API_TOKEN
 NEWA_AI_API_MODEL
+NEWA_AI_SYSTEM_PROMPT
 ```
 
 ### Jira issue configuration file
@@ -1103,6 +1104,9 @@ The summarize command supports both OpenAI-compatible APIs and Google Gemini API
 - `api_url`: API endpoint URL
 - `api_token`: API authentication token or key
 - `api_model`: Model name to use (default: `gemini-2.0-flash-exp`)
+- `system_prompt`: Custom system prompt for AI model (optional, uses default prompt if not specified)
+
+**Note:** The `system_prompt` parameter allows you to customize how the AI analyzes and summarizes test results. When not specified, NEWA uses a built-in prompt optimized for ReportPortal launch summaries in Jira format. You might want to customize this if you need different formatting, additional analysis criteria, or organization-specific requirements.
 
 **Google Gemini API Configuration:**
 
@@ -1148,6 +1152,7 @@ All settings can be overridden via environment variables:
 export NEWA_AI_API_URL="https://generativelanguage.googleapis.com/v1beta"
 export NEWA_AI_API_TOKEN="YOUR_API_KEY"
 export NEWA_AI_API_MODEL="gemini-2.0-flash-exp"
+export NEWA_AI_SYSTEM_PROMPT="Your custom system prompt here..."
 ```
 
 #### Usage Examples

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -124,7 +124,9 @@ def process_execute_job_for_summary(
     # Query AI model
     ctx.logger.info(f'Querying AI model for summary of RP launch {launch_uuid}')
     try:
-        ai_summary = ai_service.query_ai_model(user_message)
+        # Use custom system prompt from config if provided, otherwise use default
+        system_prompt = ctx.settings.ai_system_prompt or None
+        ai_summary = ai_service.query_ai_model(user_message, system_prompt=system_prompt)
     except Exception as e:
         ctx.logger.error(f'Error querying AI model: {e}')
         return

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -239,15 +239,14 @@ def collect_launch_details(
 
     # Print launch header
     attrs = ", ".join([f'{a["key"]}={a["value"]}' for a in launch_details["attributes"]])
-    # Extract first line of description
     description = launch_details.get('description', '') or ''
-    description_first_line = description.replace('<br>', '\n').split('\n')[0]
+    description = description.replace('<br>', '\n')
 
     output.extend([
         f'Launch name: {launch_details["name"]}',
         f'URL: {rp_url}/ui/#{rp_project}/launches/all/{launch_id}',
         f'Attributes:  {attrs}',
-        f'Description: {textwrap.indent(description_first_line, 2 * " ")}',
+        f'Description: {textwrap.indent(description, 2 * " ")}',
         format_statistics(launch_details, all_data),
         '',
         ])

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -56,6 +56,7 @@ class Settings:  # type: ignore[no-untyped-def]
     ai_api_url: str = ''
     ai_api_token: str = ''
     ai_api_model: str = ''
+    ai_system_prompt: str = ''
 
     def get(self, key: str, default: str = '') -> str:
         return str(getattr(self, key, default))
@@ -161,6 +162,10 @@ class Settings:  # type: ignore[no-untyped-def]
                 'ai/api_model',
                 'NEWA_AI_API_MODEL',
                 'gemini-2.0-flash-exp'),
+            ai_system_prompt=_get(
+                cp,
+                'ai/system_prompt',
+                'NEWA_AI_SYSTEM_PROMPT'),
             )
 
 


### PR DESCRIPTION
Add support for configuring the AI system prompt used by the 'summarize' subcommand through the configuration file or environment variable. When not configured, the existing hardcoded prompt is used as the default, maintaining backward compatibility.

Configuration options:
- Config file: [ai] section, system_prompt key
- Environment variable: NEWA_AI_SYSTEM_PROMPT

This allows users to customize the AI prompt for generating ReportPortal launch summaries without modifying the source code.

Changes:
- Add ai_system_prompt field to Settings class
- Load ai_system_prompt from config file [ai] section
- Pass custom prompt to AIService.query_ai_model() when configured
- Update README.md with configuration documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the AI summarize command use a configurable system prompt while preserving the existing default behavior.

New Features:
- Add configuration support for a custom AI system prompt via config file and NEWA_AI_SYSTEM_PROMPT environment variable for the summarize command.

Enhancements:
- Pass the configured AI system prompt into the AI service when generating summaries, falling back to the built-in prompt when not set.
- Include full launch descriptions (with HTML line breaks normalized) in summarize command output instead of only the first line.

Documentation:
- Document the new ai.system_prompt configuration option and its environment variable override in the README.