### PR TITLE
Add schedule attribute support and --schedule-all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,8 +551,9 @@ The following options are available:
    - `update` - Reuses the existing open issue and updates its summary, description, and custom fields. If no open issue exists but a closed issue with an old NEWA ID is found, it will be reopened and updated. When multiple old closed issues exist, the most recently updated one is selected. If the `updated` transition is configured, it will be applied after the update.
  - `auto_transition`: Defines if automatic issue state transitions are enabled (`True`) or not (`False`, a default value).
  - `schedule`: Controls whether a job should be automatically scheduled for this action (default: `True`). Can be either a boolean value or a Jinja template string that evaluates to a boolean:
-   - **Boolean value**: When set to `False`, NEWA will create or update the Jira issue but will not schedule any associated job (even if `job_recipe` is defined), unless the action is explicitly selected using the `--action-id-filter` option.
-   - **Jinja template**: When set to a string template (e.g., `"{{ ERRATUM.id != 'RHBA-1234' }}"`), NEWA will render the template and evaluate it to a boolean. The template has access to the same variables as other fields: `EVENT`, `ERRATUM`, `COMPOSE`, `JIRA`, `ROG`, `CONTEXT`, and `ENVIRONMENT`. The rendered string is converted to boolean where 'true', '1', or 'yes' (case-insensitive) are considered `True`, and all other values are considered `False`.
+   - **Boolean value**: When set to `False`, NEWA will create or update the Jira issue and save the recipe information, but will NOT automatically schedule the job during the `schedule` command. The job can be manually scheduled later using `schedule --schedule-all` or by using filters (`--action-id-filter` or `--issue-id-filter`).
+   - **Jinja template**: When set to a string template (e.g., `"{{ ERRATUM.id is match('RHSA-.*') }}"`), NEWA will render the template and evaluate it to a boolean. The template has access to the same variables as other fields: `EVENT`, `ERRATUM`, `COMPOSE`, `JIRA`, `ROG`, `CONTEXT`, and `ENVIRONMENT`. The rendered string is converted to boolean where 'true', '1', or 'yes' (case-insensitive) are considered `True`, and all other values are considered `False`.
+   - **Important**: Recipe information is ALWAYS saved to jira-* YAML files when `job_recipe` is specified, regardless of the `schedule` setting. This enables manual scheduling later without requiring access to the original issue-config file.
    - This is useful for creating tracking issues that don't require automated testing, for actions that should only be triggered on-demand, or for conditionally scheduling jobs based on event properties.
  - `erratum_comment_triggers` - For specified triggers, provides an update in an erratum through a comment. This functionality needs to be enabled also in the `newa` configuration file through `enable_comments = 1`. The following triggers are currently supported:
    - `jira` - Adds a comment when a Jira issue is initially 'adopted' by NEWA (either created or taken over due to `jira --map-issue` parameter).
