### PR TITLE
Fix: Clear old issues for KEEP/UPDATE when current newa_id found

### DIFF
--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -421,6 +421,23 @@ def _find_or_create_issue(
             selected_issue.closed = False
             new_issues.append(selected_issue)
             old_closed_issues = []
+    else:
+        # We found new issues with current newa_id, so clear old issues for KEEP and UPDATE
+        if action.on_respin in (OnRespinAction.KEEP, OnRespinAction.UPDATE):
+            if old_opened_issues:
+                old_issue_ids = ', '.join([i.id for i in old_opened_issues])
+                ctx.logger.warning(
+                    f"Found old open issue(s) {old_issue_ids} from previous respin(s) "
+                    f"with outdated newa_id. These will be ignored since we are re-using "
+                    f"issue(s) with current newa_id. Consider closing them manually or "
+                    f"using on_respin: close.")
+                old_opened_issues = []
+            if old_closed_issues:
+                old_issue_ids = ', '.join([i.id for i in old_closed_issues])
+                ctx.logger.debug(
+                    f"Ignoring old closed issue(s) {old_issue_ids} with outdated newa_id "
+                    f"since we found issue(s) with current newa_id")
+                old_closed_issues = []
 
     # Unless we want recreate closed issues we would stop processing
     if new_issues and (not recreate):


### PR DESCRIPTION
When on_respin is set to KEEP or UPDATE and NEWA finds both:
- An issue with the current newa_id (which gets re-used)
- Old open/closed issues from previous respins with outdated newa_ids

The old issues were incorrectly being passed to _close_old_issues(), which expects to only receive issues when on_respin is CLOSE. This caused an "Invalid respin action" exception.

Changes:
- Added logic to clear old_opened_issues and old_closed_issues when new_issues is found for KEEP/UPDATE actions
- Added warning log for old open issues to alert users about potential orphaned issues that may need manual cleanup
- Added debug log for old closed issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle old JIRA issues correctly when reusing issues for a respin with KEEP or UPDATE actions.

Bug Fixes:
- Prevent old respin issues with outdated newa_ids from being passed to logic that only supports CLOSE actions when KEEP or UPDATE is selected.

Enhancements:
- Log warnings for ignored old open issues and debug messages for ignored old closed issues to aid in diagnosing potential orphaned JIRA issues.