### PR TITLE
Fix RPM shebang configuration to use only -P flag

### DIFF
--- a/newa.spec
+++ b/newa.spec
@@ -1,3 +1,12 @@
+# Configure shebang options based on Python version
+# Python 3.11+: use -P flag only (safe path)
+# Python < 3.11: no flags (plain /usr/bin/python3)
+%if 0%{?python3_version_nodots} >= 311
+%global py3_shbang_opts -P
+%else
+%global py3_shbang_opts %{nil}
+%endif
+
 Name:           newa
 Version:        0.1
 Release:        %autorelease
@@ -43,5 +52,5 @@ install -D -m 0644 newa-completion.bash %{buildroot}%{_datadir}/bash-completion/
 %{_datadir}/bash-completion/completions/newa
 
 %changelog
-* Thu June 06 2024 Miroslav Vadkerti <mvadkert@redhat.com> - 0.1-1
+* Thu Jun 06 2024 Miroslav Vadkerti <mvadkert@redhat.com> - 0.1-1
 - Initial packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,6 @@ include = [
 # TODO: man page?
 # artifacts = ["newa.1"]
 
-[tool.hatch.build.targets.wheel.scripts]
-python-tag = "py3"
-shebang = "/usr/bin/python3 -P"
-
 [tool.hatch.envs.default]
 platforms = ["linux"]
 


### PR DESCRIPTION
The previous commit attempted to configure the shebang in pyproject.toml, but that configuration doesn't affect RPM builds. During RPM build, the %pyproject_install macro automatically rewrites shebangs using %py3_shebang_flags which defaults to -sP.

This commit:
- Adds %global py3_shbang_opts -P to newa.spec to override the default flags
- Removes the incorrect [tool.hatch.build.targets.wheel.scripts] section from pyproject.toml which had no effect on the RPM build process

Now the installed newa script will correctly use #!/usr/bin/python3 -P

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the installed newa script uses the correct Python shebang flags in RPM builds by aligning spec configuration and removing ineffective wheel shebang settings.

Bug Fixes:
- Override the default RPM Python shebang flags to use only -P for the newa script instead of the previous -sP behavior.

Enhancements:
- Remove unused Hatch wheel shebang configuration from pyproject.toml that did not affect RPM builds.