### PR TITLE
Add --extra-tf-cli-args option to append Testing Farm CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1512,6 +1512,31 @@ Example: Changing TF CLI arguments.
 $ newa ... schedule --fixture testingfarm.cli_args="--repository-file URL" ...
 ```
 
+#### Option `--extra-tf-cli-args`
+
+Appends additional arguments to the Testing Farm CLI command for all scheduled requests. This option allows you to safely extend Testing Farm arguments when `testingfarm.cli_args` is already configured in the NEWA recipe.
+
+**Key features:**
+- When the recipe already contains `testingfarm.cli_args`, the extra arguments are appended to the existing ones
+- When the recipe doesn't have `testingfarm.cli_args`, the extra arguments are used as-is
+
+**Use cases:**
+- Adding temporary Testing Farm options without modifying the recipe
+- Passing environment-specific arguments at runtime
+- Extending recipe-defined arguments with additional options
+
+Example: Adding a repository file to Testing Farm requests while preserving recipe args.
+```
+$ newa event --compose CentOS-Stream-9 jira --job-recipe recipe.yaml schedule --extra-tf-cli-args "--repository-file URL" execute report
+```
+
+Example: Adding multiple Testing Farm options.
+```
+$ newa ... schedule --extra-tf-cli-args "--pipeline-type tmt-multihost --debug" execute
+```
+
+**Note:** Unlike `--fixture testingfarm.cli_args="..."` which replaces the entire `testingfarm.cli_args` value from the recipe, `--extra-tf-cli-args` always appends to existing arguments, making it safer for extending recipe configurations without breaking existing functionality.
+
 #### Option `--no-reportportal`
 
 If a recipe contains `reportportal` launch configuration, NEWA will create a RP launch and instruct `tmt` to report test results to it. With `schedule --no-reportportal` option NEWA will ignore `reportportal` section from the recipe and test results won't be reported to ReportPortal. Please note that when `how: reportportal` reporting is enabled in a `tmt` plan then both `tmt` and TestinFarm request may finish with an error. Therefore, when disabling ReportPortal reporting in NEWA a user should also ensure that it is not enabled in the `tmt` plan itself. You can use `newa_report_rp` context to enable ReportPortal reporting in a `tmt` plan conditionally. Use

--- a/newa/cli/commands/schedule_cmd.py
+++ b/newa/cli/commands/schedule_cmd.py
@@ -36,13 +36,18 @@ from newa.cli.utils import initialize_state_dir, test_file_presence
     '--rp-launch-uuid',
     help='Reuse an existing ReportPortal launch UUID instead of creating a new one.',
     )
+@click.option(
+    '--extra-tf-cli-args',
+    help='Extra arguments to append to testing-farm CLI args.',
+    )
 @click.pass_obj
 def cmd_schedule(
         ctx: CLIContext,
         arch: list[str],
         fixtures: list[str],
         no_reportportal: bool,
-        rp_launch_uuid: Optional[str] = None) -> None:
+        rp_launch_uuid: Optional[str] = None,
+        extra_tf_cli_args: Optional[str] = None) -> None:
     """
     Schedule subcommand - creates schedule jobs from jira jobs.
 
@@ -80,4 +85,11 @@ def cmd_schedule(
 
     # Process each jira job
     for jira_job in jira_jobs:
-        _process_jira_job(ctx, jira_job, arch, fixtures, no_reportportal, rp_launch_uuid)
+        _process_jira_job(
+            ctx=ctx,
+            jira_job=jira_job,
+            arch_options=arch,
+            fixtures=fixtures,
+            no_reportportal=no_reportportal,
+            rp_launch_uuid=rp_launch_uuid,
+            extra_tf_cli_args=extra_tf_cli_args)

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -11,6 +11,7 @@ from newa import (
     JiraJob,
     RawRecipeConfigDimension,
     RawRecipeReportPortalConfigDimension,
+    RawRecipeTFConfigDimension,
     RecipeConfig,
     Request,
     get_url_basename,
@@ -172,7 +173,8 @@ def _process_jira_job(
         arch_options: list[str],
         fixtures: list[str],
         no_reportportal: bool,
-        rp_launch_uuid: Optional[str] = None) -> None:
+        rp_launch_uuid: Optional[str] = None,
+        extra_tf_cli_args: Optional[str] = None) -> None:
     """Process a single jira_job and create schedule jobs."""
     from newa import ScheduleJob
 
@@ -248,6 +250,17 @@ def _process_jira_job(
         # Prepare Jinja variables and render request attributes
         jinja_vars = _prepare_jinja_vars_for_request(jira_job, request, issue_fields)
         _render_request_attributes(request, jinja_vars)
+
+        # Append extra testing-farm args if provided
+        if extra_tf_cli_args:
+            if not request.testingfarm:
+                request.testingfarm = RawRecipeTFConfigDimension()
+            existing_args = (request.testingfarm.get('cli_args') or '').strip()
+            extra_args_stripped = extra_tf_cli_args.strip()
+            if existing_args:
+                request.testingfarm['cli_args'] = f"{existing_args} {extra_args_stripped}"
+            else:
+                request.testingfarm['cli_args'] = extra_args_stripped
 
         # Apply cached launch metadata if --rp-launch-uuid was provided
         if launch_metadata:

--- a/tests/unit/data/recipe_no_cli_args.yaml
+++ b/tests/unit/data/recipe_no_cli_args.yaml
@@ -1,0 +1,11 @@
+fixtures:
+    tmt:
+        url: https://github.com/RedHatQE/newa.git
+        ref: main
+        path: demodata
+        plan: /plan/plan1
+    context:
+        tier: 1
+    environment:
+        TEST: "value"
+    compose: RHEL-9.0

--- a/tests/unit/test_jira_summary_and_schedule.py
+++ b/tests/unit/test_jira_summary_and_schedule.py
@@ -461,3 +461,77 @@ class TestScheduleAndRecipeFunctionality:
         # Load and verify the jira job has NO recipe
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
         assert jira_job.recipe is None
+
+    def test_extra_tf_cli_args_appends_to_existing_cli_args(self, mock_ctx):
+        """Test that --extra-tf-cli-args appends to existing testingfarm.cli_args."""
+        from newa import Compose, Recipe, ScheduleJob
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Create a jira job with recipe that HAS testingfarm.cli_args
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml'),
+            )
+
+        # Process with extra_tf_cli_args
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            extra_tf_cli_args='--extra-arg value',
+            )
+
+        # Verify schedule job files were created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
+        # Load and verify ALL schedule jobs have appended cli_args
+        for schedule_file in schedule_job_files:
+            schedule_job = ScheduleJob.from_yaml_file(schedule_file)
+            assert schedule_job.request.testingfarm is not None
+            # Original recipe has "-c trigger=newa", we append "--extra-arg value"
+            expected = '-c trigger=newa --extra-arg value'
+            assert schedule_job.request.testingfarm['cli_args'] == expected
+
+    def test_extra_tf_cli_args_creates_testingfarm_dict_when_missing(self, mock_ctx):
+        """Test that --extra-tf-cli-args creates testingfarm dict when it doesn't exist."""
+        from newa import Compose, Recipe, ScheduleJob
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Create a jira job with recipe that does NOT have testingfarm.cli_args
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-456', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/recipe_no_cli_args.yaml'),
+            )
+
+        # Process with extra_tf_cli_args
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=[],
+            fixtures=[],
+            no_reportportal=True,
+            extra_tf_cli_args='--new-arg value',
+            )
+
+        # Verify schedule job files were created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
+        # Load and verify ALL schedule jobs have new cli_args
+        for schedule_file in schedule_job_files:
+            schedule_job = ScheduleJob.from_yaml_file(schedule_file)
+            assert schedule_job.request.testingfarm is not None
+            assert schedule_job.request.testingfarm['cli_args'] == '--new-arg value'


### PR DESCRIPTION
Introduces a new --extra-tf-cli-
args option for the schedule command that safely extends Testing Farm arguments by appending to existing testingfarm.cli_args from recipes rather than replacing them.

Key changes:
- Add --extra-tf-cli-args option to schedule_cmd.py
- Implement argument appending logic in schedule_helpers.py that:
  - Appends to existing cli_args when present in recipe
  - Creates testingfarm dict with cli_args when missing
- Add comprehensive unit tests covering both scenarios
- Document the new option in README.md with usage examples and comparison to --fixture testingfarm.cli_args approach

This option provides a safer alternative to --fixture for extending recipe-defined Testing Farm arguments without breaking existing configurations, making it ideal for adding temporary or environment-specific options at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new schedule CLI option to append extra Testing Farm CLI arguments without overwriting recipe-defined configuration.

New Features:
- Add --extra-tf-args option to the schedule command to extend Testing Farm CLI arguments at runtime.

Enhancements:
- Update schedule job processing to append extra Testing Farm CLI arguments or initialize the Testing Farm configuration when missing.
- Document the new --extra-tf-args option, its behavior, and usage examples in the README.

Tests:
- Add unit tests verifying extra Testing Farm arguments are appended to existing cli_args or used to create a Testing Farm configuration when none exists.