### PR TITLE
Add configurable color support to newa list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,103 @@ For Jira Cloud, you need to:
 1. Generate an API token at https://id.atlassian.com/manage-profile/security/api-tokens
 2. Configure both `email` and `token` in the `[jira]` section
 
+### Color configuration
+
+NEWA's `list` command supports colored output with automatic terminal detection and customizable color schemes.
+
+#### Default behavior
+
+Colors are automatically enabled when **any** of the following is true:
+- The `FORCE_COLOR` environment variable is set (forces colors regardless of terminal), OR
+- All of the following conditions are met:
+  - The `NO_COLOR` environment variable is not set
+  - Output is directed to a terminal (TTY)
+  - The `TERM` environment variable is set to a value other than `dumb`
+
+#### Environment variables
+
+- `NO_COLOR` - Disables all colored output (highest priority, overrides everything)
+- `FORCE_COLOR` - Forces colored output even when not in a TTY (overrides auto-detection)
+- `NEWA_COLOR_CONFIG` - Path to a custom color configuration file
+
+#### Customizing colors
+
+To customize the color scheme, create a YAML configuration file and reference it in your NEWA configuration:
+
+```
+[newa]
+color_config = /path/to/colors.yaml
+```
+
+Or use the environment variable:
+```bash
+export NEWA_COLOR_CONFIG=/path/to/colors.yaml
+```
+
+#### Color configuration file format
+
+The color configuration file uses ANSI escape codes to define colors for different output elements:
+
+```yaml
+# Palette colors - for structural output elements
+palette:
+  state_dir: '\033[38;5;208m'      # Orange - state directory path
+  event: '\033[38;5;203m'          # Light red - event lines
+  issue: '\033[38;5;75m'           # Medium blue - issue lines
+  request_id: '\033[32m'           # Green - request IDs (REQ-*)
+  reportportal: '\033[38;5;141m'   # Purple - ReportPortal launch lines
+
+# State colors - for request execution states
+states:
+  not_executed: '\033[33m'         # Yellow - not executed
+  running: '\033[38;5;75m'         # Medium blue - running
+  complete: '\033[32m'             # Green - complete/finished
+  error: '\033[38;5;203m'          # Light red - error state
+  default: '\033[38;5;208m'        # Orange - other states (cancelled, etc.)
+
+# Result colors - for request execution results
+results:
+  passed: '\033[32m'               # Green - tests passed
+  failed: '\033[38;5;203m'         # Light red - tests failed
+  none: '\033[38;5;75m'            # Medium blue - no result yet
+  cancelled: '\033[38;5;208m'      # Orange - cancelled
+  default: '\033[38;5;208m'        # Orange - other results (error, skipped, etc.)
+```
+
+**Important notes:**
+- If a color is not specified in the configuration file, the built-in default color will be used
+- To disable color for a specific element, simply omit it from the configuration file
+- All values must be valid ANSI escape codes
+
+An example configuration file is available at `examples/colors.yaml` in the NEWA repository.
+
+#### Common ANSI color codes
+
+**Basic colors:**
+```
+Red:     '\033[31m'
+Green:   '\033[32m'
+Yellow:  '\033[33m'
+Blue:    '\033[34m'
+Magenta: '\033[35m'
+Cyan:    '\033[36m'
+White:   '\033[37m'
+```
+
+**256-color palette** (use `'\033[38;5;Nm'` where N is 0-255):
+```
+75  - Sky blue
+141 - Purple/violet
+203 - Light red/salmon pink
+208 - Orange
+226 - Bright yellow
+```
+
+**RGB colors** (use `'\033[38;2;R;G;Bm'`):
+```
+'\033[38;2;255;100;50m'  - Custom orange
+```
+
 ### Jira issue configuration file
 
 This is a configuration for the `newa jira` subcommand and typically it targets a particular package and event, e.g. it prescribes which Jira issues should be created for an advisory.