@@ -1599,6 +1600,41 @@ The typical use case is when you want to add test results to an existing ReportP
 Example:
 ```
 $ newa event --compose CentOS-Stream-9 jira --job-recipe path/to/recipe.yaml schedule --rp-launch-uuid 12345678-1234-1234-1234-123456789abc execute report
+```
+
+#### Option `--schedule-all`
+
+Forces scheduling of all jobs, including those with `schedule: false` in the issue-config. This option overrides the `auto_schedule` attribute from jira-* YAML files.
+
+**Behavior and priority:**
+
+The schedule subcommand follows this priority order when deciding whether to schedule a job:
+1. **Filters** (`--action-id-filter`, `--issue-id-filter`) - Highest priority, always schedules matching jobs
+2. **`--schedule-all` flag** - Overrides `auto_schedule` attribute from jira-* files
+3. **`auto_schedule` attribute** - Default behavior based on the `schedule` attribute from issue-config
+
+**Use cases:**
+- Manually triggering performance or stress tests that are normally disabled (`schedule: false`)
+- Re-running all tests after infrastructure changes
+- Forcing execution of conditionally scheduled jobs regardless of their evaluation results
+
+**Important notes:**
+- When using filters (`--action-id-filter` or `--issue-id-filter`), jobs are scheduled even if `schedule: false`, making `--schedule-all` unnecessary unless you want to schedule ALL jobs
+- Recipe information is always saved to jira-* YAML files during the `jira` subcommand, regardless of the `schedule` setting, enabling manual scheduling at any time
+
+Example (schedule all jobs including those with schedule: false):
+```
+$ newa event --erratum 12345 --prev-state-dir schedule --schedule-all execute report
+```
+
+Example (schedule performance tests that have schedule: false):
+```
+$ newa event --erratum 12345 --prev-state-dir schedule --schedule-all --action-id-filter 'task_performance' execute report
+```
+
+Example (force all tests to run):
+```
+$ newa --prev-state-dir --clear schedule --schedule-all execute report
 ```
 
 

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -152,7 +152,10 @@ def cmd_list(
                 if jira_job.jira.url:
                     _print(4, jira_job.jira.url)
                 if jira_job.recipe and jira_job.recipe.url:
-                    _print(6, f'recipe: {jira_job.recipe.url}')
+                    # Show indicator only when auto_schedule is false
+                    auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
+                    auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
+                    _print(6, f'recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
                 # Skip schedule/execute details if --issues flag is set
                 if issues:
                     continue

--- a/newa/cli/commands/schedule_cmd.py
+++ b/newa/cli/commands/schedule_cmd.py
@@ -40,6 +40,13 @@ from newa.cli.utils import initialize_state_dir, test_file_presence
     '--extra-tf-cli-args',
     help='Extra arguments to append to testing-farm CLI args.',
     )
+@click.option(
+    '--schedule-all',
+    is_flag=True,
+    default=False,
+    help=('Schedule all jobs including those with schedule: false. '
+          'This overrides the auto_schedule attribute from issue-config.'),
+    )
 @click.pass_obj
 def cmd_schedule(
         ctx: CLIContext,
@@ -47,7 +54,8 @@ def cmd_schedule(
         fixtures: list[str],
         no_reportportal: bool,
         rp_launch_uuid: Optional[str] = None,
-        extra_tf_cli_args: Optional[str] = None) -> None:
+        extra_tf_cli_args: Optional[str] = None,
+        schedule_all: bool = False) -> None:
     """
     Schedule subcommand - creates schedule jobs from jira jobs.
 
@@ -92,4 +100,5 @@ def cmd_schedule(
             fixtures=fixtures,
             no_reportportal=no_reportportal,
             rp_launch_uuid=rp_launch_uuid,
-            extra_tf_cli_args=extra_tf_cli_args)
+            extra_tf_cli_args=extra_tf_cli_args,
+            schedule_all=schedule_all)

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -594,11 +594,15 @@ def _create_jira_job_from_action(
         artifact_job: ArtifactJob,
         jira_event_fields: dict[str, Any],
         new_issue: Issue,
-        save_recipe: bool) -> None:
-    """Create and save JiraJob with or without recipe.
+        auto_schedule: bool) -> None:
+    """Create and save JiraJob with recipe information.
 
-    If save_recipe is False, the recipe is set to None so that
-    the schedule command will skip this issue.
+    The recipe is always saved if job_recipe is specified, regardless of the
+    schedule attribute. The auto_schedule value is preserved in the Recipe's
+    auto_schedule field for later use by the schedule command.
+
+    The schedule command will respect auto_schedule unless overridden by
+    --schedule-all or filters (--action-id-filter, --issue-id-filter).
     """
     if action.erratum_comment_triggers:
         new_issue.erratum_comment_triggers = action.erratum_comment_triggers
