### PR TITLE
Add conditional includes support to issue-config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,70 @@ has lower priority and the whole section is replaced completely.
 The only exceptions are are `issues` and `defaults` which are merged.
 To unset a value defined in an included file one can set the value to `null`.
 
+The `include` attribute supports both simple and conditional includes:
+
+**Simple include** - Always includes the specified file:
+```yaml
+include:
+  - global_settings.yaml
+  - https://example.com/shared-config.yaml
+```
+
+**Conditional include** - Includes files based on evaluated conditions:
+```yaml
+include:
+  # Include only when condition evaluates to true
+  - url: production-settings.yaml
+    when: ENVIRONMENT.DEPLOY_ENV is match('prod.*')
+
+  # Include only for RHSA advisories
+  - url: security-config.yaml
+    when: ERRATUM.id is match('RHSA-.*')
+
+  # Always include (no condition)
+  - base-settings.yaml
+```
+
+The `when` condition uses the same syntax as in-config tests (see "In-config tests" section). Conditions are evaluated when the config file is loaded and have access to the following variables:
+
+- `EVENT` - The event object (type, id)
+- `ERRATUM` - Erratum data (if applicable)
+- `COMPOSE` - Compose data (if applicable)
+- `ROG` - RoG merge request data (if applicable)
+- `CONTEXT` - Command-line context variables (from `--context`)
+- `ENVIRONMENT` - Command-line environment variables (from `--environment`)
+
+Example:
+
+```yaml
+# issue-config.yaml
+include:
+  # Include different defaults based on erratum type
+  - url: security-team-defaults.yaml
+    when: ERRATUM.id is match('RHSA-.*')
+  - url: bugfix-team-defaults.yaml
+    when: ERRATUM.id is match('RHBA-.*')
+
+  # Conditional settings for different releases
+  - url: rhel9-specific.yaml
+    when: ERRATUM.release is match('RHEL-9.*')
+  - url: rhel8-specific.yaml
+    when: ERRATUM.release is match('RHEL-8.*')
+
+  # Include based on compose
+  - url: centos-stream-config.yaml
+    when: COMPOSE.id is match('CentOS-Stream-.*')
+
+  # Include based on CLI context
+  - url: production-settings.yaml
+    when: CONTEXT.env is match('prod.*')
+
+project: MYPROJECT
+# ... rest of config
+```
+
+This allows you to create modular, environment-specific configurations that are conditionally loaded based on the event being processed and command-line parameters.
+
 
 #### iterate
 

