### PR TITLE
Add --rp-launch-uuid option to reuse existing ReportPortal launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,6 +1431,28 @@ Example:
 $ newa event --compose CentOS-Stream-9 job-recipe path/to/recipe.yaml schedule --no-reportportal execute
 ```
 
+#### Option `--rp-launch-uuid`
+
+Allows you to reuse an existing ReportPortal launch instead of creating a new one during test execution. When this option is provided, NEWA fetches the launch metadata (name, description, URL) from ReportPortal and configures all scheduled jobs to use this existing launch.
+
+This option is mutually exclusive with `--no-reportportal`.
+
+The typical use case is when you want to add test results to an existing ReportPortal launch, for example:
+- Running additional tests for the same erratum or compose
+- Re-running tests with different configurations but keeping results in the same launch
+- Consolidating results from multiple NEWA runs into a single launch
+
+**Important notes:**
+- The launch UUID must exist in the configured ReportPortal project
+- NEWA will validate the launch exists before scheduling
+- All generated schedule jobs will use this launch UUID
+- The `execute` command will skip creating a new launch and use the provided one
+
+Example:
+```
+$ newa event --compose CentOS-Stream-9 jira --job-recipe path/to/recipe.yaml schedule --rp-launch-uuid 12345678-1234-1234-1234-123456789abc execute report
+```
+
 
 ### Subcommand `cancel`
 

--- a/newa/cli/commands/schedule_cmd.py
+++ b/newa/cli/commands/schedule_cmd.py
@@ -1,6 +1,7 @@
 """Schedule command for NEWA CLI."""
 
 import sys
+from typing import Optional
 
 import click
 
@@ -31,12 +32,17 @@ from newa.cli.utils import initialize_state_dir, test_file_presence
     default=False,
     help='Do not report test results to ReportPortal.',
     )
+@click.option(
+    '--rp-launch-uuid',
+    help='Reuse an existing ReportPortal launch UUID instead of creating a new one.',
+    )
 @click.pass_obj
 def cmd_schedule(
         ctx: CLIContext,
         arch: list[str],
         fixtures: list[str],
-        no_reportportal: bool) -> None:
+        no_reportportal: bool,
+        rp_launch_uuid: Optional[str] = None) -> None:
     """
     Schedule subcommand - creates schedule jobs from jira jobs.
 
@@ -47,6 +53,12 @@ def cmd_schedule(
     4. Creating and saving schedule job YAML files
     """
     ctx.enter_command('schedule')
+
+    # Validate mutually exclusive options
+    if no_reportportal and rp_launch_uuid:
+        ctx.logger.error(
+            'ERROR: --no-reportportal and --rp-launch-uuid are mutually exclusive options')
+        sys.exit(1)
 
     # Ensure state dir is present and initialized
     initialize_state_dir(ctx)
@@ -68,4 +80,4 @@ def cmd_schedule(
 
     # Process each jira job
     for jira_job in jira_jobs:
-        _process_jira_job(ctx, jira_job, arch, fixtures, no_reportportal)
+        _process_jira_job(ctx, jira_job, arch, fixtures, no_reportportal, rp_launch_uuid)

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 from typing import Any, Optional
 
 from newa import (
@@ -170,7 +171,8 @@ def _process_jira_job(
         jira_job: JiraJob,
         arch_options: list[str],
         fixtures: list[str],
-        no_reportportal: bool) -> None:
+        no_reportportal: bool,
+        rp_launch_uuid: Optional[str] = None) -> None:
     """Process a single jira_job and create schedule jobs."""
     from newa import ScheduleJob
 
@@ -178,6 +180,35 @@ def _process_jira_job(
     if not jira_job.recipe:
         ctx.logger.info(f'Skipping jira job {jira_job.jira.id} - no recipe specified')
         return
+
+    # Initialize ReportPortal connection if --rp-launch-uuid is provided
+    rp = None
+    launch_metadata: Optional[RawRecipeReportPortalConfigDimension] = None
+    if rp_launch_uuid:
+        from newa.cli.initialization import initialize_rp_connection
+        rp = initialize_rp_connection(ctx)
+
+        # Fetch launch metadata once (outside the request loop)
+        ctx.logger.info(f'Fetching ReportPortal launch {rp_launch_uuid}')
+        launch_info = rp.get_launch_info(rp_launch_uuid)
+
+        if not launch_info:
+            ctx.logger.error(
+                f'ERROR: Could not find ReportPortal launch {rp_launch_uuid} '
+                f'in project {rp.project}')
+            sys.exit(1)
+
+        # Store metadata to apply to all requests
+        launch_metadata = RawRecipeReportPortalConfigDimension(
+            launch_uuid=rp_launch_uuid,
+            launch_url=rp.get_launch_url(rp_launch_uuid),
+            launch_name=launch_info['name'],
+            launch_description=launch_info.get('description', ''),
+            )
+
+        ctx.logger.info(
+            f'Configured to reuse existing ReportPortal launch: '
+            f'{launch_info["name"]} ({rp_launch_uuid})')
 
     # Determine compose and architectures
     compose = jira_job.compose.id if jira_job.compose else None
@@ -217,6 +248,20 @@ def _process_jira_job(
         # Prepare Jinja variables and render request attributes
         jinja_vars = _prepare_jinja_vars_for_request(jira_job, request, issue_fields)
         _render_request_attributes(request, jinja_vars)
+
+        # Apply cached launch metadata if --rp-launch-uuid was provided
+        if launch_metadata:
+            if not request.reportportal:
+                request.reportportal = RawRecipeReportPortalConfigDimension()
+            # Update individual fields to satisfy mypy TypedDict requirements
+            if 'launch_uuid' in launch_metadata:
+                request.reportportal['launch_uuid'] = launch_metadata['launch_uuid']
+            if 'launch_url' in launch_metadata:
+                request.reportportal['launch_url'] = launch_metadata['launch_url']
+            if 'launch_name' in launch_metadata:
+                request.reportportal['launch_name'] = launch_metadata['launch_name']
+            if 'launch_description' in launch_metadata:
+                request.reportportal['launch_description'] = launch_metadata['launch_description']
 
         # Create and save schedule job
         schedule_job = ScheduleJob(

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -66,7 +66,7 @@ def _process_fixtures(
         return
 
     for fixture in fixtures:
-        r = re.fullmatch(r'([^\s=]+)=([^=]*)', fixture)
+        r = re.fullmatch(r'([^\s=]+)=(.*)', fixture)
         if not r:
             raise Exception(
                 f"Fixture {fixture} does not having expected format 'name=value'")


### PR DESCRIPTION
Introduces a new --rp-launch-uuid option for the schedule command that allows reusing an existing ReportPortal launch instead of creating a new one. This enables consolidating test results from multiple NEWA runs into a single ReportPortal launch.

Key changes:
- Add --rp-launch-uuid CLI option to schedule command (newa/cli/commands/schedule_cmd.py:34)
- Implement mutual exclusivity validation between --rp-launch-uuid and --no-reportportal
- Fetch and validate launch metadata from ReportPortal before scheduling jobs
- Apply cached launch metadata (UUID, URL, name, description) to all generated schedule jobs
- Update documentation with usage examples and important notes

The launch UUID is validated before scheduling begins, and all generated requests inherit the launch metadata to ensure consistent reporting to the existing launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for reusing an existing ReportPortal launch when scheduling jobs and document the new workflow.

New Features:
- Introduce a --rp-launch-uuid option to the schedule command to allow reusing an existing ReportPortal launch.
- Apply shared ReportPortal launch metadata to all generated schedule jobs when an existing launch UUID is provided.

Enhancements:
- Validate mutual exclusivity between --no-reportportal and --rp-launch-uuid in the schedule command.
- Verify the specified ReportPortal launch exists before scheduling and fail fast if it does not.

Documentation:
- Document the --rp-launch-uuid option, its typical use cases, constraints, and provide an example invocation in the README.