@@ -606,9 +610,10 @@ def _create_jira_job_from_action(
         new_issue.rog_comment_triggers = action.rog_comment_triggers
     new_issue.action_id = action.id
 
-    # Create recipe only if save_recipe is True and job_recipe is specified
+    # Always create recipe if job_recipe is specified
+    # The schedule command will decide whether to actually schedule it
     recipe = None
-    if save_recipe and action.job_recipe:
+    if action.job_recipe:
         recipe_url = render_template(
             action.job_recipe,
             EVENT=artifact_job.event,
@@ -621,9 +626,10 @@ def _create_jira_job_from_action(
         recipe = Recipe(
             url=recipe_url,
             context=action.context,
-            environment=action.environment)
+            environment=action.environment,
+            auto_schedule=auto_schedule)
 
-    # Create JiraJob with or without recipe
+    # Create JiraJob
     jira_job = JiraJob(
         event=artifact_job.event,
         erratum=artifact_job.erratum,
@@ -770,21 +776,22 @@ def _process_issue_action(
             ctx, rog, artifact_job, action, new_issue,
             rendered_summary, trigger_comment)
 
-    # Create jira job
-    # If rendered_schedule is False, the recipe will be None and the schedule
-    # command will skip this issue, unless we are using action_id or issue_id filters.
-    # When filters are used, they override the schedule setting.
-    save_recipe = bool(
-        rendered_schedule or ctx.action_id_filter_pattern or ctx.issue_id_filter_pattern)
+    # Create jira job with recipe information
+    # The auto_schedule attribute is preserved for the schedule command to use
     _create_jira_job_from_action(
-        ctx, action, artifact_job, jira_event_fields, new_issue, save_recipe)
+        ctx, action, artifact_job, jira_event_fields, new_issue,
+        auto_schedule=rendered_schedule)
 
-    if not rendered_schedule:
-        if save_recipe:
-            ctx.logger.info(
-                f"Issue {new_issue.id} will be scheduled (overridden by filter).")
+    # Log scheduling status
+    if action.job_recipe:
+        if rendered_schedule:
+            ctx.logger.info(f"Issue {new_issue.id} has a recipe and will be auto-scheduled.")
         else:
-            ctx.logger.info(f"Issue {new_issue.id} will not be scheduled automatically.")
+            ctx.logger.info(
+                f"Issue {new_issue.id} has a recipe but auto-schedule is disabled. "
+                f"Use 'schedule --schedule-all' or filters to schedule it manually.")
+    else:
+        ctx.logger.info(f"Issue {new_issue.id} has no recipe (manual tracking only).")
 
     # Return issue and old_issues for further processing
     return new_issue, old_issues

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -174,7 +174,8 @@ def _process_jira_job(
         fixtures: list[str],
         no_reportportal: bool,
         rp_launch_uuid: Optional[str] = None,
-        extra_tf_cli_args: Optional[str] = None) -> None:
+        extra_tf_cli_args: Optional[str] = None,
+        schedule_all: bool = False) -> None:
     """Process a single jira_job and create schedule jobs."""
     from newa import ScheduleJob
 
@@ -182,6 +183,31 @@ def _process_jira_job(
     if not jira_job.recipe:
         ctx.logger.info(f'Skipping jira job {jira_job.jira.id} - no recipe specified')
         return
+
+    # Check auto_schedule setting unless overridden by filters or --schedule-all
+    #
+    # Priority order for scheduling decisions:
+    # 1. Filters (--action-id-filter, --issue-id-filter)
+    #    - If present, load_jira_jobs() only loads matching jobs
+    #    - We then override auto_schedule=False for those matching jobs
+    # 2. --schedule-all flag
+    #    - Overrides auto_schedule=False for all loaded jobs
+    # 3. auto_schedule attribute from recipe
+    #    - Default behavior when no filters or --schedule-all
+    auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
+    if not schedule_all and not auto_schedule:
+        # Check if filters are being used - they override auto_schedule
+        if not (ctx.action_id_filter_pattern or ctx.issue_id_filter_pattern):
+            ctx.logger.info(
+                f'Skipping jira job {jira_job.jira.id} - auto_schedule is disabled. '
+                f'Use --schedule-all or --action-id-filter/--issue-id-filter to override.')
+            return
+        # Filters are present, so we override auto_schedule
+        ctx.logger.info(
+            f'Scheduling jira job {jira_job.jira.id} - overridden by filter.')
+    elif schedule_all and not auto_schedule:
+        ctx.logger.info(
+            f'Scheduling jira job {jira_job.jira.id} - overridden by --schedule-all.')
 
     # Initialize ReportPortal connection if --rp-launch-uuid is provided
     rp = None

--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -127,6 +127,11 @@ class IssueAction(Serializable):  # type: ignore[no-untyped-def]
                                 self.links[relation].extend(defaults.links[relation])
                             elif defaults.links[relation]:
                                 self.links[relation] = copy.deepcopy(defaults.links[relation])
+                # For boolean attributes (schedule, auto_transition), check if value is None
+                # rather than falsy, since False is a valid explicit value
+                elif attr_name in ('schedule', 'auto_transition'):
+                    if getattr(self, attr_name, None) is None:
+                        setattr(self, attr_name, copy.deepcopy(attr))
                 elif not getattr(self, attr_name, None):
                     setattr(self, attr_name, copy.deepcopy(attr))
         return

--- a/newa/models/jobs.py
+++ b/newa/models/jobs.py
@@ -81,7 +81,9 @@ class JiraJob(ArtifactJob):
     """A single *jira* job"""
 
     jira: Issue = field(  # type: ignore[var-annotated]
-        converter=lambda x: x if isinstance(x, Issue) else Issue(**x),
+        converter=lambda x: x if isinstance(
+            x, Issue) else Issue(
+            **x),
         )
 
     recipe: Optional[Recipe] = field(  # type: ignore[var-annotated]
@@ -99,7 +101,9 @@ class ScheduleJob(JiraJob):
     """A single *request* to be scheduled for execution"""
 
     request = field(  # type: ignore[var-annotated]
-        converter=lambda x: x if isinstance(x, Request) else Request(**x),
+        converter=lambda x: x if isinstance(
+            x, Request) else Request(
+            **x),
         )
 
     @property
@@ -112,7 +116,9 @@ class ExecuteJob(ScheduleJob):
     """A single *request* to be scheduled for execution"""
 
     execution = field(  # type: ignore[var-annotated]
-        converter=lambda x: x if isinstance(x, Execution) else Execution(**x),
+        converter=lambda x: x if isinstance(
+            x, Execution) else Execution(
+            **x),
         )
 
     @property

--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -246,6 +246,7 @@ class Recipe(Cloneable, Serializable):
     url: str
     context: Optional[RecipeContext] = None
     environment: Optional[RecipeEnvironment] = None
+    auto_schedule: Optional[bool] = True
 
 
 @define

--- a/tests/unit/test_action_schedule.py
+++ b/tests/unit/test_action_schedule.py
@@ -1,6 +1,5 @@
 """Tests for IssueAction schedule attribute functionality."""
 
-import re
 from pathlib import Path
 from unittest import mock
 
@@ -81,10 +80,10 @@ class TestActionScheduleAttribute:
             )
         assert action.schedule is False
 
-    def test_create_jira_job_called_with_save_recipe_false_when_schedule_false(
+    def test_create_jira_job_called_with_auto_schedule_false(
             self, mock_ctx, mock_artifact_job, mock_jira_handler, mock_issue_config,
             ):
-        """Test _create_jira_job_from_action called with save_recipe=False."""
+        """Test _create_jira_job_from_action called with auto_schedule=False."""
         action = IssueAction(
             id='test_action',
             summary='Test Action',
@@ -124,15 +123,15 @@ class TestActionScheduleAttribute:
                 rog=None,
                 )
 
-            # Verify that _create_jira_job_from_action WAS called with save_recipe=False
+            # Verify that _create_jira_job_from_action WAS called with auto_schedule=False
             mock_create_job.assert_called_once()
-            # Check the 6th positional argument (save_recipe)
-            call_args = mock_create_job.call_args[0]
-            assert call_args[5] is False  # save_recipe is the 6th arg (index 5)
+            # Check the auto_schedule keyword argument
+            assert mock_create_job.call_args.kwargs['auto_schedule'] is False
 
-            # Verify the log message was generated
+            # Verify the new log message was generated
             mock_ctx.logger.info.assert_any_call(
-                "Issue TEST-123 will not be scheduled automatically.",
+                "Issue TEST-123 has a recipe but auto-schedule is disabled. "
+                "Use 'schedule --schedule-all' or filters to schedule it manually.",
                 )
 
     def test_create_jira_job_called_when_schedule_true(
@@ -180,18 +179,19 @@ class TestActionScheduleAttribute:
             # Verify that _create_jira_job_from_action WAS called
             mock_create_job.assert_called_once()
 
-    def test_schedule_false_overridden_by_action_id_filter(
+    def test_schedule_false_recipe_always_saved(
             self, mock_ctx, mock_artifact_job, mock_jira_handler, mock_issue_config,
             ):
-        """Test that schedule=False is overridden when action_id_filter matches."""
-        # Set action_id_filter_pattern on context
-        mock_ctx.action_id_filter_pattern = re.compile(r'test_action')
+        """Test that recipe is always saved even when schedule=False (no filter)."""
+        # NO filter set - this is the key difference from the old behavior
+        mock_ctx.action_id_filter_pattern = None
+        mock_ctx.issue_id_filter_pattern = None
 
         action = IssueAction(
             id='test_action',
             summary='Test Action',
             job_recipe='http://example.com/recipe.yaml',
-            schedule=False,  # Normally would not schedule
+            schedule=False,  # Recipe should still be saved
             )
 
         # Mock the issue object
@@ -225,16 +225,16 @@ class TestActionScheduleAttribute:
                 rog=None,
                 )
 
-            # Verify that _create_jira_job_from_action WAS called with
-            # save_recipe=True despite schedule=False
+            # Verify that _create_jira_job_from_action WAS called with auto_schedule=False
+            # (recipe is saved, but auto_schedule will be False)
             mock_create_job.assert_called_once()
-            # Check the 6th positional argument (save_recipe)
-            call_args = mock_create_job.call_args[0]
-            assert call_args[5] is True  # save_recipe is the 6th arg (index 5)
+            # Check the auto_schedule keyword argument
+            assert mock_create_job.call_args.kwargs['auto_schedule'] is False
 
-            # Verify the override log message
+            # Verify the new behavior log message
             mock_ctx.logger.info.assert_any_call(
-                "Issue TEST-123 will be scheduled (overridden by filter).",
+                "Issue TEST-123 has a recipe but auto-schedule is disabled. "
+                "Use 'schedule --schedule-all' or filters to schedule it manually.",
                 )
 
     def test_action_without_job_recipe_creates_job_without_recipe(
@@ -259,14 +259,14 @@ class TestActionScheduleAttribute:
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=mock_issue,
-            save_recipe=True,
+            auto_schedule=True,
             )
 
         # Verify jira job file was created
         jira_job_files = list(Path(mock_ctx.state_dirpath).glob('jira-*'))
         assert len(jira_job_files) == 1
 
-        # Verify the job has no recipe
+        # Verify the job has no recipe (auto_schedule not applicable without recipe)
         from newa import JiraJob
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
         assert jira_job.recipe is None
@@ -383,3 +383,136 @@ issues:
         _, _, _, _, _, rendered_schedule = _render_action_fields(
             action, artifact_job, {}, None, False)
         assert rendered_schedule is False
+
+    def test_list_command_shows_no_auto_schedule_indicator_when_false(
+            self, mock_ctx, mock_artifact_job, capsys):
+        """Test that list command shows [no-auto-schedule] when auto_schedule=False."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        from newa import Compose, Issue, JiraJob, Recipe
+
+        # Create a jira job with auto_schedule=False on the recipe
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue('TEST-123', summary='Test Issue'),
+            recipe=Recipe(url='http://example.com/recipe.yaml', auto_schedule=False),
+            )
+
+        # Save jira job to state dir
+        mock_ctx.save_jira_job(jira_job)
+
+        # Mock print function to capture output
+        output = StringIO()
+        with patch('builtins.print', side_effect=lambda *args, **kwargs: output.write(
+                ' '.join(str(a) for a in args) + kwargs.get('end', '\n'))):
+            # Simulate the list command's recipe output logic
+            auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
+            auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
+            print(f'      recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
+
+        # Verify output contains the indicator
+        output_str = output.getvalue()
+        assert '[no-auto-schedule]' in output_str
+        assert 'http://example.com/recipe.yaml [no-auto-schedule]' in output_str
+
+    def test_list_command_omits_no_auto_schedule_indicator_when_true(
+            self, mock_ctx, mock_artifact_job, capsys):
+        """Test that list command omits [no-auto-schedule] when auto_schedule=True."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        from newa import Compose, Issue, JiraJob, Recipe
+
+        # Create a jira job with auto_schedule=True (default)
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue('TEST-123', summary='Test Issue'),
+            recipe=Recipe(url='http://example.com/recipe.yaml', auto_schedule=True),
+            )
+
+        # Save jira job to state dir
+        mock_ctx.save_jira_job(jira_job)
+
+        # Mock print function to capture output
+        output = StringIO()
+        with patch('builtins.print', side_effect=lambda *args, **kwargs: output.write(
+                ' '.join(str(a) for a in args) + kwargs.get('end', '\n'))):
+            # Simulate the list command's recipe output logic
+            auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
+            auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
+            print(f'      recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
+
+        # Verify output does NOT contain the indicator
+        output_str = output.getvalue()
+        assert '[no-auto-schedule]' not in output_str
+        assert 'http://example.com/recipe.yaml\n' in output_str
+
+    def test_list_command_omits_no_auto_schedule_indicator_for_old_state(
+            self, mock_ctx, mock_artifact_job, capsys):
+        """Test that list command defaults to True for jobs without auto_schedule (old state)."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        # Create a jira job manually without auto_schedule attribute
+        # This simulates loading from an old state directory
+        from newa.models.jobs import JiraJob as JiraJobClass
+        jira_job_dict = {
+            'event': {'id': '12345', 'type_': EventType.ERRATUM},
+            'erratum': None,
+            'compose': {'id': 'RHEL-9.0'},
+            'rog': None,
+            'jira': {'id': 'TEST-123', 'summary': 'Test Issue'},
+            'recipe': {'url': 'http://example.com/recipe.yaml'},
+            # Intentionally omit 'auto_schedule' to simulate old state
+            }
+
+        # Use getattr to simulate what list command does
+        # This should default to True for backward compatibility
+        jira_job = JiraJobClass(**jira_job_dict)
+
+        # Mock print function to capture output
+        output = StringIO()
+        with patch('builtins.print', side_effect=lambda *args, **kwargs: output.write(
+                ' '.join(str(a) for a in args) + kwargs.get('end', '\n'))):
+            # Simulate the list command's recipe output logic
+            auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
+            auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
+            print(f'      recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
+
+        # Verify output does NOT contain the indicator (defaults to True)
+        output_str = output.getvalue()
+        assert '[no-auto-schedule]' not in output_str
+
+    def test_schedule_false_not_overridden_by_defaults(self, tmp_path):
+        """Test that schedule: false is not overridden by defaults."""
+        config_content = """
+project: TEST
+transitions:
+  closed: [Closed]
+  dropped: [Dropped]
+  processed: [In Progress]
+  passed: [Verified]
+defaults:
+  assignee: 'default@example.com'
+  schedule: true
+issues:
+  - id: action_with_explicit_false
+    summary: Test Action
+    schedule: false
+"""
+        config_file = tmp_path / 'test-config.yaml'
+        config_file.write_text(config_content)
+
+        config = IssueConfig.read_file(str(config_file))
+
+        # Even though defaults has schedule: true, the explicit schedule: false should be preserved
+        assert config.issues[0].schedule is False
+        # But the assignee default should be applied
+        assert config.issues[0].assignee == 'default@example.com'

--- a/tests/unit/test_jira_summary_and_schedule.py
+++ b/tests/unit/test_jira_summary_and_schedule.py
@@ -167,14 +167,14 @@ class TestScheduleAndRecipeFunctionality:
 
         mock_issue = Issue('TEST-123')
 
-        # Call _create_jira_job_from_action with save_recipe=True
+        # Call _create_jira_job_from_action with auto_schedule=True
         _create_jira_job_from_action(
             ctx=mock_ctx,
             action=action,
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=mock_issue,
-            save_recipe=True,
+            auto_schedule=True,
             )
 
         # Verify jira job file was created
@@ -185,10 +185,11 @@ class TestScheduleAndRecipeFunctionality:
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
         assert jira_job.recipe is not None
         assert jira_job.recipe.url == 'http://example.com/recipe.yaml'
+        assert jira_job.recipe.auto_schedule is True
 
-    def test_jira_job_created_without_recipe_when_schedule_false(
+    def test_jira_job_created_with_recipe_and_auto_schedule_false(
             self, mock_ctx, mock_artifact_job):
-        """Test that JiraJob is created without recipe when schedule=False."""
+        """Test JiraJob created with recipe and auto_schedule=False."""
         action = IssueAction(
             id='test_action',
             summary='Test Action',
@@ -198,23 +199,25 @@ class TestScheduleAndRecipeFunctionality:
 
         mock_issue = Issue('TEST-123')
 
-        # Call _create_jira_job_from_action with save_recipe=False
+        # Call _create_jira_job_from_action with auto_schedule=False
         _create_jira_job_from_action(
             ctx=mock_ctx,
             action=action,
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=mock_issue,
-            save_recipe=False,
+            auto_schedule=False,
             )
 
         # Verify jira job file was created
         jira_job_files = list(Path(mock_ctx.state_dirpath).glob('jira-*'))
         assert len(jira_job_files) == 1
 
-        # Load and verify the jira job has NO recipe
+        # Load and verify the jira job HAS recipe but auto_schedule is False
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
-        assert jira_job.recipe is None
+        assert jira_job.recipe is not None
+        assert jira_job.recipe.url == 'http://example.com/recipe.yaml'
+        assert jira_job.recipe.auto_schedule is False
 
     def test_schedule_false_logs_correct_message(
             self, mock_ctx, mock_artifact_job, mock_jira_handler, mock_issue_config):
@@ -255,12 +258,13 @@ class TestScheduleAndRecipeFunctionality:
 
             # Verify the correct log message
             mock_ctx.logger.info.assert_any_call(
-                "Issue TEST-123 will not be scheduled automatically.",
+                "Issue TEST-123 has a recipe but auto-schedule is disabled. "
+                "Use 'schedule --schedule-all' or filters to schedule it manually.",
                 )
 
     def test_schedule_false_overridden_by_action_id_filter(
             self, mock_ctx, mock_artifact_job, mock_jira_handler, mock_issue_config):
-        """Test that schedule=False is overridden when action_id_filter matches."""
+        """Test that schedule=False still saves recipe when action_id_filter matches."""
         # Set action_id_filter_pattern on context
         mock_ctx.action_id_filter_pattern = re.compile(r'test_action')
 
@@ -276,7 +280,8 @@ class TestScheduleAndRecipeFunctionality:
         with mock.patch('newa.cli.jira_helpers._render_action_fields') as mock_render, \
                 mock.patch('newa.cli.jira_helpers._find_or_create_issue') as mock_find_create:
 
-            mock_render.return_value = ('summary', 'description', None, {}, {}, False)
+            # With filter, schedule=False gets overridden to True by _render_action_fields
+            mock_render.return_value = ('summary', 'description', None, {}, {}, True)
             mock_find_create.return_value = (mock_issue, [], False)
 
             # Process the action
@@ -298,20 +303,16 @@ class TestScheduleAndRecipeFunctionality:
                 rog=None,
                 )
 
-            # Verify the override log message
-            mock_ctx.logger.info.assert_any_call(
-                "Issue TEST-123 will be scheduled (overridden by filter).",
-                )
-
-        # Verify jira job has recipe (despite schedule=False)
+        # Verify jira job has recipe (filter overrides schedule=False)
         jira_job_files = list(Path(mock_ctx.state_dirpath).glob('jira-*'))
         assert len(jira_job_files) == 1
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
         assert jira_job.recipe is not None
+        assert jira_job.recipe.auto_schedule is True
 
     def test_schedule_false_overridden_by_issue_id_filter(
             self, mock_ctx, mock_artifact_job, mock_jira_handler, mock_issue_config):
-        """Test that schedule=False is overridden when issue_id_filter matches."""
+        """Test that schedule=False still saves recipe when issue_id_filter would match."""
         # Set issue_id_filter_pattern on context
         mock_ctx.issue_id_filter_pattern = re.compile(r'TEST-123')
 
@@ -327,6 +328,9 @@ class TestScheduleAndRecipeFunctionality:
         with mock.patch('newa.cli.jira_helpers._render_action_fields') as mock_render, \
                 mock.patch('newa.cli.jira_helpers._find_or_create_issue') as mock_find_create:
 
+            # issue_id_filter doesn't affect _render_action_fields
+            # (only checked during load_jira_jobs)
+            # So recipe is still saved with auto_schedule=False
             mock_render.return_value = ('summary', 'description', None, {}, {}, False)
             mock_find_create.return_value = (mock_issue, [], False)
 
@@ -349,16 +353,160 @@ class TestScheduleAndRecipeFunctionality:
                 rog=None,
                 )
 
-            # Verify the override log message
-            mock_ctx.logger.info.assert_any_call(
-                "Issue TEST-123 will be scheduled (overridden by filter).",
-                )
-
-        # Verify jira job has recipe (despite schedule=False)
+        # Verify jira job has recipe (recipe is always saved now)
         jira_job_files = list(Path(mock_ctx.state_dirpath).glob('jira-*'))
         assert len(jira_job_files) == 1
         jira_job = JiraJob.from_yaml_file(jira_job_files[0])
         assert jira_job.recipe is not None
+        # auto_schedule remains False (issue_id filter is checked later in schedule command)
+        assert jira_job.recipe.auto_schedule is False
+
+    def test_schedule_command_skips_auto_schedule_false_without_filters(self, mock_ctx):
+        """Test that schedule command skips jobs with auto_schedule=False when no filters/flags."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Create a jira job with recipe but auto_schedule=False
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # Process without filters or --schedule-all
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=[],
+            fixtures=[],
+            no_reportportal=False,
+            schedule_all=False,
+            )
+
+        # Verify skip log message
+        mock_ctx.logger.info.assert_called_with(
+            f'Skipping jira job {JIRA_NONE_ID}-123 - auto_schedule is disabled. '
+            f'Use --schedule-all or --action-id-filter/--issue-id-filter to override.',
+            )
+
+        # Verify no schedule job files were created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) == 0
+
+    def test_schedule_command_processes_auto_schedule_false_with_action_filter(self, mock_ctx):
+        """Test that action_id filter overrides auto_schedule=False."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Set action_id_filter_pattern to match
+        mock_ctx.action_id_filter_pattern = re.compile(r'test_action')
+
+        # Create a jira job with recipe but auto_schedule=False
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # Process with action_id_filter (no --schedule-all flag)
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=False,
+            )
+
+        # Verify override log message
+        mock_ctx.logger.info.assert_any_call(
+            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+            )
+
+        # Verify schedule job files WERE created (filter overrides auto_schedule=False)
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
+    def test_schedule_command_processes_auto_schedule_false_with_issue_filter(self, mock_ctx):
+        """Test that issue_id filter overrides auto_schedule=False."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Set issue_id_filter_pattern to match
+        mock_ctx.issue_id_filter_pattern = re.compile(rf'{JIRA_NONE_ID}-123')
+
+        # Create a jira job with recipe but auto_schedule=False
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # Process with issue_id_filter (no --schedule-all flag)
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=False,
+            )
+
+        # Verify override log message
+        mock_ctx.logger.info.assert_any_call(
+            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+            )
+
+        # Verify schedule job files WERE created (filter overrides auto_schedule=False)
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
+    def test_schedule_command_processes_auto_schedule_false_with_schedule_all(self, mock_ctx):
+        """Test that --schedule-all flag overrides auto_schedule=False."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Create a jira job with recipe but auto_schedule=False
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # Process with schedule_all=True
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=True,
+            )
+
+        # Verify override log message
+        mock_ctx.logger.info.assert_any_call(
+            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by --schedule-all.',
+            )
+
+        # Verify schedule job files WERE created (--schedule-all overrides auto_schedule=False)
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
 
     def test_schedule_command_skips_jobs_without_recipe(self, mock_ctx, tmp_path):
         """Test that schedule command skips jira jobs without recipes."""
@@ -416,7 +564,7 @@ class TestScheduleAndRecipeFunctionality:
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=Issue('TEST-123'),
-            save_recipe=True,
+            auto_schedule=True,
             )
 
         _create_jira_job_from_action(
@@ -425,7 +573,7 @@ class TestScheduleAndRecipeFunctionality:
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=Issue('TEST-124'),
-            save_recipe=False,
+            auto_schedule=False,
             )
 
         # Verify both jira job files were created
@@ -451,7 +599,7 @@ class TestScheduleAndRecipeFunctionality:
             artifact_job=mock_artifact_job,
             jira_event_fields={},
             new_issue=mock_issue,
-            save_recipe=True,
+            auto_schedule=True,
             )
 
         # Verify jira job file was created


### PR DESCRIPTION
Breaking change: Recipe information is now always saved to jira-* YAML files when job_recipe is specified, regardless of the schedule attribute. The schedule attribute controls the auto_schedule field in JiraJob, which determines whether jobs are automatically scheduled during the schedule command.

Changes:
- Add 'schedule' attribute to IssueAction model (default: True) supporting boolean values and Jinja templates
- Add --schedule-all option to schedule command to override auto_schedule and force scheduling of all jobs
- Add auto_schedule field to JiraJob model (Optional[bool], default=True) for backward compatibility with old state directories
- Show [no-auto-schedule] indicator in 'newa list' output for jobs with auto_schedule=false
- Rename function parameter from 'rendered_schedule' to 'auto_schedule' in _create_jira_job_from_action() for clarity
- Update README with comprehensive documentation of schedule attribute behavior and --schedule-all option
- Add type ignore comments to fix mypy errors with attrs-generated __init__ methods
- Update all tests to match new behavior

Priority order for scheduling decisions:
1. Filters (--action-id-filter, --issue-id-filter) - always schedules
2. --schedule-all flag - overrides auto_schedule attribute
3. auto_schedule attribute - default behavior from issue-config

The compact [no-auto-schedule] indicator only appears when the value is false, keeping the output clean for the default case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine job scheduling semantics by always persisting recipe information, introducing an auto-schedule flag on recipes, and adding an option to force scheduling of all jobs from the CLI.

New Features:
- Introduce an auto_schedule attribute on recipes/Jira jobs derived from the schedule action attribute to control whether jobs are auto-scheduled by default.
- Add a --schedule-all option to the schedule command to force scheduling of all jobs, including those with schedule: false.
- Display a [no-auto-schedule] indicator in the list command output for jobs whose recipes are not auto-scheduled.

Enhancements:
- Always save recipe information to jira-* YAML files whenever job_recipe is specified, enabling manual scheduling later even when automatic scheduling is disabled.
- Adjust scheduling logic to respect auto_schedule with a defined priority between filters, the --schedule-all flag, and the stored auto_schedule value.
- Ensure boolean defaults for schedule and auto_transition are only applied when unset, preserving explicit false values.
- Improve logging messages around scheduling decisions to clarify when auto-scheduling is disabled or overridden.
- Refine attrs-generated field converters and add type-ignore hints to satisfy mypy in job models.

Documentation:
- Update README to clarify the behavior of the schedule attribute, document the auto_schedule semantics, and describe the new --schedule-all option including its priority and usage examples.

Tests:
- Extend and update unit tests for Jira job creation, scheduling behavior (including filters and --schedule-all), listing output, and issue-config defaults to cover the new auto_schedule logic and persistence of recipes.