--- a/newa/cli/commands/jira_cmd.py
+++ b/newa/cli/commands/jira_cmd.py
@@ -142,7 +142,19 @@ def cmd_jira(
             # Mode 1: Using issue-config file
             # we are reading the issue config again for each artifact
             # because later we modify some objects
-            config = IssueConfig.read_file(os.path.expandvars(issue_config))
+            # Prepare variables for conditional includes in issue-config
+            config_variables = {
+                'EVENT': artifact_job.event,
+                'ERRATUM': artifact_job.erratum,
+                'COMPOSE': artifact_job.compose,
+                'ROG': artifact_job.rog,
+                'CONTEXT': ctx.cli_context,
+                'ENVIRONMENT': ctx.cli_environment,
+                }
+            config = IssueConfig.read_file(
+                os.path.expandvars(issue_config),
+                variables=config_variables,
+                logger=ctx.logger)
             issue_mapping = _parse_issue_mapping(map_issue, config)
 
             # Get or create Jira connection

--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -16,6 +16,7 @@ except ModuleNotFoundError:
 from newa.models.base import ErratumCommentTrigger, RoGCommentTrigger, Serializable
 from newa.models.recipes import RecipeContext, RecipeEnvironment
 from newa.utils.http import ResponseContentType, get_request
+from newa.utils.templates import eval_test
 from newa.utils.yaml_utils import yaml_parser
 
 if TYPE_CHECKING:
@@ -154,10 +155,16 @@ class IssueConfig(Serializable):  # type: ignore[no-untyped-def]
     board: Optional[Union[str, int]] = field(default=None)
 
     @classmethod
-    def from_yaml_with_include(cls: type['Self'], location: str) -> 'Self':
+    def from_yaml_with_include(
+            cls: type['Self'],
+            location: str,
+            variables: Optional[dict[str, Any]] = None,
+            logger: Optional[Any] = None) -> 'Self':
 
-        def load_data_from_location(location: str,
-                                    stack: Optional[list[str]] = None) -> dict[str, Any]:
+        def load_data_from_location(
+                location: str,
+                stack: Optional[list[str]] = None,
+                variables: Optional[dict[str, Any]] = None) -> dict[str, Any]:
             if stack and location in stack:
                 raise Exception(
                     'Duplicate location encountered while loading issue-config YAML '
@@ -181,15 +188,51 @@ class IssueConfig(Serializable):  # type: ignore[no-untyped-def]
 
             # process 'include' attribute
             if 'include' in data:
-                locations = data['include']
+                includes = data['include']
                 # drop 'include' so it won't be processed again
                 del data['include']
                 # if 'include' list is empty, return data
-                if not locations:
+                if not includes:
                     return data
                 # processing files in reversed order so that later definition takes priority
-                for loc in reversed(locations):
-                    included_data = load_data_from_location(loc, stack)
+                for include_entry in reversed(includes):
+                    # Support both string format and dict format with 'when' condition
+                    loc: str
+                    if isinstance(include_entry, str):
+                        # Simple string URL/path
+                        loc = include_entry
+                        should_include = True
+                    elif isinstance(include_entry, dict):
+                        # Dict format with optional 'when' condition
+                        url_value = include_entry.get('url')
+                        if not url_value:
+                            raise Exception(
+                                f"Include entry must have 'url' key: {include_entry}")
+                        loc = str(url_value)
+                        condition = include_entry.get('when')
+                        if condition:
+                            # Evaluate the condition with contextual error handling
+                            try:
+                                should_include = eval_test(condition, **(variables or {}))
+                            except Exception as exc:
+                                raise Exception(
+                                    f"Failed to evaluate 'when' condition {condition!r} "
+                                    f"for include {include_entry!r} in location {location!r}",
+                                    ) from exc
+                        else:
+                            should_include = True
+                    else:
+                        entry_type = type(include_entry).__name__
+                        raise Exception(
+                            f"Include entry must be a string or dict, got {entry_type}")
+
+                    if not should_include:
+                        if logger:
+                            logger.info(
+                                f"Skipping include '{loc}' as condition evaluated to False")
+                        continue
+
+                    included_data = load_data_from_location(loc, stack, variables)
                     if included_data:
                         for key in included_data:
                             # special handing of 'issues'
@@ -220,13 +263,17 @@ class IssueConfig(Serializable):  # type: ignore[no-untyped-def]
 
             return data
 
-        data = load_data_from_location(location)
+        data = load_data_from_location(location, variables=variables)
         return cls(**data)
 
     @classmethod
-    def read_file(cls: type['Self'], location: str) -> 'Self':
+    def read_file(
+            cls: type['Self'],
+            location: str,
+            variables: Optional[dict[str, Any]] = None,
+            logger: Optional[Any] = None) -> 'Self':
 
-        config = cls.from_yaml_with_include(location)
+        config = cls.from_yaml_with_include(location, variables=variables, logger=logger)
 
         for action in config.issues:
             if config.defaults:

--- a/tests/unit/data/issue-config-conditional-child-disabled.yaml
+++ b/tests/unit/data/issue-config-conditional-child-disabled.yaml
@@ -1,0 +1,4 @@
+defaults:
+  assignee: disabled_assignee
+  fields:
+    "Environment": "development"

--- a/tests/unit/data/issue-config-conditional-child-enabled.yaml
+++ b/tests/unit/data/issue-config-conditional-child-enabled.yaml
@@ -1,0 +1,4 @@
+defaults:
+  assignee: enabled_assignee
+  fields:
+    "Environment": "production"

--- a/tests/unit/data/issue-config-conditional-compose.yaml
+++ b/tests/unit/data/issue-config-conditional-compose.yaml
@@ -1,0 +1,4 @@
+defaults:
+  assignee: compose_assignee
+  fields:
+    "Compose Type": "compose-based"

--- a/tests/unit/data/issue-config-conditional-context.yaml
+++ b/tests/unit/data/issue-config-conditional-context.yaml
@@ -1,0 +1,3 @@
+defaults:
+  fields:
+    "Context Marker": "context-loaded"

--- a/tests/unit/data/issue-config-conditional-environment.yaml
+++ b/tests/unit/data/issue-config-conditional-environment.yaml
@@ -1,0 +1,3 @@
+defaults:
+  fields:
+    "Environment Marker": "environment-loaded"

--- a/tests/unit/data/issue-config-conditional-erratum.yaml
+++ b/tests/unit/data/issue-config-conditional-erratum.yaml
@@ -1,0 +1,4 @@
+defaults:
+  assignee: erratum_assignee
+  fields:
+    "Erratum Type": "security"

--- a/tests/unit/data/issue-config-conditional-multi.yaml
+++ b/tests/unit/data/issue-config-conditional-multi.yaml
@@ -1,0 +1,34 @@
+include:
+  # Include based on COMPOSE
+  - url: tests/unit/data/issue-config-conditional-compose.yaml
+    when: COMPOSE and COMPOSE.id is match('CentOS-Stream-.*')
+
+  # Include based on ERRATUM
+  - url: tests/unit/data/issue-config-conditional-erratum.yaml
+    when: ERRATUM and ERRATUM.id is match('RHSA-.*')
+
+  # Include based on CONTEXT
+  - url: tests/unit/data/issue-config-conditional-context.yaml
+    when: CONTEXT.test_env is defined and CONTEXT.test_env is match('staging')
+
+  # Include based on ENVIRONMENT
+  - url: tests/unit/data/issue-config-conditional-environment.yaml
+    when: ENVIRONMENT.DEPLOY_MODE is defined and ENVIRONMENT.DEPLOY_MODE is match('production')
+
+project: MULTI_TEST_PROJECT
+
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+
+defaults:
+  fields:
+    "Base Field": "base_value"
+
+issues:
+ - summary: "Test issue"
+   description: "Test"
+   type: task
+   id: test_issue

--- a/tests/unit/data/issue-config-conditional-parent.yaml
+++ b/tests/unit/data/issue-config-conditional-parent.yaml
@@ -1,0 +1,27 @@
+include:
+  # This should be included when ENABLE_FEATURE is true
+  - url: tests/unit/data/issue-config-conditional-child-enabled.yaml
+    when: ENABLE_FEATURE
+  # This should NOT be included when ENABLE_FEATURE is true
+  - url: tests/unit/data/issue-config-conditional-child-disabled.yaml
+    when: not ENABLE_FEATURE
+  # Always include this one (no condition)
+  - tests/unit/data/issue-config-include-child1.yaml
+
+project: PARENT_PROJECT
+
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+
+defaults:
+  fields:
+    "Pool Team": "parent_team"
+
+issues:
+ - summary: "Parent issue"
+   description: "Parent issue"
+   type: epic
+   id: parent_conditional

--- a/tests/unit/data/issue-config-dict-include-child.yaml
+++ b/tests/unit/data/issue-config-dict-include-child.yaml
@@ -1,0 +1,4 @@
+defaults:
+  fields:
+    "Unconditional Field": "always_loaded"
+    "Another Field": "also_loaded"

--- a/tests/unit/data/issue-config-dict-include-no-when.yaml
+++ b/tests/unit/data/issue-config-dict-include-no-when.yaml
@@ -1,0 +1,21 @@
+include:
+  # Dict-style include without 'when' clause - should always be loaded
+  - url: tests/unit/data/issue-config-dict-include-child.yaml
+
+project: DICT_NO_WHEN_PROJECT
+
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+
+defaults:
+  fields:
+    "Base Field": "from_parent"
+
+issues:
+  - summary: "Test issue"
+    description: "Test"
+    type: task
+    id: test_issue

--- a/tests/unit/test_include.py
+++ b/tests/unit/test_include.py
@@ -1,3 +1,5 @@
+import pytest
+
 from newa import IssueConfig, IssueType, RecipeConfig
 
 c = IssueConfig.read_file('tests/unit/data/issue-config-include-parent.yaml')
@@ -49,3 +51,356 @@ def test_recipe_include():
     assert r.fixtures["context"]["trigger"] == "nightly"
     # verbosity comes from child3
     assert r.fixtures["context"]["verbosity"] == 99
+
+
+def test_issue_config_conditional_include_enabled():
+    # Load config with ENABLE_FEATURE set to True
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-parent.yaml',
+        variables={'ENABLE_FEATURE': True})
+
+    # Should have 2 issues: 1 from parent + 1 from child1 (always included)
+    assert len(config.issues) == 2
+
+    # Project comes from parent
+    assert config.project == 'PARENT_PROJECT'
+
+    # Assignee should come from child1 (it overrides the enabled child
+    # which has no assignee in defaults). Actually, looking at the order:
+    # enabled child is processed first, then child1. Since child1 defines
+    # assignee as 'child1', that wins
+    assert config.defaults.assignee == 'child1'
+
+    # Environment field should come from enabled child
+    assert config.defaults.fields['Environment'] == 'production'
+
+    # Pool Team should come from parent (defined in parent, wins over child1's value)
+    assert config.defaults.fields['Pool Team'] == 'parent_team'
+
+    # Story Points should come from child1 (always included)
+    assert config.defaults.fields['Story Points'] == 1
+
+
+def test_issue_config_conditional_include_disabled():
+    # Load config with ENABLE_FEATURE set to False
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-parent.yaml',
+        variables={'ENABLE_FEATURE': False})
+
+    # Should have 2 issues: 1 from parent + 1 from child1
+    assert len(config.issues) == 2
+
+    # Project comes from parent
+    assert config.project == 'PARENT_PROJECT'
+
+    # Assignee should come from child1 (overrides disabled child)
+    assert config.defaults.assignee == 'child1'
+
+    # Environment field should come from disabled child
+    assert config.defaults.fields['Environment'] == 'development'
+
+    # Pool Team should come from parent
+    assert config.defaults.fields['Pool Team'] == 'parent_team'
+
+    # Story Points should still come from child1 (always included)
+    assert config.defaults.fields['Story Points'] == 1
+
+
+def test_issue_config_conditional_include_with_compose():
+    from newa.models.artifacts import Compose
+    from newa.models.events import Event
+
+    # Create test data with COMPOSE matching the condition
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': Compose(id='CentOS-Stream-9'),
+            'EVENT': Event(type_='compose', id='CentOS-Stream-9'),
+            'ERRATUM': None,
+            'ROG': None,
+            'CONTEXT': {},
+            'ENVIRONMENT': {},
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # Compose-specific defaults should be loaded
+    assert config.defaults.assignee == 'compose_assignee'
+    assert config.defaults.fields['Compose Type'] == 'compose-based'
+
+    # Base field should still be present
+    assert config.defaults.fields['Base Field'] == 'base_value'
+
+    # Other conditional includes should NOT be loaded
+    assert 'Erratum Type' not in config.defaults.fields
+    assert 'Context Marker' not in config.defaults.fields
+    assert 'Environment Marker' not in config.defaults.fields
+
+
+def test_issue_config_conditional_include_with_erratum():
+    from newa.models.artifacts import Erratum, ErratumContentType
+    from newa.models.base import Arch
+    from newa.models.events import Event
+
+    # Create test data with ERRATUM matching the condition
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': None,
+            'EVENT': Event(type_='erratum', id='RHSA-2024:12345'),
+            'ERRATUM': Erratum(
+                id='RHSA-2024:12345',
+                content_type=ErratumContentType.RPM,
+                respin_count=1,
+                summary='Test security advisory',
+                release='RHEL-9.4.0',
+                url='https://errata.example.com/advisory/12345',
+                archs=[Arch.X86_64],
+                builds=[],
+                components=[],
+                jira_issues=[],
+                people_assigned_to=''),
+            'ROG': None,
+            'CONTEXT': {},
+            'ENVIRONMENT': {},
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # Erratum-specific defaults should be loaded
+    assert config.defaults.assignee == 'erratum_assignee'
+    assert config.defaults.fields['Erratum Type'] == 'security'
+
+    # Base field should still be present
+    assert config.defaults.fields['Base Field'] == 'base_value'
+
+    # Other conditional includes should NOT be loaded
+    assert 'Compose Type' not in config.defaults.fields
+    assert 'Context Marker' not in config.defaults.fields
+    assert 'Environment Marker' not in config.defaults.fields
+
+
+def test_issue_config_conditional_include_with_context():
+    from newa.models.events import Event
+
+    # Create test data with CONTEXT matching the condition
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': None,
+            'EVENT': Event(type_='compose', id='test'),
+            'ERRATUM': None,
+            'ROG': None,
+            'CONTEXT': {'test_env': 'staging'},
+            'ENVIRONMENT': {},
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # Context-specific defaults should be loaded
+    assert config.defaults.fields['Context Marker'] == 'context-loaded'
+
+    # Base field should still be present
+    assert config.defaults.fields['Base Field'] == 'base_value'
+
+    # Other conditional includes should NOT be loaded
+    assert 'Compose Type' not in config.defaults.fields
+    assert 'Erratum Type' not in config.defaults.fields
+    assert 'Environment Marker' not in config.defaults.fields
+
+
+def test_issue_config_conditional_include_with_environment():
+    from newa.models.events import Event
+
+    # Create test data with ENVIRONMENT matching the condition
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': None,
+            'EVENT': Event(type_='compose', id='test'),
+            'ERRATUM': None,
+            'ROG': None,
+            'CONTEXT': {},
+            'ENVIRONMENT': {'DEPLOY_MODE': 'production'},
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # Environment-specific defaults should be loaded
+    assert config.defaults.fields['Environment Marker'] == 'environment-loaded'
+
+    # Base field should still be present
+    assert config.defaults.fields['Base Field'] == 'base_value'
+
+    # Other conditional includes should NOT be loaded
+    assert 'Compose Type' not in config.defaults.fields
+    assert 'Erratum Type' not in config.defaults.fields
+    assert 'Context Marker' not in config.defaults.fields
+
+
+def test_issue_config_conditional_include_multiple_matches():
+    from newa.models.artifacts import Compose, Erratum, ErratumContentType
+    from newa.models.base import Arch
+    from newa.models.events import Event
+
+    # Create test data where multiple conditions match
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': Compose(id='CentOS-Stream-9'),
+            'EVENT': Event(type_='erratum', id='RHSA-2024:12345'),
+            'ERRATUM': Erratum(
+                id='RHSA-2024:12345',
+                content_type=ErratumContentType.RPM,
+                respin_count=1,
+                summary='Test security advisory',
+                release='RHEL-9.4.0',
+                url='https://errata.example.com/advisory/12345',
+                archs=[Arch.X86_64],
+                builds=[],
+                components=[],
+                jira_issues=[],
+                people_assigned_to=''),
+            'ROG': None,
+            'CONTEXT': {'test_env': 'staging'},
+            'ENVIRONMENT': {'DEPLOY_MODE': 'production'},
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # All matching conditionals should be loaded
+    assert config.defaults.fields['Compose Type'] == 'compose-based'
+    assert config.defaults.fields['Erratum Type'] == 'security'
+    assert config.defaults.fields['Context Marker'] == 'context-loaded'
+    assert config.defaults.fields['Environment Marker'] == 'environment-loaded'
+
+    # Base field should still be present
+    assert config.defaults.fields['Base Field'] == 'base_value'
+
+    # Assignee should come from the last matching include (erratum)
+    # because includes are processed in order
+    assert config.defaults.assignee == 'erratum_assignee'
+
+
+def test_issue_config_conditional_include_no_matches():
+    from newa.models.events import Event
+
+    # Create test data where no conditions match
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-conditional-multi.yaml',
+        variables={
+            'COMPOSE': None,
+            'EVENT': Event(type_='compose', id='test'),
+            'ERRATUM': None,
+            'ROG': None,
+            'CONTEXT': {'test_env': 'development'},  # Doesn't match 'staging'
+            'ENVIRONMENT': {'DEPLOY_MODE': 'test'},  # Doesn't match 'production'
+            })
+
+    # Should have 1 issue from parent
+    assert len(config.issues) == 1
+    assert config.project == 'MULTI_TEST_PROJECT'
+
+    # Only base field should be present (no conditional includes loaded)
+    assert config.defaults.fields['Base Field'] == 'base_value'
+    assert 'Compose Type' not in config.defaults.fields
+    assert 'Erratum Type' not in config.defaults.fields
+    assert 'Context Marker' not in config.defaults.fields
+    assert 'Environment Marker' not in config.defaults.fields
+
+    # No assignee should be set
+    assert config.defaults.assignee is None
+
+
+def test_issue_config_include_dict_missing_url_raises(tmp_path):
+    """Test that include entry dict without 'url' key raises an exception."""
+    config_path = tmp_path / "issue-config-missing-url.yaml"
+    config_path.write_text(
+        """
+project: TEST_PROJECT
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+include:
+  - foo: "bar"
+issues:
+  - summary: "Test issue"
+    description: "Test"
+    type: task
+    id: test_issue
+""",
+        encoding="utf-8",
+        )
+
+    with pytest.raises(Exception, match=r"Include entry must have 'url' key"):
+        IssueConfig.read_file(str(config_path))
+
+
+def test_issue_config_include_invalid_type_raises(tmp_path):
+    """Test that include entry of unsupported type raises an exception."""
+    config_path = tmp_path / "issue-config-invalid-type.yaml"
+    config_path.write_text(
+        """
+project: TEST_PROJECT
+transitions:
+  closed:
+    - Closed
+  dropped:
+    - Dropped
+include:
+  - 123
+issues:
+  - summary: "Test issue"
+    description: "Test"
+    type: task
+    id: test_issue
+""",
+        encoding="utf-8",
+        )
+
+    with pytest.raises(Exception, match=r"Include entry must be a string or dict, got"):
+        IssueConfig.read_file(str(config_path))
+
+
+def test_issue_config_dict_style_include_without_when():
+    """Test that dict-style include with only 'url' (no 'when') is always loaded."""
+    from newa.models.events import Event
+
+    # Dict-style include with only "url" must always be loaded, regardless of
+    # variables that would otherwise affect "when" conditions for other includes.
+    config = IssueConfig.read_file(
+        'tests/unit/data/issue-config-dict-include-no-when.yaml',
+        variables={
+            # Use a mix of values to simulate a real evaluation context; these
+            # should not affect the unconditional dict-style include.
+            'COMPOSE': None,
+            'EVENT': Event(type_='compose', id='test'),
+            'ERRATUM': None,
+            'ROG': None,
+            'CONTEXT': {},
+            'ENVIRONMENT': {},
+            },
+        )
+
+    # Verify the config loaded correctly
+    assert config.project == 'DICT_NO_WHEN_PROJECT'
+    assert len(config.issues) == 1
+
+    # Fields from the unconditional dict-style include must always be present
+    assert config.defaults.fields['Unconditional Field'] == 'always_loaded'
+    assert config.defaults.fields['Another Field'] == 'also_loaded'
+
+    # Base field from parent should also be present
+    assert config.defaults.fields['Base Field'] == 'from_parent'