--- a/examples/colors.yaml
+++ b/examples/colors.yaml
@@ -1,0 +1,59 @@
+# NEWA Color Configuration Example
+#
+# This file allows you to customize colors for 'newa list' output.
+# To use this file, add the following to your newa.conf:
+#
+#   [newa]
+#   color_config = /path/to/colors.yaml
+#
+# Or set the environment variable:
+#   export NEWA_COLOR_CONFIG=/path/to/colors.yaml
+#
+# Color values should be ANSI escape codes.
+# If a color is not specified, the default color will be used.
+# If you don't want any color for a specific item, omit it from this file.
+
+# Palette colors - for structural output elements
+palette:
+  state_dir: '\033[38;5;208m'      # Orange - state directory path
+  event: '\033[38;5;203m'          # Light red - event lines
+  issue: '\033[38;5;75m'           # Medium blue - issue lines
+  request_id: '\033[32m'           # Green - request IDs (REQ-*)
+  reportportal: '\033[38;5;141m'   # Purple - ReportPortal launch lines
+
+# State colors - for request execution states
+states:
+  not_executed: '\033[33m'         # Yellow - not executed
+  running: '\033[38;5;75m'         # Medium blue - running
+  complete: '\033[32m'             # Green - complete/finished
+  error: '\033[38;5;203m'          # Light red - error state
+  default: '\033[38;5;208m'        # Orange - other states (cancelled, etc.)
+
+# Result colors - for request execution results
+results:
+  passed: '\033[32m'               # Green - tests passed
+  failed: '\033[38;5;203m'         # Light red - tests failed
+  none: '\033[38;5;75m'            # Medium blue - no result yet
+  cancelled: '\033[38;5;208m'      # Orange - cancelled
+  default: '\033[38;5;208m'        # Orange - other results (error, skipped, etc.)
+
+# Common ANSI 256-color codes for reference:
+#
+# Basic colors:
+#   Red:     '\033[31m'
+#   Green:   '\033[32m'
+#   Yellow:  '\033[33m'
+#   Blue:    '\033[34m'
+#   Magenta: '\033[35m'
+#   Cyan:    '\033[36m'
+#   White:   '\033[37m'
+#
+# 256-color palette (use '\033[38;5;Nm' where N is 0-255):
+#   75  - Sky blue
+#   141 - Purple/violet
+#   203 - Light red/salmon pink
+#   208 - Orange
+#   226 - Bright yellow
+#
+# You can also use RGB colors: '\033[38;2;R;G;Bm'
+# Example: '\033[38;2;255;100;50m' for a custom orange

