### PR TITLE
Support Jinja templates in schedule attribute

### DIFF
--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -92,7 +92,7 @@ class IssueAction(Serializable):  # type: ignore[no-untyped-def]
     context: Optional[RecipeContext] = None
     environment: Optional[RecipeEnvironment] = None
     links: Optional[dict[str, list[str]]] = None
-    schedule: bool = True
+    schedule: Union[bool, str] = True
 
     # function to handle issue-config file defaults
 


### PR DESCRIPTION
The schedule attribute in IssueAction can now be either a boolean or a Jinja template string that evaluates to a boolean. This enables conditional job scheduling based on event properties such as erratum type, compose ID, or custom context variables.

When schedule is a string, it is rendered using the same template variables available to other fields (EVENT, ERRATUM, COMPOSE, JIRA, ROG, CONTEXT, ENVIRONMENT) and then converted to boolean where 'true', '1', or 'yes' (case-insensitive) evaluate to True.

Updated README with comprehensive documentation and a practical example showing how to schedule security tests only for RHSA advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow issue actions to control job scheduling via either boolean or Jinja-templated schedule values and propagate the rendered result through Jira job creation.

New Features:
- Support using Jinja template strings in the IssueAction schedule field to conditionally enable or disable job scheduling based on event data.

Enhancements:
- Extend Jira action field rendering to compute and pass through a resolved schedule flag used when deciding whether to create jobs.

Documentation:
- Document the dual boolean/Jinja behavior of the schedule option and add an example showing conditional scheduling for RHSA advisories in the README.