### PR TITLE
Make 'list' the default subcommand when no subcommand is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,32 @@ $ REQUESTS_CA_BUNDLE=/etc/pki/tls/cert.pem newa event --erratum 124115 jira --is
 
 ## NEWA options and subcommands
 
+### Default behavior
+
+When you run `newa` without specifying any subcommand, it defaults to the `list` subcommand with its default options. This allows for quick inspection of recent NEWA test runs without typing the full command.
+
+Examples:
+```bash
+# These are equivalent - both list the last 10 state directories
+$ newa
+$ newa list
+
+# These are also equivalent - both list a specific state directory
+$ newa --state-dir /var/tmp/newa/run-123
+$ newa --state-dir /var/tmp/newa/run-123 list
+
+# Global options work with the default subcommand
+$ newa -P
+$ newa --prev-state-dir
+
+# To use list-specific options, you must explicitly specify 'list'
+$ newa list --last 20
+$ newa list --all
+$ newa -P list --refresh
+```
+
+This default behavior makes it convenient to check the status of your NEWA runs without having to remember the `list` subcommand each time. Note that list-specific options (like `--last`, `--all`, `--events`, `--issues`, `--refresh`) require you to explicitly specify the `list` subcommand.
+
 ### NEWA options
 
 #### Option `--clear`

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -385,8 +385,10 @@ def main(click_context: click.Context,
     ctx.cli_environment.update(dict(_split(s) for s in envvars))
     ctx.cli_context.update(dict(_split(s) for s in contexts))
 
-    # If no subcommand was specified, invoke the list command by default
-    if click_context.invoked_subcommand is None:
+    # If no subcommand was specified, invoke the list command by default.
+    # Avoid doing this during resilient parsing (e.g., shell completion).
+    if (not click_context.resilient_parsing
+            and click_context.invoked_subcommand is None):
         click_context.invoke(cmd_list)
 
 

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -96,7 +96,7 @@ def _should_filter_yaml_file(
     return False  # File matches all filters, keep it
 
 
-@click.group(chain=True)
+@click.group(chain=True, invoke_without_command=True)
 @click.option(
     '--state-dir',
     '-D',
@@ -384,6 +384,10 @@ def main(click_context: click.Context,
     # store environment variables and context provided on a cmdline
     ctx.cli_environment.update(dict(_split(s) for s in envvars))
     ctx.cli_context.update(dict(_split(s) for s in contexts))
+
+    # If no subcommand was specified, invoke the list command by default
+    if click_context.invoked_subcommand is None:
+        click_context.invoke(cmd_list)
 
 
 # Register commands

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -849,3 +849,127 @@ def test_erratum_jira_issues_populated():
 # Mark the last test to use the mock fixture
 test_erratum_jira_issues_populated = pytest.mark.usefixtures('_mock_errata_tool')(
     test_erratum_jira_issues_populated)
+
+
+def test_default_subcommand_is_list(tmp_path):
+    """Test that running newa without a subcommand defaults to the list command."""
+    runner = CliRunner()
+
+    # Create a topdir with some state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create a state directory with a YAML file
+    state_dir = topdir / "run-2024-01-01-12-00-00"
+    state_dir.mkdir()
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: Test erratum
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Run newa without any subcommand
+    result = runner.invoke(
+        cli.main,
+        [],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    # Should succeed and invoke the list command
+    assert result.exit_code == 0
+
+    # Output should contain the state directory path (from list command)
+    assert str(state_dir) in result.output
+
+
+def test_default_subcommand_with_options(tmp_path):
+    """Test that global options work with the default list subcommand."""
+    runner = CliRunner()
+
+    # Create a topdir with multiple state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create two state directories
+    state_dir1 = topdir / "run-2024-01-01-12-00-00"
+    state_dir1.mkdir()
+    state_dir2 = topdir / "run-2024-01-02-12-00-00"
+    state_dir2.mkdir()
+
+    # Create YAML files in both
+    (state_dir1 / "event-1.yaml").write_text("""
+event:
+  id: '1'
+  type_: erratum
+erratum:
+  id: '1'
+  content_type: rpm
+  respin_count: 1
+  summary: Test erratum 1
+  url: https://errata.example.com/1
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+    (state_dir2 / "event-2.yaml").write_text("""
+event:
+  id: '2'
+  type_: erratum
+erratum:
+  id: '2'
+  content_type: rpm
+  respin_count: 1
+  summary: Test erratum 2
+  url: https://errata.example.com/2
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Run newa with --state-dir option but no subcommand
+    result = runner.invoke(
+        cli.main,
+        ['--state-dir', str(state_dir1)],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    # Should succeed
+    assert result.exit_code == 0
+
+    # Output should contain only the specified state directory
+    assert str(state_dir1) in result.output
+    # Should not contain the other state directory
+    assert str(state_dir2) not in result.output
+
+
+def test_explicit_subcommand_still_works(tmp_path):
+    """Test that explicit subcommands still work as expected."""
+    runner = CliRunner()
+
+    # Create a topdir with a state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+    state_dir = topdir / "run-2024-01-01-12-00-00"
+    state_dir.mkdir()
+
+    # Run newa with explicit list subcommand
+    result = runner.invoke(
+        cli.main,
+        ['--state-dir', str(state_dir), 'list'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    # Should succeed
+    assert result.exit_code == 0
+
+    # Output should contain the state directory path
+    assert str(state_dir) in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -882,7 +882,7 @@ compose:
     result = runner.invoke(
         cli.main,
         [],
-        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+        env={'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     # Should succeed and invoke the list command
     assert result.exit_code == 0
@@ -941,7 +941,7 @@ compose:
     result = runner.invoke(
         cli.main,
         ['--state-dir', str(state_dir1)],
-        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+        env={'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     # Should succeed
     assert result.exit_code == 0
@@ -966,7 +966,7 @@ def test_explicit_subcommand_still_works(tmp_path):
     result = runner.invoke(
         cli.main,
         ['--state-dir', str(state_dir), 'list'],
-        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+        env={'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     # Should succeed
     assert result.exit_code == 0


### PR DESCRIPTION
When users run 'newa' without any subcommand, it now defaults to running 'newa list' with default options. This provides a convenient way to quickly check recent NEWA test runs without having to remember the list subcommand.

Changes:
- Added invoke_without_command=True to the main CLI group decorator
- Added logic to invoke cmd_list when no subcommand is provided
- Updated README with documentation of default behavior
- Added comprehensive tests for default subcommand functionality

Tests added:
- test_default_subcommand_is_list: Verifies default list invocation
- test_default_subcommand_with_options: Tests global options work
- test_explicit_subcommand_still_works: Ensures explicit commands work

All tests pass and pre-commit hooks validate successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the CLI default to the list command when no subcommand is provided.

New Features:
- Default invocation of the CLI with no subcommand now runs the list command with its default options.

Documentation:
- Document the default list-subcommand behavior and provide examples of equivalent invocations in the README.

Tests:
- Add tests covering default list invocation, interaction with global options, and preservation of explicit subcommand behavior.