--- a/newa/cli/color_config.py
+++ b/newa/cli/color_config.py
@@ -1,0 +1,67 @@
+"""Color configuration management for NEWA CLI."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from newa.utils.yaml_utils import yaml_parser
+
+
+class ColorConfig:
+    """Color configuration loaded from YAML file."""
+
+    def __init__(self, config_dict: Optional[dict[str, dict[str, str]]] = None):
+        """
+        Initialize color configuration.
+
+        Args:
+            config_dict: Dictionary containing color configuration
+        """
+        self.config = config_dict or {}
+
+    def get_color(self, category: str, key: str) -> Optional[str]:
+        """
+        Get color code for a specific category and key.
+
+        Args:
+            category: Category name (e.g., 'palette', 'states', 'results')
+            key: Key within category (e.g., 'state_dir', 'running', 'passed')
+
+        Returns:
+            Color code string if defined, None otherwise
+        """
+        if category not in self.config:
+            return None
+
+        category_config = self.config[category]
+        if not isinstance(category_config, dict):
+            return None
+
+        return category_config.get(key)
+
+    @classmethod
+    def load_from_file(cls, filepath: Path) -> 'ColorConfig':
+        """
+        Load color configuration from YAML file.
+
+        Args:
+            filepath: Path to the color configuration file
+
+        Returns:
+            ColorConfig instance
+        """
+        logger = logging.getLogger(__name__)
+
+        if not filepath.exists():
+            return cls()
+
+        try:
+            with open(filepath) as f:
+                config_dict = yaml_parser().load(f)
+                return cls(config_dict or {})
+        except Exception as e:
+            # If file is malformed, log warning and return empty config (use defaults)
+            logger.warning(
+                f'Failed to load color configuration from {filepath}: {e}. '
+                f'Using default colors.')
+            return cls()

--- a/newa/cli/color_utils.py
+++ b/newa/cli/color_utils.py
@@ -1,0 +1,242 @@
+"""Color utilities for NEWA CLI output."""
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Default color codes
+DEFAULT_COLORS = {
+    'RED': '\033[38;5;203m',  # light red (salmon pink)
+    'GREEN': '\033[32m',
+    'YELLOW': '\033[33m',
+    'BLUE': '\033[38;5;75m',  # medium blue
+    'ORANGE': '\033[38;5;208m',
+    'PURPLE': '\033[38;5;141m',
+    }
+
+
+class Colors:
+    """ANSI color codes."""
+
+    # Reset
+    RESET = '\033[0m'
+
+    # Colors - initialized with defaults
+    RED = DEFAULT_COLORS['RED']
+    GREEN = DEFAULT_COLORS['GREEN']
+    YELLOW = DEFAULT_COLORS['YELLOW']
+    BLUE = DEFAULT_COLORS['BLUE']
+    ORANGE = DEFAULT_COLORS['ORANGE']
+    PURPLE = DEFAULT_COLORS['PURPLE']
+
+    # Palette colors (for output elements)
+    STATE_DIR: Optional[str] = None  # None means use default (no override)
+    EVENT: Optional[str] = None
+    ISSUE: Optional[str] = None
+    REQUEST_ID: Optional[str] = None
+    REPORTPORTAL: Optional[str] = None
+
+    # State colors
+    STATE_NOT_EXECUTED: Optional[str] = None
+    STATE_RUNNING: Optional[str] = None
+    STATE_COMPLETE: Optional[str] = None
+    STATE_ERROR: Optional[str] = None
+    STATE_DEFAULT: Optional[str] = None
+
+    # Result colors
+    RESULT_PASSED: Optional[str] = None
+    RESULT_FAILED: Optional[str] = None
+    RESULT_NONE: Optional[str] = None
+    RESULT_CANCELLED: Optional[str] = None
+    RESULT_DEFAULT: Optional[str] = None
+
+    # Disable all colors
+    @classmethod
+    def disable(cls) -> None:
+        """Disable all colors by setting them to empty strings."""
+        cls.RESET = ''
+        cls.RED = ''
+        cls.GREEN = ''
+        cls.YELLOW = ''
+        cls.BLUE = ''
+        cls.ORANGE = ''
+        cls.PURPLE = ''
+
+
+def should_use_colors() -> bool:
+    """
+    Determine if colored output should be used.
+
+    Checks environment variables and terminal capabilities:
+    - NO_COLOR: If set (to any value), disables colors
+    - FORCE_COLOR: If set (to any value), forces colors
+    - Otherwise: Auto-detect based on terminal capabilities
+
+    Returns:
+        bool: True if colors should be used, False otherwise
+    """
+    # Check NO_COLOR environment variable (highest priority for disabling)
+    if os.environ.get('NO_COLOR'):
+        return False
+
+    # Check FORCE_COLOR environment variable
+    if os.environ.get('FORCE_COLOR'):
+        return True
+
+    # Auto-detect: check if stdout is a TTY and supports colors
+    if not hasattr(sys.stdout, 'isatty'):
+        return False
+
+    if not sys.stdout.isatty():
+        return False
+
+    # Check TERM environment variable for color support
+    term = os.environ.get('TERM', '')
+    # Most modern terminals support colors
+    return term != 'dumb'
+
+
+def colorize(text: str, color_code: str) -> str:
+    """
+    Colorize text with the given ANSI color code.
+
+    Args:
+        text: The text to colorize
+        color_code: The ANSI color code (e.g., Colors.RED)
+
+    Returns:
+        str: The colorized text with reset code appended
+    """
+    if not color_code:  # Colors disabled
+        return text
+    return f'{color_code}{text}{Colors.RESET}'
+
+
+def colorize_state(state: str) -> str:
+    """
+    Colorize request state according to the color scheme.
+
+    States:
+    - 'not executed': yellow (or configured)
+    - 'running': blue (or configured)
+    - 'complete'/'finished': green (or configured)
+    - 'error': red (or configured)
+    - others: orange (or configured)
+
+    Args:
+        state: The state string
+
+    Returns:
+        str: The colorized state string
+    """
+    state_lower = state.lower() if state else ''
+
+    if 'not executed' in state_lower:
+        color = Colors.STATE_NOT_EXECUTED or Colors.YELLOW
+        return colorize(state, color)
+    if 'running' in state_lower:
+        color = Colors.STATE_RUNNING or Colors.BLUE
+        return colorize(state, color)
+    if state_lower in ('complete', 'finished'):
+        color = Colors.STATE_COMPLETE or Colors.GREEN
+        return colorize(state, color)
+    if 'error' in state_lower:
+        color = Colors.STATE_ERROR or Colors.RED
+        return colorize(state, color)
+    # Default for other states (e.g., 'executed, not reported', 'cancelled')
+    color = Colors.STATE_DEFAULT or Colors.ORANGE
+    return colorize(state, color)
+
+
+def colorize_result(result: str) -> str:
+    """
+    Colorize request result according to the color scheme.
+
+    Results:
+    - 'passed': green (or configured)
+    - 'failed': red (or configured)
+    - 'None': blue (or configured)
+    - 'cancelled'/'canceled': orange (or configured)
+    - others (error, skipped, etc.): orange (or configured)
+
+    Args:
+        result: The result string
+
+    Returns:
+        str: The colorized result string
+    """
+    result_lower = result.lower() if result else ''
+
+    if result_lower == 'passed':
+        color = Colors.RESULT_PASSED or Colors.GREEN
+        return colorize(result, color)
+    if result_lower == 'failed':
+        color = Colors.RESULT_FAILED or Colors.RED
+        return colorize(result, color)
+    if result_lower == 'none':
+        color = Colors.RESULT_NONE or Colors.BLUE
+        return colorize(result, color)
+    if result_lower in ('cancelled', 'canceled'):
+        color = Colors.RESULT_CANCELLED or Colors.ORANGE
+        return colorize(result, color)
+    # Default for error, skipped, and other values
+    color = Colors.RESULT_DEFAULT or Colors.ORANGE
+    return colorize(result, color)
+
+
+def colorize_text(text: str, color_code: str) -> str:
+    """
+    Colorize arbitrary text with the given color.
+
+    This is a convenience wrapper around colorize() for specific color names.
+
+    Args:
+        text: The text to colorize
+        color_code: The ANSI color code (e.g., Colors.ORANGE)
+
+    Returns:
+        str: The colorized text
+    """
+    return colorize(text, color_code)
+
+
+def init_colors(color_config_path: Optional[str] = None) -> None:
+    """
+    Initialize colors based on environment, terminal detection, and config file.
+
+    Args:
+        color_config_path: Path to color configuration file. If None, no config is loaded.
+    """
+    if not should_use_colors():
+        Colors.disable()
+        return
+
+    # Load color configuration if path provided
+    if color_config_path:
+        from newa.cli.color_config import ColorConfig
+
+        config_path = Path(color_config_path)
+        if config_path.exists():
+            color_config = ColorConfig.load_from_file(config_path)
+
+            # Load palette colors
+            Colors.STATE_DIR = color_config.get_color('palette', 'state_dir')
+            Colors.EVENT = color_config.get_color('palette', 'event')
+            Colors.ISSUE = color_config.get_color('palette', 'issue')
+            Colors.REQUEST_ID = color_config.get_color('palette', 'request_id')
+            Colors.REPORTPORTAL = color_config.get_color('palette', 'reportportal')
+
+            # Load state colors
+            Colors.STATE_NOT_EXECUTED = color_config.get_color('states', 'not_executed')
+            Colors.STATE_RUNNING = color_config.get_color('states', 'running')
+            Colors.STATE_COMPLETE = color_config.get_color('states', 'complete')
+            Colors.STATE_ERROR = color_config.get_color('states', 'error')
+            Colors.STATE_DEFAULT = color_config.get_color('states', 'default')
+
+            # Load result colors
+            Colors.RESULT_PASSED = color_config.get_color('results', 'passed')
+            Colors.RESULT_FAILED = color_config.get_color('results', 'failed')
+            Colors.RESULT_NONE = color_config.get_color('results', 'none')
+            Colors.RESULT_CANCELLED = color_config.get_color('results', 'cancelled')
+            Colors.RESULT_DEFAULT = color_config.get_color('results', 'default')

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -12,6 +12,13 @@ from newa import (
     SCHEDULE_FILE_PREFIX,
     CLIContext,
     )
+from newa.cli.color_utils import (
+    Colors,
+    colorize_result,
+    colorize_state,
+    colorize_text,
+    init_colors,
+    )
 from newa.cli.report_helpers import _update_all_tf_request_statuses
 
 
@@ -66,6 +73,8 @@ def cmd_list(
         refresh_all: bool) -> None:
     """List NEWA execution details from state directories."""
     ctx.enter_command('list')
+    # Initialize colors based on environment, terminal capabilities, and config
+    init_colors(ctx.settings.newa_color_config)
     # Ensure --events and --issues are not used together
     if events and issues:
         raise click.UsageError('--events and --issues cannot be used together')
@@ -103,17 +112,22 @@ def cmd_list(
         print(f'{" " * indent}{s}', end=end)
 
     for state_dir in state_dirs:
-        print(f'{state_dir}:')
+        state_dir_color = Colors.STATE_DIR or Colors.ORANGE
+        print(f'{colorize_text(str(state_dir), state_dir_color)}:')
         ctx.state_dirpath = state_dir
         event_jobs = list(ctx.load_artifact_jobs(filter_events=True))
+        event_color = Colors.EVENT or Colors.RED
         for event_job in event_jobs:
             if event_job.erratum:
-                _print(2, f'event {event_job.id} - {event_job.erratum.summary}')
+                _print(2, colorize_text(
+                    f'event {event_job.id} - {event_job.erratum.summary}', event_color))
                 _print(2, event_job.erratum.url)
             elif event_job.rog:
-                _print(2, f'event {event_job.id} - {event_job.rog.title}')
+                _print(2, colorize_text(
+                    f'event {event_job.id} - {event_job.rog.title}', event_color))
             elif event_job.jira_issue:
-                _print(2, f'event {event_job.id} - {event_job.jira_issue.summary}')
+                _print(2, colorize_text(
+                    f'event {event_job.id} - {event_job.jira_issue.summary}', event_color))
                 _print(2, event_job.jira_issue.url)
                 people_info = []
                 if event_job.jira_issue.assignee:
@@ -123,16 +137,18 @@ def cmd_list(
                 if people_info:
                     _print(2, ', '.join(people_info))
             else:
-                _print(2, f'event {event_job.id}')
+                _print(2, colorize_text(f'event {event_job.id}', event_color))
             # Skip Jira issues and other details if --events flag is set
             if events:
                 continue
             jira_file_prefix = f'{JIRA_FILE_PREFIX}{event_job.event.short_id}-{event_job.short_id}'
             jira_jobs = list(ctx.load_jira_jobs(jira_file_prefix, filter_actions=True))
+            issue_color = Colors.ISSUE or Colors.BLUE
             for jira_job in jira_jobs:
                 jira_summary = f'- {jira_job.jira.summary}' if jira_job.jira.summary else ''
                 jira_action_id = jira_job.jira.action_id or 'no action id'
-                _print(4, f'issue {jira_job.jira.id} ({jira_action_id}) {jira_summary}')
+                issue_line = f'issue {jira_job.jira.id} ({jira_action_id}) {jira_summary}'
+                _print(4, colorize_text(issue_line, issue_color))
                 if jira_job.jira.url:
                     _print(4, jira_job.jira.url)
                 if jira_job.recipe and jira_job.recipe.url:
@@ -147,15 +163,21 @@ def cmd_list(
                         schedule_file_prefix,
                         filter_actions=True))
                 # print RP launch URL, should be common for all execute jobs
+                reportportal_color = Colors.REPORTPORTAL or Colors.PURPLE
                 if schedule_jobs and schedule_jobs[0].request.reportportal:
                     launch_name = schedule_jobs[0].request.reportportal.get('launch_name', None)
                     if launch_name:
-                        _print(6, f'ReportPortal launch: {launch_name}')
+                        _print(
+                            6,
+                            colorize_text(
+                                f'ReportPortal launch: {launch_name}',
+                                reportportal_color))
                         launch_url = schedule_jobs[0].request.reportportal.get('launch_url', None)
                         if launch_url:
                             _print(6, launch_url)
+                request_id_color = Colors.REQUEST_ID or Colors.GREEN
                 for schedule_job in schedule_jobs:
-                    _print(6, f'{schedule_job.request.id}', end='')
+                    _print(6, colorize_text(schedule_job.request.id, request_id_color), end='')
                     execute_file_prefix = (f'{EXECUTE_FILE_PREFIX}{event_job.event.short_id}-'
                                            f'{event_job.short_id}-{jira_job.jira.id}-'
                                            f'{schedule_job.request.id}')
@@ -185,10 +207,16 @@ def cmd_list(
                                     execute_job.execution, "result", RequestResult.NONE)
                                 url = getattr(
                                     execute_job.execution, "artifacts_url", "not available")
+                                # Apply color formatting to state and result
+                                colored_state = colorize_state(state)
+                                colored_result = colorize_result(result.value)
                                 print(
-                                    f' - state: {state}, result: {result.value}, artifacts: {url}')
+                                    f' - state: {colored_state}, '
+                                    f'result: {colored_result}, '
+                                    f'artifacts: {url}')
                     else:
-                        print(' - not executed')
+                        # Apply color formatting to 'not executed' state
+                        print(f' - {colorize_state("not executed")}')
         print()
     # restore logger level and statedir
     ctx.logger.setLevel(saved_logger_level)

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -49,6 +49,7 @@ class Settings:  # type: ignore[no-untyped-def]
     newa_statedir_topdir: Path = field(  # type: ignore[var-annotated]
         factory=Path, converter=lambda p: Path(p) if p else STATEDIR_TOPDIR)
     newa_clear_on_subcommand: bool = False
+    newa_color_config: str = ''
     et_url: str = ''
     et_enable_comments: bool = False
     et_deduplicate_releases: bool = False
@@ -105,6 +106,10 @@ class Settings:  # type: ignore[no-untyped-def]
                     cp,
                     'newa/clear_on_subcommand',
                     'NEWA_CLEAR_ON_SUBCOMMAND')),
+            newa_color_config=_get(
+                cp,
+                'newa/color_config',
+                'NEWA_COLOR_CONFIG'),
             et_url=_get(
                 cp,
                 'erratatool/url',


### PR DESCRIPTION
This commit introduces a comprehensive color configuration system for the 'newa list' output, providing users with customizable color schemes while maintaining sensible defaults.

Features:
- Automatic terminal color detection with TTY support
- Environment variable controls (NO_COLOR, FORCE_COLOR)
- Customizable color schemes via YAML configuration files
- Separate color configuration file support
- Built-in default colors that match current color scheme

Implementation:
- Created color_utils.py with color detection and formatting functions
- Created color_config.py for YAML-based configuration loading
- Added newa_color_config setting to Settings model
- Updated list_cmd.py to apply colors to all output elements
- Added type annotations for mypy compatibility

Color categories:
- Palette colors: state_dir, event, issue, request_id, reportportal
- State colors: not_executed, running, complete, error, default
- Result colors: passed, failed, none, cancelled, default

Configuration:
Users can specify color config via:
- NEWA config file: [newa] color_config = /path/to/colors.yaml
- Environment variable: NEWA_COLOR_CONFIG=/path/to/colors.yaml

If no color config is specified or a color is omitted from the config, built-in defaults are used, ensuring backward compatibility.

Documentation:
- Added comprehensive README section explaining color configuration
- Included example color config file with helpful comments
- Documented ANSI color code reference for user convenience

All changes pass pre-commit checks (autopep8, mypy, ruff) and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable ANSI color support to the `newa list` command, with auto-detection and YAML-based theming while preserving sensible defaults and a no-color mode.

New Features:
- Introduce a color configuration system for CLI output driven by ANSI codes and YAML theme files.
- Allow users to specify a color configuration path via config file or NEWA_COLOR_CONFIG environment variable.
- Add per-category coloring for list output elements such as state directories, events, issues, request IDs, states, and results.

Enhancements:
- Update the list command output to consistently apply colorization to key elements including states, results, events, issues, and ReportPortal info based on the active color scheme.
- Add terminal capability and environment-variable–aware logic to enable, force, or disable colored output automatically.

Documentation:
- Extend the README with usage and reference documentation for color configuration, including examples and ANSI color code guidance.
- Add an example colors.yaml file demonstrating customizable palettes for the list command.