### PR TITLE
Refactor --copy-state-dir to work with --state-dir/--prev-state-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,7 +756,9 @@ $ newa --extract-state-dir /path/to/archive.tar.gz --action-id-filter 'regressio
 
 #### Option `--copy-state-dir`, `-C`
 
-Copies YAML files from a specified state directory to a newly created state directory and continues with the new state-dir. This option is useful when you want to reuse state from an existing directory (e.g., from a different machine or a shared location) without modifying the original state-dir.
+Copies YAML files from a state directory (identified by `--state-dir` or `--prev-state-dir`) to a newly created state directory and continues with the new state-dir. This option is useful when you want to reuse state from an existing directory (e.g., from a different machine or a shared location) without modifying the original state-dir.
+
+This option must be used together with either `--state-dir` or `--prev-state-dir` to identify the source directory. The source directory becomes read-only, and a new state-dir is automatically created as the target.
 
 This option can be combined with `--action-id-filter` and `--issue-id-filter` to copy only specific YAML files that match the filter criteria. When filters are specified:
 - `--action-id-filter`: Only copies YAML files where the `jira.action_id` field matches the provided regex pattern
@@ -767,27 +769,32 @@ This option cannot be used together with `--extract-state-dir`.
 
 Example (basic copy without filters):
 ```
-$ newa --copy-state-dir /path/to/existing/run-123 list
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir list
 ```
 
 Example (copying from a mounted network share):
 ```
-$ newa --copy-state-dir /mnt/shared/newa-state-dir/run-456 jira --issue-config config.yaml schedule execute report
+$ newa --state-dir /mnt/shared/newa-state-dir/run-456 --copy-state-dir jira --issue-config config.yaml schedule execute report
+```
+
+Example (copying from previous state-dir):
+```
+$ newa --prev-state-dir --copy-state-dir list
 ```
 
 Example (copy only files for specific action):
 ```
-$ newa --copy-state-dir /path/to/existing/run-123 --action-id-filter 'tier1_.*' schedule execute report
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --action-id-filter 'tier1_.*' schedule execute report
 ```
 
 Example (copy only files for specific Jira issue):
 ```
-$ newa --copy-state-dir /path/to/existing/run-123 --issue-id-filter 'RHEL-12345' schedule execute report
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --issue-id-filter 'RHEL-12345' schedule execute report
 ```
 
 Example (copy files matching both action and issue filters):
 ```
-$ newa --copy-state-dir /path/to/existing/run-123 --action-id-filter 'regression_.*' --issue-id-filter 'PROJ-.*' schedule execute report
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --action-id-filter 'regression_.*' --issue-id-filter 'PROJ-.*' schedule execute report
 ```
 
 #### Option `--context, -c`


### PR DESCRIPTION
Change the --copy-state-dir option from taking a directory argument to being a flag that must be used together with either --state-dir or --prev-state-dir to identify the source directory.

The new behavior:
- --copy-state-dir is now a flag (no argument)
- Must be used with --state-dir or --prev-state-dir
- The directory identified by those options becomes the source
- A new state-dir is automatically created as the target
- Source directory remains unmodified (read-only)

Changes:
- newa/cli/main.py:
  * Convert --copy-state-dir from string parameter to boolean flag
  * Add validation requiring --state-dir or --prev-state-dir
  * Update state directory initialization logic
  * Simplify source directory path handling
  * Add type assertion for mypy compliance

- tests/unit/test_cli.py:
  * Update all 5 copy_state_dir tests to use new syntax
  * Use NEWA_STATEDIR_TOPDIR env var to control target location
  * Verify filtering behavior still works correctly

- README.md:
  * Update --copy-state-dir documentation
  * Clarify requirement to use with --state-dir/--prev-state-dir
  * Update all usage examples to reflect new syntax
  * Add example using --prev-state-dir --copy-state-dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor the --copy-state-dir CLI option to be a boolean flag that works with --state-dir/--prev-state-dir and update tests and documentation to reflect the new behavior.

New Features:
- Allow --copy-state-dir to use --prev-state-dir as a source for creating a new state directory.

Enhancements:
- Change --copy-state-dir from taking a directory argument to a flag that uses the active state directory as the copy source.
- Adjust state directory initialization logic to create a new target state-dir automatically when copying from an existing one.
- Improve CLI validation to enforce that --copy-state-dir is only used when a source state directory is provided.

Documentation:
- Update README documentation and examples for --copy-state-dir to describe the new flag-based usage and its interaction with --state-dir/--prev-state-dir.

Tests:
- Update CLI tests for --copy-state-dir to cover the new flag semantics and automatic state-dir creation behavior, including filtered copy scenarios.