### PR DESCRIPTION
Extends the issue-config include mechanism to support conditional includes with a 'when' clause that evaluates conditions before loading resources. This enables dynamic configuration based on event type, artifact properties, and CLI parameters.

Changes:
- Support both simple string format and dict format with optional 'when' condition in include directives
- Pass event-specific variables (EVENT, ERRATUM, COMPOSE, ROG) and CLI variables (CONTEXT, ENVIRONMENT) to conditional evaluations
- Maintain backward compatibility with existing string-only includes
- Add comprehensive tests for all variable types and edge cases
- Update documentation with examples and available variables

Available variables in conditions:
- EVENT: The event object
- ERRATUM: Erratum artifact (when applicable)
- COMPOSE: Compose artifact (when applicable)
- ROG: RoG artifact (when applicable)
- CONTEXT: CLI context parameters
- ENVIRONMENT: CLI environment variables

Example usage:
  include:
    - url: path/to/config.yaml when: COMPOSE and COMPOSE.id is match('CentOS-Stream-.*')

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for conditional includes in issue-config files, allowing included configurations to be loaded based on evaluated conditions and CLI/runtime context.

Enhancements:
- Extend issue-config include handling to accept either simple string entries or dicts with url and optional when condition, evaluating conditions with supplied variables before loading child configs.
- Wire Jira CLI command to pass event, artifact, context, and environment variables into issue-config loading so conditional includes can react to runtime data.

Documentation:
- Document simple and conditional include formats for issue-config files, including available condition variables and example configurations.

Tests:
- Add unit tests and fixture configs covering conditional include behavior, including enabled/disabled flags, artifact-based conditions, CLI context/environment conditions, multiple matching includes, and no-match scenarios.