### PR TITLE
Improve Jira issue parsing to support all project prefixes and handle…

### DIFF
--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -26,7 +26,7 @@ def extract_jira_issues_from_comment(comment: str) -> list[str]:
     if not comment:
         return []
 
-    pattern = r'\b(RHEL-\d{4,8})\b'
+    pattern = r'\b([A-Z]{2,20}-\d{4,8})\b'
     return re.findall(pattern, comment)
 
 
@@ -148,7 +148,8 @@ def format_jira_issue_details(jira_issues_data: dict[str, dict[str, Any]]) -> li
     """Format detailed information for Jira issues.
 
     Args:
-        jira_issues_data: Dictionary mapping issue key to issue details
+        jira_issues_data: Dictionary mapping issue key to issue details.
+                         For issues with errors, the dict will contain {'error': 'message'}
 
     Returns:
         List of formatted lines
@@ -165,18 +166,27 @@ def format_jira_issue_details(jira_issues_data: dict[str, dict[str, Any]]) -> li
 
     for issue_key in sorted(jira_issues_data.keys()):
         issue = jira_issues_data[issue_key]
-        components = ", ".join(issue["components"]) if issue["components"] else "None"
-        affects = ", ".join(issue["affects_versions"]) if issue["affects_versions"] else "None"
-        fix = ", ".join(issue["fix_versions"]) if issue["fix_versions"] else "None"
-        output.extend([
-            f'Issue: {issue["key"]}',
-            f'Summary: {issue["summary"]}',
-            f'Status: {issue["status"]}',
-            f'Component: {components}',
-            f'Affects Version/s: {affects}',
-            f'Fix Version/s: {fix}',
-            '',
-            ])
+
+        # Check if this is an error entry
+        if 'error' in issue:
+            output.extend([
+                f'Issue: {issue_key}',
+                f'Error: {issue["error"]}',
+                '',
+                ])
+        else:
+            components = ", ".join(issue["components"]) if issue["components"] else "None"
+            affects = ", ".join(issue["affects_versions"]) if issue["affects_versions"] else "None"
+            fix = ", ".join(issue["fix_versions"]) if issue["fix_versions"] else "None"
+            output.extend([
+                f'Issue: {issue["key"]}',
+                f'Summary: {issue["summary"]}',
+                f'Status: {issue["status"]}',
+                f'Component: {components}',
+                f'Affects Version/s: {affects}',
+                f'Fix Version/s: {fix}',
+                '',
+                ])
 
     return output
 


### PR DESCRIPTION
… missing issues

Update the Jira issue extraction regex to match any project prefix (e.g., RHEL-1234, JIRA-5678) instead of only RHEL issues. Add error handling for issues that don't exist or are restricted, displaying a clear error message instead of omitting them from the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand Jira issue extraction and surface errors for missing or inaccessible issues in summarize CLI output.

New Features:
- Support parsing Jira issue keys with any uppercase project prefix instead of only RHEL-prefixed issues.
- Display explicit error entries for Jira issues that are missing or access-restricted when fetching details in bulk.

Enhancements:
- Clarify summarize helper docstrings to describe error entries in Jira issue data.