### PR TITLE
Extend issue action filtering capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,34 @@ Example (triggering performance tests that have `schedule: false`):
 $ newa --action-id-filter 'task_performance' event --erratum 12345 jira --issue-config errata-config.yaml schedule execute report
 ```
 
+#### Option `--issue-id-filter`
+
+Instructs NEWA to process only jobs associated with Jira issues whose key/ID matches the provided regular expression.
+This option has an effect across all NEWA subcommands, allowing users to limit which issues are processed.
+
+**Behavior across subcommands:**
+- For **schedule, execute, report, summarize, and list** subcommands: filters existing jobs where the Jira issue ID matches the pattern
+- For **jira** subcommand: only processes actions when exactly 1 existing Jira issue is found that matches the filter pattern. If no matching issue exists or multiple matching issues are found, the action is skipped. New issues are never created when using this option.
+
+This option can be combined with `--action-id-filter` for fine-grained control over which jobs are processed. When using `--issue-id-filter` with the jira subcommand, parent-child action dependencies are relaxed to allow processing actions whose parents may have been filtered out.
+
+Use with caution.
+
+Example (process only a specific Jira issue):
+```
+$ newa --issue-id-filter 'RHEL-12345' event --erratum 123456 jira --issue-config config.yaml schedule execute report
+```
+
+Example (process issues matching a pattern):
+```
+$ newa --issue-id-filter 'SECENGSP-816[0-5]' --prev-state-dir schedule execute report
+```
+
+Example (combine with --action-id-filter):
+```
+$ newa --action-id-filter 'tier.*' --issue-id-filter 'RHEL-.*' event --compose CentOS-Stream-10 jira --issue-config config.yaml schedule
+```
+
 #### Option `--jira-issue`
 
 Directs NEWA to the `JIRA`-type event it should use, in particular a Jira issue key. Option can be used multiple times but each event will be processed individually. This event is not that useful for test scheduling at the moment. But you can use NEWA to create a pre-configure set of associated Jira issues.

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -86,6 +86,11 @@ logging.basicConfig(
     default='',
     help='Regular expression matching issue-config action ids to process (only).',
     )
+@click.option(
+    '--issue-id-filter',
+    default='',
+    help='Regular expression matching Jira issue keys to process (only).',
+    )
 @click.pass_context
 def main(click_context: click.Context,
          state_dir: str,
@@ -97,7 +102,8 @@ def main(click_context: click.Context,
          contexts: list[str],
          extract_state_dir: str,
          force: bool,
-         action_id_filter: str) -> None:
+         action_id_filter: str,
+         issue_id_filter: str) -> None:
     """NEWA - New Errata Workflow Automation."""
     import io
     import tarfile
@@ -143,6 +149,12 @@ def main(click_context: click.Context,
         raise Exception(
             f'Cannot compile --action-id-filter regular expression. {e!r}') from e
 
+    try:
+        issue_pattern = re.compile(issue_id_filter) if issue_id_filter else None
+    except re.error as e:
+        raise Exception(
+            f'Cannot compile --issue-id-filter regular expression. {e!r}') from e
+
     ctx = CLIContext(
         settings=settings,
         logger=logging.getLogger(),
@@ -152,6 +164,7 @@ def main(click_context: click.Context,
         prev_state_dirpath=prev_state_dirpath,
         force=force,
         action_id_filter_pattern=pattern,
+        issue_id_filter_pattern=issue_pattern,
         )
     click_context.obj = ctx
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,0 +1,171 @@
+"""Tests for action_id and issue_id filtering functionality."""
+import re
+from unittest import mock
+
+import pytest
+
+from newa import CLIContext, Settings
+
+
+@pytest.fixture
+def mock_logger():
+    """Return a mocked logger."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def ctx_no_filter(tmp_path, mock_logger):
+    """Return a CLIContext without any filters."""
+    return CLIContext(
+        logger=mock_logger,
+        settings=Settings(),
+        state_dirpath=tmp_path,
+        cli_environment={},
+        cli_context={},
+        action_id_filter_pattern=None,
+        issue_id_filter_pattern=None)
+
+
+@pytest.fixture
+def ctx_with_action_filter(tmp_path, mock_logger):
+    """Return a CLIContext with action_id filter."""
+    return CLIContext(
+        logger=mock_logger,
+        settings=Settings(),
+        state_dirpath=tmp_path,
+        cli_environment={},
+        cli_context={},
+        action_id_filter_pattern=re.compile(r'tier.*'),
+        issue_id_filter_pattern=None)
+
+
+@pytest.fixture
+def ctx_with_issue_filter(tmp_path, mock_logger):
+    """Return a CLIContext with issue_id filter."""
+    return CLIContext(
+        logger=mock_logger,
+        settings=Settings(),
+        state_dirpath=tmp_path,
+        cli_environment={},
+        cli_context={},
+        action_id_filter_pattern=None,
+        issue_id_filter_pattern=re.compile(r'RHEL-123.*'))
+
+
+@pytest.fixture
+def ctx_with_both_filters(tmp_path, mock_logger):
+    """Return a CLIContext with both filters."""
+    return CLIContext(
+        logger=mock_logger,
+        settings=Settings(),
+        state_dirpath=tmp_path,
+        cli_environment={},
+        cli_context={},
+        action_id_filter_pattern=re.compile(r'tier.*'),
+        issue_id_filter_pattern=re.compile(r'RHEL-123.*'))
+
+
+class TestActionIdFilter:
+    """Tests for _should_filter_by_action_id method."""
+
+    def test_no_filter_returns_false(self, ctx_no_filter):
+        """When no filter pattern is set, should not filter."""
+        result = ctx_no_filter._should_filter_by_action_id('any_action_id')
+        assert result is False
+
+    def test_matching_action_returns_false(self, ctx_with_action_filter):
+        """When action_id matches pattern, should not filter (return False)."""
+        result = ctx_with_action_filter._should_filter_by_action_id('tier1')
+        assert result is False
+        # Check debug log was called
+        ctx_with_action_filter.logger.debug.assert_called_once()
+
+    def test_non_matching_action_returns_true(self, ctx_with_action_filter):
+        """When action_id doesn't match pattern, should filter (return True)."""
+        result = ctx_with_action_filter._should_filter_by_action_id('build_x86')
+        assert result is True
+        # Check info log was called (log_message=True by default)
+        ctx_with_action_filter.logger.info.assert_called_once()
+
+    def test_none_action_id_returns_true(self, ctx_with_action_filter):
+        """When action_id is None, should filter (return True)."""
+        result = ctx_with_action_filter._should_filter_by_action_id(None)
+        assert result is True
+
+    def test_log_message_false_uses_debug(self, ctx_with_action_filter):
+        """When log_message=False, should use debug log for skips."""
+        result = ctx_with_action_filter._should_filter_by_action_id(
+            'build_x86', log_message=False)
+        assert result is True
+        # Check debug log was called, not info
+        ctx_with_action_filter.logger.debug.assert_called_once()
+        ctx_with_action_filter.logger.info.assert_not_called()
+
+
+class TestIssueIdFilter:
+    """Tests for _should_filter_by_issue_id method."""
+
+    def test_no_filter_returns_false(self, ctx_no_filter):
+        """When no filter pattern is set, should not filter."""
+        result = ctx_no_filter._should_filter_by_issue_id('RHEL-12345')
+        assert result is False
+
+    def test_matching_issue_returns_false(self, ctx_with_issue_filter):
+        """When issue_id matches pattern, should not filter (return False)."""
+        result = ctx_with_issue_filter._should_filter_by_issue_id('RHEL-12345')
+        assert result is False
+        # Check debug log was called
+        ctx_with_issue_filter.logger.debug.assert_called_once()
+
+    def test_non_matching_issue_returns_true(self, ctx_with_issue_filter):
+        """When issue_id doesn't match pattern, should filter (return True)."""
+        result = ctx_with_issue_filter._should_filter_by_issue_id('RHEL-99999')
+        assert result is True
+        # Check info log was called (log_message=True by default)
+        ctx_with_issue_filter.logger.info.assert_called_once()
+
+    def test_none_issue_id_returns_true(self, ctx_with_issue_filter):
+        """When issue_id is None, should filter (return True)."""
+        result = ctx_with_issue_filter._should_filter_by_issue_id(None)
+        assert result is True
+
+    def test_log_message_false_uses_debug(self, ctx_with_issue_filter):
+        """When log_message=False, should use debug log for skips."""
+        result = ctx_with_issue_filter._should_filter_by_issue_id(
+            'RHEL-99999', log_message=False)
+        assert result is True
+        # Check debug log was called, not info
+        ctx_with_issue_filter.logger.debug.assert_called_once()
+        ctx_with_issue_filter.logger.info.assert_not_called()
+
+
+class TestBothFilters:
+    """Tests for using both filters together."""
+
+    def test_both_match(self, ctx_with_both_filters):
+        """When both filters match, both should return False."""
+        action_result = ctx_with_both_filters._should_filter_by_action_id('tier1')
+        issue_result = ctx_with_both_filters._should_filter_by_issue_id('RHEL-12345')
+        assert action_result is False
+        assert issue_result is False
+
+    def test_action_matches_issue_doesnt(self, ctx_with_both_filters):
+        """When action matches but issue doesn't, issue filter should return True."""
+        action_result = ctx_with_both_filters._should_filter_by_action_id('tier1')
+        issue_result = ctx_with_both_filters._should_filter_by_issue_id('RHEL-99999')
+        assert action_result is False
+        assert issue_result is True
+
+    def test_issue_matches_action_doesnt(self, ctx_with_both_filters):
+        """When issue matches but action doesn't, action filter should return True."""
+        action_result = ctx_with_both_filters._should_filter_by_action_id('build_x86')
+        issue_result = ctx_with_both_filters._should_filter_by_issue_id('RHEL-12345')
+        assert action_result is True
+        assert issue_result is False
+
+    def test_both_dont_match(self, ctx_with_both_filters):
+        """When both filters don't match, both should return True."""
+        action_result = ctx_with_both_filters._should_filter_by_action_id('build_x86')
+        issue_result = ctx_with_both_filters._should_filter_by_issue_id('RHEL-99999')
+        assert action_result is True
+        assert issue_result is True


### PR DESCRIPTION
## Summary by Sourcery

Add configurable filtering of jobs and Jira operations by issue ID alongside existing action ID filtering.

New Features:
- Introduce an --issue-id-filter CLI option to restrict processing to Jira issues whose keys match a given regular expression.
- Apply issue ID–based filtering to job loading and Jira issue handling, preventing new issue creation when an issue filter is active and no matching issue exists.

Enhancements:
- Refine action ID filtering into reusable helpers and improve logging for both action and issue filtering decisions.
- Relax parent-child action dependency checks when issue ID filtering is enabled to allow partial processing flows.

Documentation:
- Document the new --issue-id-filter option, its behavior across subcommands, and combined usage with --action-id-filter.

Tests:
- Add unit tests covering action ID and issue ID filtering behavior individually and in combination.