### PR TITLE
Enable COPR builds for EPEL-10

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,6 +50,8 @@ jobs:
       - fedora-all-aarch64
       - epel-9-x86_64
       - epel-9-aarch64
+      - epel-10-x86_64
+      - epel-10-aarch64
     enable_net: false
     osh_diff_scan_after_copr_build: false
     list_on_homepage: true
@@ -72,6 +74,8 @@ jobs:
       - fedora-all-aarch64
       - epel-9-x86_64
       - epel-9-aarch64
+      - epel-10-x86_64
+      - epel-10-aarch64
     enable_net: false
     list_on_homepage: true
     preserve_project: true


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add EPEL 10 x86_64 and aarch64 targets to Packit COPR build job configuration.