### PR TITLE
Refactor Jira connection handling with centralized lazy initialization

### DIFF
--- a/newa/cli/commands/report_cmd.py
+++ b/newa/cli/commands/report_cmd.py
@@ -8,7 +8,6 @@ from newa import CLIContext, ExecuteJob
 from newa.cli.execute_helpers import _create_jira_job_mapping
 from newa.cli.initialization import (
     initialize_et_connection,
-    initialize_jira_connection,
     initialize_rp_connection,
     )
 from newa.cli.report_helpers import (
@@ -44,7 +43,7 @@ def cmd_report(ctx: CLIContext) -> None:
 
     # Initialize connections
     rp = initialize_rp_connection(ctx) if ctx.settings.rp_url else None
-    jira_connection = initialize_jira_connection(ctx)
+    jira_connection = ctx.get_jira_connection().get_connection()
     et = initialize_et_connection(ctx) if ctx.settings.et_enable_comments else None
 
     # Update TF request statuses for all jobs

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -7,7 +7,7 @@ from jira import JIRA
 
 from newa import CLIContext, ExecuteJob
 from newa.cli.constants import JIRA_NONE_ID
-from newa.cli.initialization import initialize_jira_connection, initialize_rp_connection
+from newa.cli.initialization import initialize_rp_connection
 from newa.cli.summarize_helpers import (
     collect_launch_details,
     format_jira_issue_details,
@@ -210,7 +210,7 @@ def cmd_summarize(ctx: CLIContext, preview: bool) -> None:
         ctx.logger.error('ReportPortal URL must be configured to use summarize command')
         return
 
-    jira_connection = initialize_jira_connection(ctx)
+    jira_connection = ctx.get_jira_connection().get_connection()
 
     ai_service = AIService(
         api_url=ctx.settings.ai_api_url,

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -19,7 +19,6 @@ from newa import (
     ScheduleJob,
     )
 from newa.cli.constants import JIRA_NONE_ID, RP_LAUNCH_DESCR_CHARS_LIMIT
-from newa.cli.initialization import initialize_jira_connection
 from newa.cli.utils import test_file_presence
 
 
@@ -282,7 +281,7 @@ def _process_rp_launches_and_jira_updates(
 
         # Update Jira issue if not using execute --continue
         if not (jira_id.startswith(JIRA_NONE_ID) or ctx.continue_execution):
-            jira_connection = initialize_jira_connection(ctx)
+            jira_connection = ctx.get_jira_connection().get_connection()
             _add_jira_comment_for_execution(
                 ctx, jira_connection, jira_id, job, launch_url)
 

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -656,8 +656,6 @@ def _create_simple_jira_job(
         job_recipe: str,
         jira_none_id: Generator[str, int, None]) -> None:
     """Create a simple JiraJob without using issue-config."""
-    from newa.cli.initialization import initialize_jira_connection
-
     if not job_recipe:
         raise Exception("Option --job-recipe is mandatory when --issue-config is not set")
 
@@ -667,8 +665,8 @@ def _create_simple_jira_job(
 
     # Handle issue option
     if issue:
-        jira_connection = initialize_jira_connection(ctx)
-        jira_issue = jira_connection.issue(issue)
+        jira_connection = ctx.get_jira_connection()
+        jira_issue = jira_connection.get_connection().issue(issue)
         ctx.logger.info(f"Using issue {issue}")
         new_issue = Issue(issue,
                           summary=jira_issue.fields.summary,

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -18,7 +18,6 @@ from newa import (
     yaml_parser,
     )
 from newa.cli.constants import JIRA_NONE_ID
-from newa.cli.initialization import initialize_jira_connection
 
 
 def _determine_architectures(
@@ -155,8 +154,8 @@ def _get_issue_fields_for_jira(
         jira_job: JiraJob) -> Any:
     """Get Jira issue fields if available, otherwise return empty dict."""
     if jira_job.jira.id and (not jira_job.jira.id.startswith(JIRA_NONE_ID)):
-        jira_connection = initialize_jira_connection(ctx)
-        issue_fields = jira_connection.issue(jira_job.jira.id).fields
+        jira_connection = ctx.get_jira_connection()
+        issue_fields = jira_connection.get_connection().issue(jira_job.jira.id).fields
         issue_fields.id = jira_job.jira.id
         short_sleep()
         return issue_fields

--- a/newa/services/__init__.py
+++ b/newa/services/__init__.py
@@ -2,7 +2,8 @@
 
 from newa.services.ai_service import AIService
 from newa.services.errata_service import ErrataTool
-from newa.services.jira_service import IssueHandler, JiraField, JiraIssueLinkType
+from newa.services.jira_connection import JiraConnection, JiraField, JiraIssueLinkType
+from newa.services.jira_service import IssueHandler
 from newa.services.reportportal_service import ReportPortal
 from newa.services.rog_service import RoGTool
 
@@ -10,6 +11,7 @@ __all__ = [
     'AIService',
     'ErrataTool',
     'IssueHandler',
+    'JiraConnection',
     'JiraField',
     'JiraIssueLinkType',
     'ReportPortal',

--- a/newa/services/jira_connection.py
+++ b/newa/services/jira_connection.py
@@ -1,0 +1,152 @@
+"""Jira connection management."""
+
+from typing import Optional, Union
+
+import jira
+import jira.client
+
+try:
+    from attrs import define, field
+except ModuleNotFoundError:
+    from attr import define, field
+
+from newa.utils.helpers import short_sleep
+
+
+@define
+class JiraField:
+    """Represents a Jira field definition."""
+    id_: str
+    name: str
+    type_: Optional[str]
+    items: Optional[str]
+
+
+@define
+class JiraIssueLinkType:
+    """Represents a Jira issue link type."""
+    name: str
+    inward: bool
+
+
+@define
+class JiraConnection:
+    """
+    Manages a single Jira connection instance with lazy initialization.
+
+    This class handles the connection to Jira. Metadata such as field mappings,
+    issue link types, and sprint cache are loaded on-demand only when needed
+    (e.g., during issue-config processing).
+    """
+
+    url: str = field()
+    token: str = field()
+
+    # Private connection instance, initialized on first use
+    _connection: Optional[jira.JIRA] = field(default=None, init=False, repr=False)
+
+    # Cached metadata - loaded on-demand, not automatically
+    field_map: dict[str, JiraField] = field(factory=dict, init=False, repr=False)
+    issue_link_types_map: dict[str, JiraIssueLinkType] = field(
+        factory=dict, init=False, repr=False)
+    sprint_cache: dict[str, list[int]] = field(
+        factory=lambda: {'active': [], 'future': []}, init=False, repr=False)
+
+    # Track which board's sprint cache is currently loaded
+    _cached_board: Optional[Union[str, int]] = field(default=None, init=False, repr=False)
+
+    def get_connection(self) -> jira.JIRA:
+        """
+        Get or create Jira connection with lazy initialization.
+
+        Returns:
+            jira.JIRA: The initialized Jira connection
+
+        Raises:
+            Exception: If authentication fails or connection cannot be established
+        """
+        if self._connection is None:
+            self._connection = jira.JIRA(self.url, token_auth=self.token)
+
+            # Verify connection works
+            try:
+                self._connection.myself()
+                short_sleep()
+            except jira.JIRAError as e:
+                raise Exception('Could not authenticate to Jira. Wrong token?') from e
+
+        return self._connection
+
+    def ensure_metadata_loaded(self) -> None:
+        """
+        Ensure field mappings and issue link types are loaded.
+
+        This should be called explicitly when metadata is needed (e.g., during
+        issue-config processing). It only loads the data once.
+        """
+        # Skip if already loaded
+        if self.field_map:
+            return
+
+        conn = self.get_connection()
+
+        # Read field map from Jira and store its simplified version
+        fields = conn.fields()
+        for f in fields:
+            self.field_map[f['name']] = JiraField(
+                name=f['name'],
+                id_=f['id'],
+                type_=f['schema']['type'] if 'schema' in f else None,
+                items=f['schema']['items'] if ('schema' in f and 'items' in f['schema']) else None,
+                )
+
+        # Read issue link types
+        issue_link_types = conn.issue_link_types()
+        for link_type in issue_link_types:
+            self.issue_link_types_map[str(link_type.inward)] = JiraIssueLinkType(
+                name=link_type.name, inward=True,
+                )
+            self.issue_link_types_map[str(link_type.outward)] = JiraIssueLinkType(
+                name=link_type.name, inward=False,
+                )
+
+    def ensure_sprint_cache_loaded(self, board: Optional[Union[str, int]]) -> None:
+        """
+        Ensure sprint cache is loaded for the specified board.
+
+        Args:
+            board: Board name (str) or ID (int) from issue-config
+
+        This should be called explicitly when sprint data is needed. It only
+        loads/reloads the data if the board changes.
+        """
+        if not board:
+            return
+
+        # Skip if already loaded for this board (check if cache was loaded, not if sprints exist)
+        if self._cached_board == board:
+            return
+
+        conn = self.get_connection()
+
+        # If board is identified by name, find its id
+        if isinstance(board, str):
+            boards = conn.boards(name=board)
+            if len(boards) == 1:
+                board_id = boards[0].id
+            else:
+                raise Exception(f"Could not find Jira board with name '{board}'")
+            short_sleep()
+        else:
+            board_id = board
+
+        # Fetch both states at once
+        sprints = conn.sprints(board_id, state='active,future')
+        self.sprint_cache['active'] = [
+            s.id for s in sprints if s.originBoardId == board_id and s.state == 'active'
+            ]
+        self.sprint_cache['future'] = [
+            s.id for s in sprints if s.originBoardId == board_id and s.state == 'future'
+            ]
+        self._cached_board = board
+        short_sleep()


### PR DESCRIPTION
This commit consolidates inconsistent Jira connection handling across the codebase by introducing a dedicated JiraConnection class with lazy initialization and on-demand metadata loading.

Key changes:
- Add JiraConnection class for centralized connection management with lazy initialization of connection, field mappings, issue link types, and sprint cache
- Add get_jira_connection() method to CLIContext for connection reuse across the application
- Refactor IssueHandler to use shared JiraConnection instead of managing its own connection and metadata
- Move JiraField and JiraIssueLinkType definitions from jira_service to jira_connection module
- Load metadata (field_map, issue_link_types) only when needed during issue-config processing via ensure_metadata_loaded()
- Load sprint cache only when needed via ensure_sprint_cache_loaded(board), with board configuration sourced from issue-config file
- Remove initialize_jira_connection() helper in favor of ctx.get_jira_connection()
- Update all Jira connection usage sites across CLI commands and helpers

Benefits:
- Single Responsibility Principle: IssueHandler focuses on business logic, JiraConnection handles connection management
- Resource efficiency: connection reuse reduces overhead, metadata loads on-demand
- Improved maintainability: centralized connection logic easier to modify and test
- Reduced Jira API utilization: metadata only fetched when necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor Jira integration to use a centralized, lazily initialized JiraConnection shared via CLI context and consumed by IssueHandler and CLI helpers.

Enhancements:
- Introduce a JiraConnection class that encapsulates Jira client creation, authentication verification, and on-demand loading of field mappings, issue link types, and sprint cache.
- Update IssueHandler to depend on JiraConnection and instance-level configuration instead of managing its own static Jira client, metadata, and sprint cache.
- Expose a get_jira_connection() helper on CLIContext to provide a reusable, lazily initialized JiraConnection across commands and helpers.
- Replace direct Jira client initialization and the initialize_jira_connection() helper across CLI commands and helpers with usage of the shared JiraConnection instance.