### PR TITLE
Sanitize rendered issue descriptions to prevent Jira Cloud auto-linking

### DIFF
--- a/newa/services/jira_service.py
+++ b/newa/services/jira_service.py
@@ -447,8 +447,12 @@ class IssueHandler:  # type: ignore[no-untyped-def]
                      fields: Optional[dict[str, Union[str, float, list[str]]]] = None,
                      links: Optional[dict[str, list[str]]] = None) -> Issue:
         """Create issue"""
+        # Build complete description first, then sanitize once
         if use_newa_id:
-            description = f"{self._format_for_jira(self.newa_id(action))}\n\n{description}"
+            description = f"{self.newa_id(action)}\n\n{description}"
+
+        # Sanitize the complete description for Jira Cloud to prevent auto-linking
+        description = self._format_for_jira(description)
         data = {
             "project": {"key": self.project},
             "summary": summary,
@@ -659,8 +663,9 @@ class IssueHandler:  # type: ignore[no-untyped-def]
             if self.logger:
                 self.logger.debug(f"Updating summary for issue {issue.id}")
 
-        # Update description with NEWA ID
-        new_description = f"{self._format_for_jira(self.newa_id(action))}\n\n{description}"
+        # Build complete description first, then sanitize once
+        new_description = f"{self.newa_id(action)}\n\n{description}"
+        new_description = self._format_for_jira(new_description)
         if current_description != new_description:
             update_fields["description"] = new_description
             if self.logger:


### PR DESCRIPTION
When rendering Jira issue descriptions from templates, the rendered text (containing strings like RHEL-9.8.0) was not being sanitized for Jira Cloud. This caused Jira to incorrectly auto-link these strings as issue references.

This fix applies the sanitize_comment() method to the rendered description, which replaces regular hyphens with non-breaking hyphens (U+2011) for Jira Cloud instances. This preserves the visual appearance while preventing unwanted auto-linking behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent Jira Cloud from auto-linking version-like strings in issue descriptions by sanitizing rendered text prior to API calls.