### PR TITLE
Update regexp pattern for RHEL key detection

### DIFF
--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -26,7 +26,7 @@ def extract_jira_issues_from_comment(comment: str) -> list[str]:
     if not comment:
         return []
 
-    pattern = r'https://issues\.redhat\.com/browse/(RHEL-\d+)'
+    pattern = r'\b(RHEL-\d{4,8})\b'
     return re.findall(pattern, comment)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct JIRA issue extraction by matching generic RHEL-####… keys in comments that may not include the full issues.redhat.com URL.