### PR TITLE
Fix clean termination of newa execute command on Ctrl+C

### DIFF
--- a/newa/cli/commands/execute_cmd.py
+++ b/newa/cli/commands/execute_cmd.py
@@ -114,7 +114,11 @@ def cmd_execute(
         ctx, rp, et, jira_schedule_job_mapping)
 
     # Execute worker pool to process all schedule jobs
-    _execute_worker_pool(ctx, schedule_job_list, workers)
+    try:
+        _execute_worker_pool(ctx, schedule_job_list, workers)
+    except KeyboardInterrupt:
+        # Let _execute_worker_pool handle user-facing logging; just translate to Click's Abort.
+        raise click.Abort from None
 
     # Finalize RP launches after execution
     _finalize_rp_launches(ctx, rp, launch_list)

--- a/newa/cli/workers.py
+++ b/newa/cli/workers.py
@@ -19,12 +19,16 @@ from newa.cli.utils import test_patterns_match
 
 def worker(ctx: CLIContext, schedule_file: Path) -> None:
     """Main worker function that delegates to TF or TMT worker."""
-    # read request details
-    schedule_job = ScheduleJob.from_yaml_file(Path(schedule_file))
-    if schedule_job.request.how == ExecuteHow.TMT:
-        tmt_worker(ctx, schedule_file, schedule_job)
-    else:
-        tf_worker(ctx, schedule_file, schedule_job)
+    try:
+        # read request details
+        schedule_job = ScheduleJob.from_yaml_file(Path(schedule_file))
+        if schedule_job.request.how == ExecuteHow.TMT:
+            tmt_worker(ctx, schedule_file, schedule_job)
+        else:
+            tf_worker(ctx, schedule_file, schedule_job)
+    except KeyboardInterrupt:
+        # Silently exit on keyboard interrupt - cleanup is handled by parent
+        raise SystemExit(0) from None
 
 
 def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -> None:


### PR DESCRIPTION
Previously, when the user interrupted the execute command with Ctrl+C during TF request status checking, the program would exit with OSError tracebacks from multiprocessing worker processes about "Bad file descriptor".

This fix implements proper signal handling and cleanup:
- Add try-except-finally block to properly terminate and join the worker pool
- Prevent worker processes from printing tracebacks by temporarily ignoring SIGINT during pool creation
- Handle KeyboardInterrupt in worker functions to exit cleanly
- Convert KeyboardInterrupt to click.Abort for clean CLI termination

The program now exits gracefully with just a simple "Execution terminated by user" message instead of displaying confusing multiprocessing tracebacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve graceful termination and cleanup of the execute command when interrupted by the user.

Bug Fixes:
- Prevent multiprocessing worker pool from leaving dangling processes and emitting OSError tracebacks on Ctrl+C during execute.
- Ensure worker processes exit cleanly on KeyboardInterrupt without printing confusing tracebacks.
- Convert top-level KeyboardInterrupt during execute to a clean click.Abort with a user-friendly log message.

Enhancements:
- Add robust signal handling around multiprocessing pool creation and lifecycle to ensure proper cleanup on interruption.