### PR TITLE
Fix: Normalize request IDs to handle non-breaking hyphens from Jira C…

### DIFF
--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -24,6 +24,22 @@ from newa.cli.constants import JIRA_NONE_ID, RP_LAUNCH_DESCR_CHARS_LIMIT
 from newa.cli.utils import test_file_presence
 
 
+def normalize_request_ids(request_ids: list[str]) -> list[str]:
+    """
+    Normalize request IDs by replacing non-breaking hyphens with regular hyphens.
+
+    This handles cases where users copy request IDs from Jira Cloud comments,
+    which use non-breaking hyphens (U+2011) to prevent auto-linking.
+
+    Args:
+        request_ids: List of request IDs to normalize
+
+    Returns:
+        List of normalized request IDs with regular hyphens
+    """
+    return [req_id.replace('\u2011', '-') for req_id in request_ids]
+
+
 def sanitize_restart_result(ctx: CLIContext, results: list[str]) -> list[RequestResult]:
     """Validate and sanitize restart result values."""
     sanitized = []
@@ -64,7 +80,8 @@ def _validate_execute_parameters(
     ctx.continue_execution = _continue
 
     if restart_request:
-        ctx.restart_request = restart_request
+        # Normalize request IDs to handle non-breaking hyphens from Jira Cloud
+        ctx.restart_request = normalize_request_ids(restart_request)
         ctx.continue_execution = True
 
     if restart_result:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -973,3 +973,30 @@ def test_explicit_subcommand_still_works(tmp_path):
 
     # Output should contain the state directory path
     assert str(state_dir) in result.output
+
+
+def test_normalize_request_ids():
+    """Test that request IDs with non-breaking hyphens are normalized to regular hyphens."""
+    from newa.cli.execute_helpers import normalize_request_ids
+
+    # Test with regular hyphens (should remain unchanged)
+    regular_ids = ['REQ-1.2.1', 'REQ-2.2.2', 'REQ-3.4.5']
+    assert normalize_request_ids(regular_ids) == regular_ids
+
+    # Test with non-breaking hyphens (U+2011) - simulates copying from Jira Cloud
+    nonbreaking_ids = ['REQ\u20111.2.1', 'REQ\u20112.2.2', 'REQ\u20113.4.5']
+    expected = ['REQ-1.2.1', 'REQ-2.2.2', 'REQ-3.4.5']
+    assert normalize_request_ids(nonbreaking_ids) == expected
+
+    # Test with multiple non-breaking hyphens in a single ID
+    multiple_nonbreaking = ['REQ\u20111\u20112.1', 'REQ\u20112\u20114\u20116']
+    expected_multiple = ['REQ-1-2.1', 'REQ-2-4-6']
+    assert normalize_request_ids(multiple_nonbreaking) == expected_multiple
+
+    # Test with mixed hyphens
+    mixed_ids = ['REQ-1.2.1', 'REQ\u20112.2.2', 'REQ-3.4.5']
+    expected_mixed = ['REQ-1.2.1', 'REQ-2.2.2', 'REQ-3.4.5']
+    assert normalize_request_ids(mixed_ids) == expected_mixed
+
+    # Test empty list
+    assert normalize_request_ids([]) == []


### PR DESCRIPTION
…loud

When users copy request IDs from Jira Cloud comments, they contain non-breaking hyphens (U+2011) that are used to prevent auto-linking. This caused the -R/--restart-request option to fail to match request IDs, as the exact string comparison would fail.

This commit adds normalization that converts non-breaking hyphens to regular hyphens before matching, allowing users to seamlessly copy request IDs from Jira and use them with the execute command.

Changes:
- Added normalize_request_ids() function to convert U+2011 to '-'
- Updated _validate_execute_parameters() to normalize request IDs
- Added comprehensive test coverage for normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize CLI restart request IDs to handle non-breaking hyphens copied from external tools like Jira Cloud.

Bug Fixes:
- Ensure execute restart requests work when request IDs contain non-breaking hyphens instead of regular hyphens.

Tests:
- Add unit tests verifying normalization of request IDs with regular, non-breaking, mixed hyphens and empty input.