### PR TITLE
Add OAuth2 authentication support for AI service (Google Gemini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,13 +1595,20 @@ The summarize command supports both OpenAI-compatible APIs and Google Gemini API
 
 **Configuration parameters:**
 - `api_url`: API endpoint URL
-- `api_token`: API authentication token or key
+- `api_token`: API authentication token or key (for API key authentication)
 - `api_model`: Model name to use (default: `gemini-2.0-flash-exp`)
 - `system_prompt`: Custom system prompt for AI model (optional, uses default prompt if not specified)
+- `oauth2_client_secret_file`: Path to OAuth2 client secret JSON file (for OAuth2 authentication)
+- `oauth2_scopes`: Comma-separated OAuth2 scopes (optional, defaults to `https://www.googleapis.com/auth/generative-language.retriever`)
+- `oauth2_token_file`: Path to cached OAuth2 token file (optional, defaults to `~/.newa_oauth2_token.json`)
 
 **Note:** The `system_prompt` parameter allows you to customize how the AI analyzes and summarizes test results. When not specified, NEWA uses a built-in prompt optimized for ReportPortal launch summaries in Jira format. You might want to customize this if you need different formatting, additional analysis criteria, or organization-specific requirements.
 
 **Google Gemini API Configuration:**
+
+For Gemini, you can use either **API key authentication** (simpler) or **OAuth2 authentication** (more secure).
+
+**Option 1: API Key Authentication**
 
 For Gemini, you can configure the URL in two ways:
 
@@ -1619,6 +1626,42 @@ api_model = gemini-2.0-flash-exp
 api_url = https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
 api_token = YOUR_GEMINI_API_KEY
 ```
+
+**Option 2: OAuth2 Authentication (Google Gemini)**
+
+For enhanced security, you can use OAuth2 authentication instead of API keys with Google Gemini:
+
+1. **Install OAuth2 dependencies**:
+   ```bash
+   pip install newa[oauth2]
+   ```
+
+2. **Create OAuth2 credentials**:
+   - Go to [Google Cloud Console](https://console.cloud.google.com/)
+   - Create or select a project
+   - Enable the Generative Language API
+   - Go to "Credentials" → "Create Credentials" → "OAuth client ID"
+   - Select "Desktop app" as application type
+   - Download the JSON file and save it as `~/.newa_client_secret.json`
+
+3. **Configure NEWA**:
+   ```
+   [ai]
+   api_url = https://generativelanguage.googleapis.com/v1beta
+   api_model = gemini-2.0-flash-exp
+   oauth2_client_secret_file = ~/.newa_client_secret.json
+   # Optional: customize scopes (default: https://www.googleapis.com/auth/generative-language.retriever)
+   # oauth2_scopes = https://www.googleapis.com/auth/generative-language.retriever
+   # Optional: customize token cache location (default: ~/.newa_oauth2_token.json)
+   # oauth2_token_file = ~/.newa_oauth2_token.json
+   ```
+
+4. **First run authentication**:
+   On the first run of `newa summarize`, a browser window will open for authentication.
+   After authorization, credentials are cached in `~/.newa_oauth2_token.json` (or your custom location).
+   Subsequent runs will use the cached credentials and automatically refresh them when needed.
+
+**Note**: If both `api_token` and `oauth2_client_secret_file` are configured, OAuth2 takes precedence for Gemini APIs.
 
 **OpenAI-compatible API Configuration:**
 
@@ -1646,6 +1689,10 @@ export NEWA_AI_API_URL="https://generativelanguage.googleapis.com/v1beta"
 export NEWA_AI_API_TOKEN="YOUR_API_KEY"
 export NEWA_AI_API_MODEL="gemini-2.0-flash-exp"
 export NEWA_AI_SYSTEM_PROMPT="Your custom system prompt here..."
+# OAuth2 specific environment variables
+export NEWA_AI_OAUTH2_CLIENT_SECRET_FILE="~/.newa_client_secret.json"
+export NEWA_AI_OAUTH2_SCOPES="https://www.googleapis.com/auth/generative-language.retriever"
+export NEWA_AI_OAUTH2_TOKEN_FILE="~/.newa_oauth2_token.json"
 ```
 
 #### Usage Examples

--- a/README.md
+++ b/README.md
@@ -1657,9 +1657,19 @@ For enhanced security, you can use OAuth2 authentication instead of API keys wit
    ```
 
 4. **First run authentication**:
-   On the first run of `newa summarize`, a browser window will open for authentication.
+   On the first run of `newa summarize`, NEWA will automatically attempt to authenticate using the most appropriate method for your environment:
+   - **Interactive environments** (desktop/laptop): A browser window will open for authentication
+   - **Containerized/headless environments**: A local server flow will be used on port 6392 (6392 spells 'NEWA' on keypad). You'll be given a URL to open in a browser on your host machine to complete authentication.
+
    After authorization, credentials are cached in `~/.newa_oauth2_token.json` (or your custom location).
    Subsequent runs will use the cached credentials and automatically refresh them when needed.
+
+   The authentication method is automatically detected - no configuration needed. If browser-based authentication fails (e.g., in a container), NEWA will automatically fall back to the local server flow.
+
+   **For containerized environments**: Ensure port 6392 is exposed when running NEWA in a container. For example with Podman:
+   ```bash
+   podman run -p 6392:6392 ... your-newa-container
+   ```
 
 **Note**: If both `api_token` and `oauth2_client_secret_file` are configured, OAuth2 takes precedence for Gemini APIs.
 

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -230,10 +230,22 @@ def cmd_summarize(ctx: CLIContext, preview: bool) -> None:
         return
 
     # Check AI configuration
-    if not ctx.settings.ai_api_url or not ctx.settings.ai_api_token:
+    # Require either API token OR OAuth2 client secret file
+    has_api_token = bool(ctx.settings.ai_api_token)
+    has_oauth2 = bool(ctx.settings.ai_oauth2_client_secret_file)
+
+    if not ctx.settings.ai_api_url:
         ctx.logger.error(
-            'AI API URL and token must be configured in newa.conf [ai] section or '
-            'via NEWA_AI_API_URL and NEWA_AI_API_TOKEN environment variables')
+            'AI API URL must be configured in newa.conf [ai] section or '
+            'via NEWA_AI_API_URL environment variable')
+        return
+
+    if not has_api_token and not has_oauth2:
+        ctx.logger.error(
+            'AI authentication must be configured with either:\n'
+            '  - API token (api_token in [ai] section or NEWA_AI_API_TOKEN env var), or\n'
+            '  - OAuth2 (oauth2_client_secret_file in [ai] section or '
+            'NEWA_AI_OAUTH2_CLIENT_SECRET_FILE env var)')
         return
 
     # Initialize services
@@ -247,7 +259,10 @@ def cmd_summarize(ctx: CLIContext, preview: bool) -> None:
     ai_service = AIService(
         api_url=ctx.settings.ai_api_url,
         api_token=ctx.settings.ai_api_token,
-        model=ctx.settings.ai_api_model)
+        model=ctx.settings.ai_api_model,
+        oauth2_client_secret_file=ctx.settings.ai_oauth2_client_secret_file,
+        oauth2_scopes=ctx.settings.ai_oauth2_scopes,
+        oauth2_token_file=ctx.settings.ai_oauth2_token_file)
 
     # Track processed launch UUIDs to avoid duplicate summaries
     processed_launches: set[str] = set()

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -69,6 +69,9 @@ class Settings:  # type: ignore[no-untyped-def]
     ai_api_token: str = ''
     ai_api_model: str = ''
     ai_system_prompt: str = ''
+    ai_oauth2_client_secret_file: str = ''
+    ai_oauth2_scopes: str = ''
+    ai_oauth2_token_file: str = ''
 
     def get(self, key: str, default: str = '') -> str:
         return str(getattr(self, key, default))
@@ -187,6 +190,18 @@ class Settings:  # type: ignore[no-untyped-def]
                 cp,
                 'ai/system_prompt',
                 'NEWA_AI_SYSTEM_PROMPT'),
+            ai_oauth2_client_secret_file=_get(
+                cp,
+                'ai/oauth2_client_secret_file',
+                'NEWA_AI_OAUTH2_CLIENT_SECRET_FILE'),
+            ai_oauth2_scopes=_get(
+                cp,
+                'ai/oauth2_scopes',
+                'NEWA_AI_OAUTH2_SCOPES'),
+            ai_oauth2_token_file=_get(
+                cp,
+                'ai/oauth2_token_file',
+                'NEWA_AI_OAUTH2_TOKEN_FILE'),
             )
 
 

--- a/newa/services/ai_service.py
+++ b/newa/services/ai_service.py
@@ -1,14 +1,25 @@
 """AI service for generating ReportPortal launch summaries."""
 
 import json
+import os
+from pathlib import Path
 from typing import Any, Optional
 
 import requests
 
 try:
-    from attrs import define
+    from attrs import define, field
 except ModuleNotFoundError:
-    from attr import define
+    from attr import define, field
+
+# Optional OAuth2 dependencies
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    HAS_GOOGLE_AUTH = True
+except ImportError:
+    HAS_GOOGLE_AUTH = False
 
 
 # System prompt for AI model
@@ -115,9 +126,99 @@ class AIService:
     api_url: str
     api_token: str
     model: str
+    oauth2_client_secret_file: str = ''
+    oauth2_scopes: str = ''
+    oauth2_token_file: str = ''
+
+    # Cached OAuth2 credentials
+    _credentials: Optional[Any] = field(default=None, init=False, repr=False)
+
+    def _get_oauth2_credentials(self) -> Any:
+        """Get or refresh OAuth2 credentials for Google APIs.
+
+        Returns:
+            Google OAuth2 Credentials object
+
+        Raises:
+            Exception: If OAuth2 libraries are not available or authentication fails
+        """
+        if not HAS_GOOGLE_AUTH:
+            raise Exception(
+                "OAuth2 authentication requires google-auth-oauthlib and google-auth packages. "
+                "Install them with: pip install newa[oauth2]")
+
+        if self._credentials and self._credentials.valid:
+            return self._credentials
+
+        creds = None
+        # Expand ~ and environment variables in paths
+        if self.oauth2_token_file:
+            token_file = Path(os.path.expandvars(self.oauth2_token_file)).expanduser()
+        else:
+            token_file = Path.home() / '.newa_oauth2_token.json'
+        client_secret_file = Path(os.path.expandvars(
+            self.oauth2_client_secret_file)).expanduser()
+
+        # Load cached token if it exists
+        if token_file.exists():
+            try:
+                # Determine scopes for credentials validation
+                scopes = None
+                if self.oauth2_scopes:
+                    scopes = [s.strip() for s in self.oauth2_scopes.split(',') if s.strip()]
+                creds = Credentials.from_authorized_user_file(str(token_file), scopes)
+            except Exception:
+                # Token file is corrupted or invalid, will re-authenticate
+                pass
+
+        # Refresh or get new credentials
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                # Refresh expired token
+                try:
+                    creds.refresh(Request())
+                except Exception:
+                    # Refresh failed, need to re-authenticate
+                    creds = None
+
+            if not creds:
+                # Perform OAuth2 flow
+                if not client_secret_file.exists():
+                    raise Exception(
+                        f"OAuth2 client secret file not found: {client_secret_file}. "
+                        "Please download it from Google Cloud Console and save it to this path.")
+
+                # Default scopes for Gemini API
+                if self.oauth2_scopes:
+                    scopes = [s.strip() for s in self.oauth2_scopes.split(',') if s.strip()]
+                else:
+                    scopes = ['https://www.googleapis.com/auth/generative-language.retriever']
+
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    str(client_secret_file), scopes)
+                creds = flow.run_local_server(port=0)
+
+            # Save credentials for next run
+            token_file.parent.mkdir(parents=True, exist_ok=True)
+            token_file.write_text(creds.to_json())
+
+        self._credentials = creds
+        return creds
+
+    def _is_oauth2_configured(self) -> bool:
+        """Check if OAuth2 is configured (client secret file is specified)."""
+        if not self.oauth2_client_secret_file:
+            return False
+        # Expand ~ and environment variables in the path
+        expanded_path = Path(os.path.expandvars(
+            self.oauth2_client_secret_file)).expanduser()
+        return expanded_path.exists()
 
     def query_ai_model(self, user_message: str, system_prompt: Optional[str] = None) -> str:
         """Query the AI model with the given prompts.
+
+        Supports both API key and OAuth2 authentication.
+        OAuth2 is used if oauth2_client_secret_file is configured.
 
         Args:
             user_message: The user message/input data
@@ -132,14 +233,46 @@ class AIService:
         if not self.api_url:
             raise Exception("AI API URL is not configured")
 
-        if not self.api_token:
-            raise Exception("AI API token is not configured")
-
         # Detect API type based on URL
         is_gemini = 'generativelanguage.googleapis.com' in self.api_url
 
+        # Determine authentication method
+        use_oauth2 = is_gemini and self._is_oauth2_configured()
+
         payload: dict[str, Any]
-        if is_gemini:
+        if use_oauth2:
+            # OAuth2 authentication for Gemini
+            creds = self._get_oauth2_credentials()
+            access_token = creds.token
+
+            # Construct URL
+            if '/models/' in self.api_url and ':generateContent' in self.api_url:
+                url_with_key = self.api_url
+            else:
+                base_url = self.api_url.rstrip('/')
+                url_with_key = f"{base_url}/models/{self.model}:generateContent"
+
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {access_token}",
+                }
+
+            # Combine system prompt and user message for Gemini
+            combined_message = f"{system_prompt}\n\nThe report is below.\n\n{user_message}"
+
+            payload = {
+                "contents": [{
+                    "parts": [{
+                        "text": combined_message,
+                        }],
+                    }],
+                }
+
+        elif is_gemini:
+            # API key authentication for Gemini (existing code)
+            if not self.api_token:
+                raise Exception("AI API token is not configured")
+
             # Google Gemini API format
             # API key is passed as URL parameter
             # Support both full URL (with model embedded) and base URL + model
@@ -166,6 +299,9 @@ class AIService:
                 }
         else:
             # OpenAI-compatible API format
+            if not self.api_token:
+                raise Exception("AI API token is not configured")
+
             url_with_key = self.api_url
             headers = {
                 "Content-Type": "application/json",

--- a/newa/services/ai_service.py
+++ b/newa/services/ai_service.py
@@ -196,7 +196,21 @@ class AIService:
 
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(client_secret_file), scopes)
-                creds = flow.run_local_server(port=0)
+
+                # Try local server flow first (for desktop/interactive environments)
+                # Fall back to containerized flow if it fails (for containers/headless
+                # environments)
+                try:
+                    creds = flow.run_local_server(port=0)
+                except Exception:
+                    # Local server failed (likely in container or headless environment)
+                    # Use local server without opening browser instead
+                    # Note: For containerized environments, port 6392 must be exposed
+                    # (6392 is 'NEWA' on keypad)
+                    print("\nBrowser-based authentication not available (container/headless environment).")
+                    print("Using local server flow with manual URL on port 6392...\n")
+                    print("NOTE: For containerized environments, ensure port 6392 is exposed.\n")
+                    creds = flow.run_local_server(port=6392, open_browser=False)
 
             # Save credentials for next run
             token_file.parent.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+oauth2 = [
+    "google-auth>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+]
 
 [project.scripts]
 newa = "newa.cli.main:main"
@@ -137,6 +141,9 @@ module = [
     "jira.*",
     "gitlab",
     "ruamel.*",
+    "google.auth.*",
+    "google.oauth2.*",
+    "google_auth_oauthlib.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
This change introduces optional OAuth2 authentication for Google Gemini API as an alternative to API key authentication, providing enhanced security.

Changes:
- Add optional 'oauth2' dependency group with google-auth packages
- Extend Settings model with OAuth2 configuration fields
- Enhance AIService to support both API key and OAuth2 authentication
- Update validation to accept either authentication method
- Add comprehensive OAuth2 setup documentation to README

OAuth2 is automatically used when oauth2_client_secret_file is configured. API key authentication continues to work for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional OAuth2-based authentication for Google Gemini in the AI summarization flow while preserving existing API key support.

New Features:
- Support OAuth2 authentication for Google Gemini in AIService, including local OAuth2 flow, token caching, and automatic refresh.
- Allow configuring AI OAuth2 parameters (client secret file, scopes, token file) via settings, config file, and environment variables.

Enhancements:
- Relax AI configuration requirements so that either an API token or OAuth2 credentials can be used for authentication.
- Extend mypy configuration and optional dependencies to include Google OAuth libraries needed for OAuth2 support.

Documentation:
- Document Gemini OAuth2 configuration, setup steps, and environment variables in the README, alongside existing API key configuration.