### PR TITLE
Add --rp-purge/-X option to remove previous test results before execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,7 +1541,43 @@ newa --prev-state-dir execute -R REQ-1.2.1 -R REQ-2.2.2 report
 ```
 
 #### Option `--restart-result`, `-r`
-This option can be used to reschedule NEWA request that have ended with a particular result - `passed, failed, error`. For example, `--restart-result error`. Result can be either `passed`, `failed` or `error` where 'error' means that test execution hasn't been finished correctly. This option can be used multiple times. Implies `--continue`.
+This option can be used to reschedule NEWA requests that have ended with a particular result - `passed, failed, error`. For example, `--restart-result error`. Result can be either `passed`, `failed` or `error` where 'error' means that test execution hasn't been finished correctly. This option can be used multiple times. Implies `--continue`.
+
+#### Option `--rp-purge`, `-X`
+
+Removes previous test results from the ReportPortal launch before executing new Testing Farm requests. This option is particularly useful when restarting specific TF requests to avoid duplicate test results in the same ReportPortal launch.
+
+**How it works:**
+- Before initiating each Testing Farm request, NEWA identifies and removes the corresponding previous test results from ReportPortal
+- Test results are identified using the `newa_batch` tag that uniquely identifies each execution run
+- **Only the test results for requests being executed are removed** - other requests in the launch remain untouched
+- If no matching test results are found, execution continues normally without any messages
+- This operation happens per-worker, ensuring that only the requests being re-executed have their old results removed
+
+**Use cases:**
+- Restarting failed or errored test requests without accumulating duplicate results
+- Re-running specific tests with updated configurations while keeping other results intact
+- Maintaining clean ReportPortal launches when using `--restart-request`, `--restart-result`, or `--force`
+
+**Important notes:**
+- Only removes test results from existing ReportPortal launches (requires `launch_uuid` to be set)
+- Works with `--restart-request`, `--restart-result`, and `--force` options
+- If a request is not scheduled for execution, its old test results remain untouched
+
+Example (restart failed tests and remove previous results):
+```
+$ newa --prev-state-dir execute --restart-result error --rp-purge report
+```
+
+Example (restart specific request and remove previous results):
+```
+$ newa --prev-state-dir execute --restart-request REQ-2.2.14 --rp-purge report
+```
+
+Example (force re-execution and remove previous results):
+```
+$ newa --force execute --rp-purge report
+```
 
 
 ### Subcommand `report`

--- a/docs/agents/claude-newa.md
+++ b/docs/agents/claude-newa.md
@@ -103,6 +103,13 @@ You are a NEWA Test Orchestration Specialist, an expert in managing complex asyn
   - For specific request rescheduling: `execute --restart-request <request_id> --no-wait`
 - CRITICAL: Both `--restart-result` and `--restart-request` flags automatically imply `--continue`
 - CRITICAL: Always include `--no-wait` even for rescheduling to maintain asynchronous execution
+- **ReportPortal Result Cleanup:**
+  - When rescheduling tests, ASK the user if they want to remove previous test results from the ReportPortal launch to avoid duplicates
+  - If user confirms, add the `--rp-purge` (or `-X`) flag to the execute command
+  - Example: `execute --restart-result error --rp-purge --no-wait`
+  - The `--rp-purge` flag removes previous test results ONLY for the requests being re-executed, not the entire launch
+  - This is particularly useful when restarting failed/errored tests to maintain clean ReportPortal launches
+  - **IMPORTANT:** Only suggest `--rp-purge` when rescheduling (with `--restart-*` or `--force`), never for initial test runs
 - After rescheduling, inform the user which requests are being rescheduled and provide the new Testing Farm request IDs
 - The user can check status later by requesting an update
 

--- a/newa/cli/commands/execute_cmd.py
+++ b/newa/cli/commands/execute_cmd.py
@@ -61,6 +61,13 @@ from newa.cli.utils import initialize_state_dir
     default=False,
     help='Do not wait for TF requests to finish.',
     )
+@click.option(
+    '--rp-purge',
+    '-X',
+    is_flag=True,
+    default=False,
+    help='Remove previous test result from ReportPortal launch before executing a request.',
+    )
 @click.pass_obj
 def cmd_execute(
         ctx: CLIContext,
@@ -68,7 +75,8 @@ def cmd_execute(
         _continue: bool,
         no_wait: bool,
         restart_request: list[str],
-        restart_result: list[str]) -> None:
+        restart_result: list[str],
+        rp_purge: bool) -> None:
     """
     Execute scheduled test jobs.
 
@@ -82,6 +90,9 @@ def cmd_execute(
 
     # Set no_wait flag
     ctx.no_wait = no_wait
+
+    # Set rp_purge flag
+    ctx.rp_purge = rp_purge
 
     # Validate parameters and configure execution mode
     _validate_execute_parameters(ctx, _continue, restart_request, restart_result)

--- a/newa/cli/workers.py
+++ b/newa/cli/workers.py
@@ -41,8 +41,10 @@ def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -
 
     start_new_request = True
     skip_initial_sleep = False
-    # if --continue, then read ExecuteJob details as well
-    if ctx.continue_execution:
+    execute_job = None
+
+    # Load former execute_job only if --continue or --rp-purge will need it
+    if ctx.continue_execution or ctx.rp_purge:
         parent = schedule_file.parent
         name = schedule_file.name
         from newa import EXECUTE_FILE_PREFIX, SCHEDULE_FILE_PREFIX
@@ -55,19 +57,39 @@ def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -
                     1)))
         if execute_job_file.exists():
             execute_job = ExecuteJob.from_yaml_file(execute_job_file)
-            if execute_job.execution.result in ctx.restart_result:
-                log(f'Restarting request {execute_job.request.id}'
-                    f' with result {execute_job.execution.result.value}')
-            elif ctx.restart_request:
-                (match, pattern) = test_patterns_match(execute_job.request.id, ctx.restart_request)
-                if match:
-                    log(f'Restarting request {execute_job.request.id} with ID matching {pattern}')
+            if ctx.continue_execution:
+                if execute_job.execution.result in ctx.restart_result:
+                    log(f'Restarting request {execute_job.request.id}'
+                        f' with result {execute_job.execution.result.value}')
+                elif ctx.restart_request:
+                    (match, pattern) = test_patterns_match(
+                        execute_job.request.id, ctx.restart_request)
+                    if match:
+                        log(f'Restarting request {execute_job.request.id} '
+                            f'with ID matching {pattern}')
+                    else:
+                        start_new_request = False
                 else:
                     start_new_request = False
-            else:
-                start_new_request = False
 
     if start_new_request:
+        # Remove old test suite from ReportPortal if --rp-purge is set
+        if ctx.rp_purge and schedule_job.request.reportportal:
+            launch_uuid = schedule_job.request.reportportal.get('launch_uuid')
+            if launch_uuid and execute_job:
+                newa_batch_id = execute_job.execution.batch_id
+                newa_req_id = schedule_job.request.id
+                from newa.cli.initialization import initialize_rp_connection
+                rp = initialize_rp_connection(ctx)
+                removed = rp.remove_test_suite_by_tag(
+                    launch_uuid=launch_uuid,
+                    newa_batch_id=newa_batch_id,
+                    logger=ctx.logger)
+                if removed:
+                    ctx.logger.debug(
+                        f'{schedule_file.name}: Removed old test results for request '
+                        f'{newa_req_id} from launch {launch_uuid}')
+
         log('initiating TF request')
         tf_request = schedule_job.request.initiate_tf_request(ctx)
         log(f'TF request filed with uuid {tf_request.uuid}')
@@ -95,6 +117,9 @@ def tf_worker(ctx: CLIContext, schedule_file: Path, schedule_job: ScheduleJob) -
             )
         ctx.save_execute_job(execute_job)
     else:
+        # execute_job must exist here because start_new_request is only False
+        # when we loaded execute_job in the continue_execution block
+        assert execute_job is not None
         log(f'Re-using existing request {execute_job.request.id}')
         tf_request = TFRequest(api=execute_job.execution.request_api,
                                uuid=execute_job.execution.request_uuid)

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -218,6 +218,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
     timestamp: str = ''
     continue_execution: bool = False
     no_wait: bool = False
+    rp_purge: bool = False
     restart_request: list[str] = field(factory=list)
     restart_result: list[RequestResult] = field(factory=list,  # type: ignore[var-annotated]
                                                 converter=lambda results: [

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -169,3 +169,107 @@ class ReportPortal:
         if req.status_code in HTTP_STATUS_CODES_OK:
             return req.json()
         return None
+
+    def delete_request(self,
+                       path: str,
+                       version: int = 1) -> bool:
+        from urllib.parse import quote as Q  # noqa: N812
+        url = urllib.parse.urljoin(
+            self.url,
+            f'/api/v{version}/{Q(self.project)}/{Q(path.lstrip("/"))}')
+        headers = {"Authorization": f"bearer {self.token}", "Content-Type": "application/json"}
+        req = requests.delete(url, headers=headers)
+        return req.status_code in HTTP_STATUS_CODES_OK
+
+    def remove_test_suite_by_tag(self,
+                                 launch_uuid: str,
+                                 newa_batch_id: str,
+                                 logger: Optional['logging.Logger'] = None) -> bool:
+        """
+        Remove a test suite from a ReportPortal launch by newa_batch tag.
+
+        Args:
+            launch_uuid: UUID of the ReportPortal launch
+            newa_batch_id: NEWA batch ID for precise targeting (unique per request execution)
+            logger: Optional logger for debug messages
+
+        Returns:
+            True if suite was found and removed, False otherwise
+        """
+        # First get launch info to retrieve numeric launch ID
+        launch_info = self.get_launch_info(launch_uuid)
+        if not launch_info:
+            if logger:
+                logger.warning(f'Could not find launch {launch_uuid} in ReportPortal')
+            return False
+
+        launch_id = launch_info['id']
+
+        # Search for test items (suites) with the newa_batch tag
+        # Using the search API with filter for attributes
+        # The correct syntax for filtering by attribute key:value is
+        # filter.has.compositeAttribute=key:value
+        params = {
+            'filter.eq.launchId': str(launch_id),
+            'filter.eq.type': 'suite',
+            'filter.has.compositeAttribute': f'newa_batch:{newa_batch_id}',
+            }
+
+        # Get test items matching the criteria (with pagination support)
+        # ReportPortal API returns paginated results, so we need to iterate through all pages
+        page = 1
+        page_size = 50  # ReportPortal default page size
+        deleted_items = []
+        failed_items = []
+
+        while True:
+            # Add pagination parameters
+            paginated_params = params.copy()
+            paginated_params['page.page'] = str(page)
+            paginated_params['page.size'] = str(page_size)
+
+            items = self.get_request('/item', params=paginated_params, version=1)
+
+            if not items or not items.get('content'):
+                # No more items on this page
+                break
+
+            # Delete each matching suite on this page
+            for item in items['content']:
+                item_id = item['id']
+                if logger:
+                    logger.info(
+                        f'Removing test suite {item_id} with tag newa_batch={newa_batch_id} '
+                        f'from launch {launch_uuid}')
+                success = self.delete_request(f'/item/{item_id}', version=1)
+                if success:
+                    deleted_items.append(item_id)
+                else:
+                    failed_items.append(item_id)
+                    if logger:
+                        logger.warning(
+                            f'Failed to remove test suite {item_id} from launch {launch_uuid}')
+
+            # Check if there are more pages
+            page_metadata = items.get('page', {})
+            total_pages = page_metadata.get('totalPages', 1)
+            if page >= total_pages:
+                break
+
+            page += 1
+
+        # Log summary
+        if not deleted_items and not failed_items:
+            if logger:
+                logger.debug(
+                    f'No test suite found with tag newa_batch={newa_batch_id} '
+                    f'in launch {launch_uuid}')
+            return False
+
+        if failed_items and logger:
+            logger.warning(
+                f'Failed to remove {len(failed_items)} test suite(s) from launch {launch_uuid}: '
+                f'{", ".join(str(i) for i in failed_items)}')
+
+        # Return True if at least one item was successfully deleted
+        return len(deleted_items) > 0


### PR DESCRIPTION
This commit introduces a new --rp-purge/-X option for the execute command that removes previous test results from ReportPortal launches before executing new Testing Farm requests. This feature is useful when restarting specific TF requests to avoid duplicate test results in the same launch.

Key changes:
- Add --rp-purge/-X option to execute command with per-request removal
- Implement delete_request() method in ReportPortal service
- Add remove_test_suite_by_tag() to remove test suites by newa_batch ID
- Update workers to load previous execute_job for both --continue and --force
- Support suite removal with --restart-request, --restart-result, and --force
- Fix ReportPortal API filtering using filter.has.compositeAttribute syntax
- Update README with comprehensive documentation and examples

Implementation details:
- Test results are identified using newa_batch tag (unique per execution)
- Only removes results for requests being executed, not entire launch
- Works per-worker to ensure only scheduled requests are cleaned up
- Launch UUID is converted to numeric ID for API compatibility
- Loads previous execute_job regardless of --continue flag for batch_id access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for purging previous ReportPortal test results before executing Testing Farm requests and document the new behavior.

New Features:
- Introduce a --rp-purge/-X option for the execute command to remove previous test results from ReportPortal launches per request.
- Add ReportPortal service capabilities to delete resources and remove test suites based on a newa_batch tag within a launch.

Enhancements:
- Ensure workers always load the previous execute job when available to support restart and ReportPortal purge workflows.
- Improve handling of existing execute jobs by asserting their presence when reusing requests.

Documentation:
- Document the --rp-purge/-X option in the README with usage details, behavior description, and example commands.