### PR TITLE
[WIP] Allow clickable TF/jira links

### DIFF
--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -188,7 +188,15 @@ def _create_or_reuse_rp_launch(
     if not new_launch_uuid:
         raise Exception('Failed to create RP launch')
 
-    ctx.logger.info(f'Created RP launch {new_launch_uuid} for issue {jira_id}')
+    if ctx.settings.use_urls_in_logs and ctx.settings.rp_url:
+        rp_launch_url = (
+            f"{ctx.settings.rp_url}/ui/#{ctx.settings.rp_project}"
+            f"/launches/all/{new_launch_uuid}")
+        ctx.logger.info(
+            f'Created RP launch {new_launch_uuid} ({rp_launch_url})'
+            f' for issue {jira_id}')
+    else:
+        ctx.logger.info(f'Created RP launch {new_launch_uuid} for issue {jira_id}')
     return str(new_launch_uuid)
 
 

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -346,7 +346,7 @@ def _find_or_create_issue(
                 action, all_respins=True, closed=True)
 
         for jira_issue_key, jira_issue in search_result.items():
-            if ctx.settings.jira_show_url:
+            if ctx.settings.use_urls_in_logs:
                 ctx.logger.debug(
                     f"Checking {jira_issue_key} "
                     f"({ctx.settings.jira_url}/browse/{jira_issue_key})")
@@ -449,14 +449,14 @@ def _find_or_create_issue(
         opened_issues = [i for i in new_issues if not i.closed]
         closed_issues = [i for i in new_issues if i.closed]
         if not opened_issues:
-            closed_ids = ', '.join([i.id for i in closed_issues])
-            if ctx.settings.jira_show_url:
-                ctx.logger.info(
-                    f"Relevant issues {closed_ids} "
-                    f"({ctx.settings.jira_url}/browse/{closed_ids}) found but already closed")
+            if ctx.settings.use_urls_in_logs:
+                closed_ids = ', '.join(
+                    [f"{i.id} ({ctx.settings.jira_url}/browse/{i.id})"
+                     for i in closed_issues])
             else:
-                ctx.logger.info(
-                    f"Relevant issues {closed_ids} found but already closed")
+                closed_ids = ', '.join([i.id for i in closed_issues])
+            ctx.logger.info(
+                f"Relevant issues {closed_ids} found but already closed")
             return None, [], False  # Signal to skip this action
 
         new_issues = opened_issues
@@ -494,7 +494,7 @@ def _find_or_create_issue(
             assert action.id is not None
             processed_actions[action.id] = new_issue
             created_action_ids.append(action.id)
-            if ctx.settings.jira_show_url:
+            if ctx.settings.use_urls_in_logs:
                 ctx.logger.info(
                     f"New issue {new_issue.id} created "
                     f"({ctx.settings.jira_url}/browse/{new_issue.id})")
@@ -538,10 +538,10 @@ def _find_or_create_issue(
                 ctx.logger.debug(f"refresh_issue returned: {trigger_comment}")
             else:
                 ctx.logger.info("Skipping issue refresh due to --no-newa-id flag")
-            if ctx.settings.jira_show_url:
+            if ctx.settings.use_urls_in_logs:
                 ctx.logger.info(
                     f"Issue {new_issue} "
-                    f"({ctx.settings.jira_url}/browse/{new_issue})re-used")
+                    f"({ctx.settings.jira_url}/browse/{new_issue}) re-used")
             else:
                 ctx.logger.info(f"Issue {new_issue} re-used")
 

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -346,7 +346,12 @@ def _find_or_create_issue(
                 action, all_respins=True, closed=True)
 
         for jira_issue_key, jira_issue in search_result.items():
-            ctx.logger.debug(f"Checking {jira_issue_key}")
+            if ctx.settings.jira_show_url:
+                ctx.logger.debug(
+                    f"Checking {jira_issue_key} "
+                    f"({ctx.settings.jira_url}/browse/{jira_issue_key})")
+            else:
+                ctx.logger.debug(f"Checking {jira_issue_key}")
 
             is_new = False
             # Use helper function for backwards-compatible comparison
@@ -445,8 +450,13 @@ def _find_or_create_issue(
         closed_issues = [i for i in new_issues if i.closed]
         if not opened_issues:
             closed_ids = ', '.join([i.id for i in closed_issues])
-            ctx.logger.info(
-                f"Relevant issues {closed_ids} found but already closed")
+            if ctx.settings.jira_show_url:
+                ctx.logger.info(
+                    f"Relevant issues {closed_ids} "
+                    f"({ctx.settings.jira_url}/browse/{closed_ids}) found but already closed")
+            else:
+                ctx.logger.info(
+                    f"Relevant issues {closed_ids} found but already closed")
             return None, [], False  # Signal to skip this action
 
         new_issues = opened_issues
@@ -484,7 +494,12 @@ def _find_or_create_issue(
             assert action.id is not None
             processed_actions[action.id] = new_issue
             created_action_ids.append(action.id)
-            ctx.logger.info(f"New issue {new_issue.id} created")
+            if ctx.settings.jira_show_url:
+                ctx.logger.info(
+                    f"New issue {new_issue.id} created "
+                    f"({ctx.settings.jira_url}/browse/{new_issue.id})")
+            else:
+                ctx.logger.info(f"New issue {new_issue.id} created")
             trigger_comment = True
         else:
             return None, [], False  # Signal to skip this action
@@ -523,7 +538,12 @@ def _find_or_create_issue(
                 ctx.logger.debug(f"refresh_issue returned: {trigger_comment}")
             else:
                 ctx.logger.info("Skipping issue refresh due to --no-newa-id flag")
-            ctx.logger.info(f"Issue {new_issue} re-used")
+            if ctx.settings.jira_show_url:
+                ctx.logger.info(
+                    f"Issue {new_issue} "
+                    f"({ctx.settings.jira_url}/browse/{new_issue})re-used")
+            else:
+                ctx.logger.info(f"Issue {new_issue} re-used")
 
         # Add issue links from action configuration
         jira_handler.add_issue_links(new_issue, rendered_links)

--- a/newa/cli/workers.py
+++ b/newa/cli/workers.py
@@ -150,7 +150,7 @@ def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -
                     pass
             envs = ','.join([f"{e['os']['compose']}/{e['arch']}"
                              for e in tf_request.details['environments_requested']])
-            if ctx.settings.tf_show_url:
+            if ctx.settings.use_urls_in_logs and execute_job.execution.artifacts_url:
                 log(
                     f'TF request {execute_job.execution.artifacts_url}'
                     f' envs: {envs} state: {state}')

--- a/newa/cli/workers.py
+++ b/newa/cli/workers.py
@@ -150,7 +150,12 @@ def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -
                     pass
             envs = ','.join([f"{e['os']['compose']}/{e['arch']}"
                              for e in tf_request.details['environments_requested']])
-            log(f'TF request {tf_request.uuid} envs: {envs} state: {state}')
+            if ctx.settings.tf_show_url:
+                log(
+                    f'TF request {execute_job.execution.artifacts_url}'
+                    f' envs: {envs} state: {state}')
+            else:
+                log(f'TF request {tf_request.uuid} envs: {envs} state: {state}')
             finished = tf_request.is_finished()
         else:
             log(f'Could not read details of TF request {tf_request.uuid}')

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -63,10 +63,9 @@ class Settings:  # type: ignore[no-untyped-def]
     jira_token: str = ''
     jira_email: str = ''
     jira_project: str = ''
-    jira_show_url: bool = False
     tf_token: str = ''
     tf_recheck_delay: str = ''
-    tf_show_url: bool = False
+    use_urls_in_logs: bool = False
     rog_token: str = ''
     ai_api_url: str = ''
     ai_api_token: str = ''
@@ -167,11 +166,6 @@ class Settings:  # type: ignore[no-untyped-def]
                 cp,
                 'jira/email',
                 'NEWA_JIRA_EMAIL'),
-            jira_show_url=_str_to_bool(
-                _get(
-                    cp,
-                    'jira/show_url',
-                    'NEWA_JIRA_SHOW_URL')),
             tf_token=_get(
                 cp,
                 'testingfarm/token',
@@ -181,11 +175,11 @@ class Settings:  # type: ignore[no-untyped-def]
                 'testingfarm/recheck_delay',
                 'NEWA_TF_RECHECK_DELAY',
                 "60"),
-            tf_show_url=_str_to_bool(
+            use_urls_in_logs=_str_to_bool(
                 _get(
                     cp,
-                    'testingfarm/show_url',
-                    'NEWA_TF_SHOW_URL')),
+                    'newa/use_urls_in_logs',
+                    'NEWA_USE_URLS_IN_LOGS')),
             rog_token=_get(
                 cp,
                 'rog/token',

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -63,8 +63,10 @@ class Settings:  # type: ignore[no-untyped-def]
     jira_token: str = ''
     jira_email: str = ''
     jira_project: str = ''
+    jira_show_url: bool = False
     tf_token: str = ''
     tf_recheck_delay: str = ''
+    tf_show_url: bool = False
     rog_token: str = ''
     ai_api_url: str = ''
     ai_api_token: str = ''
@@ -165,6 +167,11 @@ class Settings:  # type: ignore[no-untyped-def]
                 cp,
                 'jira/email',
                 'NEWA_JIRA_EMAIL'),
+            jira_show_url=_str_to_bool(
+                _get(
+                    cp,
+                    'jira/show_url',
+                    'NEWA_JIRA_SHOW_URL')),
             tf_token=_get(
                 cp,
                 'testingfarm/token',
@@ -174,6 +181,11 @@ class Settings:  # type: ignore[no-untyped-def]
                 'testingfarm/recheck_delay',
                 'NEWA_TF_RECHECK_DELAY',
                 "60"),
+            tf_show_url=_str_to_bool(
+                _get(
+                    cp,
+                    'testingfarm/show_url',
+                    'NEWA_TF_SHOW_URL')),
             rog_token=_get(
                 cp,
                 'rog/token',


### PR DESCRIPTION
For debugging/configuring purposes I often run newa manually from the command line. I don't wait for the complete results, I just want to quickly get to the log on Testing Farm or see the Jira issues. That means highlighting the TF UUID/jira issue number in the newa output stream with a mouse, alt+shift+D to open `doer` and then mouse clicking on the correct line to open the desired interface. (Note: that does not work for staging jira instance, because that is not even present in the  `doer` UI list)

This change introduces two options in newa.conf file to allow printing clickable links to TF/Jira in the newa output stream and getting the results quickly without the overhead of mouse-selecting and sometimes missclicking in `doer`.

## Summary by Sourcery

Add configurable options to include clickable Testing Farm and Jira URLs in CLI logs for easier navigation from terminal output.

New Features:
- Introduce jira_show_url and tf_show_url settings to control whether Jira and Testing Farm URLs are printed in logs.

Enhancements:
- Extend Jira-related logging to optionally include direct issue URLs when searching, creating, or reusing issues.
- Update Testing Farm worker logging to optionally print the artifacts URL instead of just the request UUID.