### PR TITLE
Configure shebang to use only -P option instead of -sP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ include = [
 # TODO: man page?
 # artifacts = ["newa.1"]
 
+[tool.hatch.build.targets.wheel.scripts]
+python-tag = "py3"
+shebang = "/usr/bin/python3 -P"
+
 [tool.hatch.envs.default]
 platforms = ["linux"]
 


### PR DESCRIPTION
The -s option (ignore user site-packages directory) is removed from the generated newa script shebang, keeping only -P (don't prepend unsafe paths to sys.path) for better compatibility with user environments.

Added since users were not installing google.oauth2 libraries system-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)