### PR TITLE
Add --action-tag-filter option for selective action processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ issues:
    on_respin: close
    auto_transition: True
    job_recipe: https://path/to/my/NEWA/recipe/errata.yaml
+   action_tags:
+     - tier1
+     - regression
    erratum_comment_triggers:
      - execute
      - report
@@ -359,6 +362,9 @@ issues:
    parent_id: errata_epic
    on_respin: close
    job_recipe: https://path/to/my/NEWA/recipe/performance.yaml
+   action_tags:
+     - tier2
+     - performance
    schedule: false
 
  - summary: "ER#{{ ERRATUM.id }} - Security testing {{ ERRATUM.builds|join(' ') }}"
@@ -368,6 +374,9 @@ issues:
    parent_id: errata_epic
    on_respin: close
    job_recipe: https://path/to/my/NEWA/recipe/security.yaml
+   action_tags:
+     - tier1
+     - security
    schedule: "{{ ERRATUM.id is match('RHSA-.*') }}"
 ```
 
@@ -572,6 +581,7 @@ The following options are available:
  - `type`: Jira issue type, could be `epic`, `task`, `sub-task`
  - `id`: unique identifier within the scope of issue-config file, it is used to identify this specific config item.
  - `parent_id`: refers to item `id` which should become a parent Jira issue of this issue.
+ - `action_tags`: Optional list of string tags that can be used to categorize and filter actions. These tags are stored in the generated YAML files and can be used with `--action-tag-filter` to selectively process subsets of actions. This is useful for splitting test execution into parts (e.g., by test tier, category, or priority). See example below.
  - `newa_id`: Optional custom identifier (usually a Jinja2 template) that NEWA will embed in the Jira issue description. This identifier is used by NEWA to find and reuse existing Jira issues in subsequent runs instead of creating duplicates. When NEWA processes an issue-config, it first searches for existing Jira issues containing this identifier in their description. If found, the existing issue is reused; otherwise, a new issue is created and the identifier is added to its description. This is particularly useful for erratum-based workflows where you want to track the same erratum across multiple NEWA runs. See example below.
  - `on_respin`: Defines action when the issue is obsoleted by a newer version (due to erratum respin). Possible values are:
    - `close` - Creates a new issue and marks the old one as obsolete
@@ -1252,6 +1262,44 @@ $ newa --action-id-filter '(epic|tier1).*' event --compose CentOS-Stream-10 jira
 Example (triggering performance tests that have `schedule: false`):
 ```
 $ newa --action-id-filter 'task_performance' event --erratum 12345 jira --issue-config errata-config.yaml schedule execute report
+```
+
+#### Option `--action-tag-filter`
+
+Instructs NEWA to process only actions whose `action_tags` match the provided regular expression. An action is included if **any** of its tags matches the pattern. This option works across all NEWA subcommands and can be used to split test execution into logical parts.
+
+When using this filter:
+- Actions are matched if any tag matches the regex pattern
+- Parent actions are automatically included when their child actions match (similar to `--action-id-filter`)
+- Actions with `schedule: false` will have their jobs scheduled if they match the filter pattern
+- This option can be combined with `--action-id-filter` and `--issue-id-filter` for fine-grained control
+- Tags are stored in generated YAML files, so filtering works at all stages (jira, schedule, execute, report, list)
+
+Use with caution.
+
+Example (run only tier1 tests):
+```
+$ newa --action-tag-filter 'tier1' event --erratum 12345 jira --issue-config config.yaml schedule execute report
+```
+
+Example (run tier1 or tier2 tests):
+```
+$ newa --action-tag-filter 'tier[12]' event --compose CentOS-Stream-10 jira --issue-config config.yaml schedule execute report
+```
+
+Example (run all regression tests):
+```
+$ newa --action-tag-filter 'regression' --prev-state-dir schedule execute report
+```
+
+Example (combine with other filters):
+```
+$ newa --action-tag-filter 'security' --action-id-filter 'task_.*' event --erratum 12345 jira --issue-config config.yaml schedule
+```
+
+Example (use with --copy-state-dir to create a subset):
+```
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --action-tag-filter 'tier1' schedule execute report
 ```
 
 #### Option `--issue-id-filter`

--- a/README.md
+++ b/README.md
@@ -1266,10 +1266,28 @@ $ newa --action-id-filter 'task_performance' event --erratum 12345 jira --issue-
 
 #### Option `--action-tag-filter`
 
-Instructs NEWA to process only actions whose `action_tags` match the provided regular expression. An action is included if **any** of its tags matches the pattern. This option works across all NEWA subcommands and can be used to split test execution into logical parts.
+Instructs NEWA to process only actions whose `action_tags` match the provided filter expression. This option uses a powerful expression syntax that combines regex pattern matching with boolean operators (OR, AND, NOT), allowing you to create complex filtering rules. The filter works across all NEWA subcommands and can be used to split test execution into logical parts.
 
-When using this filter:
-- Actions are matched if any tag matches the regex pattern
+**Filter Expression Syntax:**
+
+The filter expression supports three boolean operators:
+- **`|` (OR)**: Match if **any** of the patterns match. Example: `tier1|tier2` matches actions with either "tier1" OR "tier2" tag
+- **`,` (AND)**: Match if **all** of the conditions are satisfied. Example: `regression,rhel-9` matches only actions that have BOTH "regression" AND "rhel-9" tags
+- **`!` (NOT)**: Exclude actions that match the pattern. Example: `!slow` excludes actions with "slow" tag
+
+Each pattern in the expression is a **full regex pattern**, giving you the power to use wildcards and other regex features:
+- `tier.*` - matches "tier1", "tier2", "tier_anything"
+- `tier[12]` - matches exactly "tier1" or "tier2"
+- `rhel-\d+` - matches "rhel-9", "rhel-10", etc.
+
+**Boolean operators can be combined** to create sophisticated filters:
+- `tier1|tier2` - Match actions with tier1 OR tier2
+- `regression,rhel-9.*` - Match actions with regression AND rhel-9.x tags
+- `!slow` - Exclude slow tests
+- `tier[12]|regression,rhel-9.*,!slow` - Match (tier1 OR tier2 OR regression) AND (rhel-9.x) AND NOT (slow)
+
+**Filter Behavior:**
+- Actions are matched if their tags satisfy the entire filter expression
 - Parent actions are automatically included when their child actions match (similar to `--action-id-filter`)
 - Actions with `schedule: false` will have their jobs scheduled if they match the filter pattern
 - This option can be combined with `--action-id-filter` and `--issue-id-filter` for fine-grained control
@@ -1277,29 +1295,42 @@ When using this filter:
 
 Use with caution.
 
-Example (run only tier1 tests):
+**Examples:**
+
+Simple OR filter (run tier1 OR tier2 tests):
 ```
-$ newa --action-tag-filter 'tier1' event --erratum 12345 jira --issue-config config.yaml schedule execute report
+$ newa --action-tag-filter 'tier1|tier2' event --erratum 12345 jira --issue-config config.yaml schedule execute report
 ```
 
-Example (run tier1 or tier2 tests):
+Regex pattern (run tests matching tier followed by any character):
 ```
-$ newa --action-tag-filter 'tier[12]' event --compose CentOS-Stream-10 jira --issue-config config.yaml schedule execute report
-```
-
-Example (run all regression tests):
-```
-$ newa --action-tag-filter 'regression' --prev-state-dir schedule execute report
+$ newa --action-tag-filter 'tier.*' event --compose CentOS-Stream-10 jira --issue-config config.yaml schedule execute report
 ```
 
-Example (combine with other filters):
+AND filter (run regression tests for RHEL-9 only):
 ```
-$ newa --action-tag-filter 'security' --action-id-filter 'task_.*' event --erratum 12345 jira --issue-config config.yaml schedule
+$ newa --action-tag-filter 'regression,rhel-9.*' --prev-state-dir schedule execute report
 ```
 
-Example (use with --copy-state-dir to create a subset):
+NOT filter (run all tests except slow ones):
 ```
-$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --action-tag-filter 'tier1' schedule execute report
+$ newa --action-tag-filter '!slow' event --erratum 12345 jira --issue-config config.yaml schedule execute report
+```
+
+Complex combined filter:
+```
+# Run (tier1 OR tier2) AND (rhel-9.x) AND NOT (slow or nightly)
+$ newa --action-tag-filter 'tier[12],rhel-9.*,!slow,!nightly' event --erratum 12345 jira --issue-config config.yaml schedule
+```
+
+Combine with other filters:
+```
+$ newa --action-tag-filter 'security|regression' --action-id-filter 'task_.*' event --erratum 12345 jira --issue-config config.yaml schedule
+```
+
+Use with --copy-state-dir to create a subset:
+```
+$ newa --state-dir /path/to/existing/run-123 --copy-state-dir --action-tag-filter 'tier1,!slow' schedule execute report
 ```
 
 #### Option `--issue-id-filter`

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -151,6 +151,9 @@ def cmd_list(
                 _print(4, colorize_text(issue_line, issue_color))
                 if jira_job.jira.url:
                     _print(4, jira_job.jira.url)
+                if jira_job.jira.action_tags:
+                    tags_str = ', '.join(jira_job.jira.action_tags)
+                    _print(4, f'tags: {tags_str}')
                 if jira_job.recipe and jira_job.recipe.url:
                     # Show indicator only when auto_schedule is false
                     auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)

--- a/newa/cli/filter_helpers.py
+++ b/newa/cli/filter_helpers.py
@@ -1,0 +1,26 @@
+"""Shared helper functions for filtering logic."""
+
+from re import Pattern
+from typing import Optional
+
+
+def should_filter_by_action_tags(
+        action_tags: Optional[list[str]],
+        pattern: Pattern[str]) -> bool:
+    """
+    Check if action_tags should be filtered based on the given pattern.
+
+    Args:
+        action_tags: List of action tags (or None/empty if no tags)
+        pattern: Compiled regex pattern to match against tags
+
+    Returns:
+        True if the action should be filtered out (skipped), False if it should be kept.
+        An action is kept if ANY of its tags matches the pattern.
+    """
+    if not action_tags:
+        # No tags, filter it out
+        return True
+
+    # Check if any tag matches the pattern (using fullmatch for exact match)
+    return not any(pattern.fullmatch(tag) for tag in action_tags)

--- a/newa/cli/filter_helpers.py
+++ b/newa/cli/filter_helpers.py
@@ -1,26 +1,24 @@
 """Shared helper functions for filtering logic."""
 
-from re import Pattern
 from typing import Optional
+
+from newa.cli.tag_filter import TagFilter
 
 
 def should_filter_by_action_tags(
         action_tags: Optional[list[str]],
-        pattern: Pattern[str]) -> bool:
+        tag_filter: TagFilter) -> bool:
     """
-    Check if action_tags should be filtered based on the given pattern.
+    Check if action_tags should be filtered based on the given tag filter.
 
     Args:
         action_tags: List of action tags (or None/empty if no tags)
-        pattern: Compiled regex pattern to match against tags
+        tag_filter: TagFilter object with parsed filter expression
 
     Returns:
         True if the action should be filtered out (skipped), False if it should be kept.
-        An action is kept if ANY of its tags matches the pattern.
+        An action is kept if it matches the tag filter criteria.
     """
-    if not action_tags:
-        # No tags, filter it out
-        return True
-
-    # Check if any tag matches the pattern (using fullmatch for exact match)
-    return not any(pattern.fullmatch(tag) for tag in action_tags)
+    # The TagFilter.matches() returns True if tags match the filter
+    # We need to invert this: filter out (return True) if tags DON'T match
+    return not tag_filter.matches(action_tags)

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -5,7 +5,10 @@ import re
 import urllib.parse
 from collections.abc import Generator
 from re import Pattern
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from newa.cli.tag_filter import TagFilter
 
 from newa import (
     ArtifactJob,
@@ -822,18 +825,17 @@ def _build_action_id_filtered_list(
 
 def _build_action_tag_filtered_list(
         issue_actions: list[IssueAction],
-        pattern: Pattern[str]) -> list[str]:
-    """Using the given tag RegExp Pattern and IssueAction list build a list
-    of action IDs where any action_tag matches the pattern, and their parent action IDs"""
-    # initially populate ids_filtered with action ids where any action_tag matches pattern
+        tag_filter: 'TagFilter') -> list[str]:
+    """Using the given TagFilter and IssueAction list build a list
+    of action IDs where action_tags match the filter, and their parent action IDs"""
+    from newa.cli.filter_helpers import should_filter_by_action_tags
+
+    # initially populate ids_filtered with action ids where action_tags match the filter
     ids_filtered = set()
     for action in issue_actions:
-        if action.id and action.action_tags:
-            # Check if any action_tag matches the pattern
-            for tag in action.action_tags:
-                if pattern.fullmatch(tag):
-                    ids_filtered.add(action.id)
-                    break  # No need to check remaining action_tags for this action
+        # Check if action_tags match the filter (should_filter returns True if NOT matching)
+        if action.id and not should_filter_by_action_tags(action.action_tags, tag_filter):
+            ids_filtered.add(action.id)
 
     prev_filtered_list_len = -1
     # repeat while filtered list grows (to include parents)

--- a/newa/cli/jira_helpers.py
+++ b/newa/cli/jira_helpers.py
@@ -602,13 +602,15 @@ def _create_jira_job_from_action(
     auto_schedule field for later use by the schedule command.
 
     The schedule command will respect auto_schedule unless overridden by
-    --schedule-all or filters (--action-id-filter, --issue-id-filter).
+    --schedule-all or filters (--action-id-filter, --issue-id-filter, --action-tag-filter).
     """
     if action.erratum_comment_triggers:
         new_issue.erratum_comment_triggers = action.erratum_comment_triggers
     if action.rog_comment_triggers:
         new_issue.rog_comment_triggers = action.rog_comment_triggers
     new_issue.action_id = action.id
+    if action.action_tags:
+        new_issue.action_tags = action.action_tags
 
     # Always create recipe if job_recipe is specified
     # The schedule command will decide whether to actually schedule it
@@ -818,6 +820,75 @@ def _build_action_id_filtered_list(
     return list(ids_filtered)
 
 
+def _build_action_tag_filtered_list(
+        issue_actions: list[IssueAction],
+        pattern: Pattern[str]) -> list[str]:
+    """Using the given tag RegExp Pattern and IssueAction list build a list
+    of action IDs where any action_tag matches the pattern, and their parent action IDs"""
+    # initially populate ids_filtered with action ids where any action_tag matches pattern
+    ids_filtered = set()
+    for action in issue_actions:
+        if action.id and action.action_tags:
+            # Check if any action_tag matches the pattern
+            for tag in action.action_tags:
+                if pattern.fullmatch(tag):
+                    ids_filtered.add(action.id)
+                    break  # No need to check remaining action_tags for this action
+
+    prev_filtered_list_len = -1
+    # repeat while filtered list grows (to include parents)
+    while len(ids_filtered) > prev_filtered_list_len:
+        prev_filtered_list_len = len(ids_filtered)
+        # if action has a parent_id, add parent_id to actions_filtered set
+        for action in issue_actions:
+            if action.id in ids_filtered and action.parent_id:
+                ids_filtered.add(action.parent_id)
+    return list(ids_filtered)
+
+
+def _build_combined_action_filtered_list(
+        ctx: CLIContext,
+        issue_actions: list[IssueAction]) -> Optional[list[str]]:
+    """
+    Build combined filtered list of action IDs based on active filters.
+
+    Combines action-id and action-tag filters using AND logic (intersection).
+    Includes parent action IDs for all matched actions.
+
+    Returns:
+        List of action IDs to process, or None if no filters are active
+    """
+    id_filtered_list: Optional[list[str]] = None
+    tag_filtered_list: Optional[list[str]] = None
+
+    if ctx.action_id_filter_pattern:
+        # Include parents of actions matching the given id regexp pattern
+        id_filtered_list = _build_action_id_filtered_list(
+            issue_actions, ctx.action_id_filter_pattern)
+        ctx.logger.debug(
+            f"Filtered action id list including parent ids: {id_filtered_list}")
+
+    if ctx.action_tag_filter_pattern:
+        # Include parents of actions matching the tag pattern
+        tag_filtered_list = _build_action_tag_filtered_list(
+            issue_actions, ctx.action_tag_filter_pattern)
+        ctx.logger.debug(
+            f"Filtered action tag list including parent ids: {tag_filtered_list}")
+
+    # Combine filters: if both are specified, use intersection (AND logic)
+    if id_filtered_list is not None and tag_filtered_list is not None:
+        combined_list = list(set(id_filtered_list) & set(tag_filtered_list))
+        ctx.logger.debug(
+            f"Combined filtered list (intersection of action-id and action-tag): "
+            f"{combined_list}")
+        return combined_list
+    if id_filtered_list is not None:
+        return id_filtered_list
+    if tag_filtered_list is not None:
+        return tag_filtered_list
+    return None
+
+
 def _process_issue_config(
         ctx: CLIContext,
         artifact_job: ArtifactJob,
@@ -834,14 +905,8 @@ def _process_issue_config(
     # All issue actions from the configuration
     issue_actions = config.issues[:]
 
-    action_id_filtered_list: Optional[list[str]] = None
-    if ctx.action_id_filter_pattern:
-        # only for the issue config processing case we are going to include
-        # also parents of actions matching the given id regexp pattern
-        action_id_filtered_list = _build_action_id_filtered_list(
-            issue_actions, ctx.action_id_filter_pattern)
-        ctx.logger.debug(
-            f"Filtered action id list including parent ids: {action_id_filtered_list}")
+    # Build combined filtered list from action-id and action-tag filters
+    action_id_filtered_list = _build_combined_action_filtered_list(ctx, issue_actions)
 
     # Processed actions (action.id : issue)
     processed_actions: dict[str, Issue] = {}

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -85,18 +85,11 @@ def _should_filter_yaml_file(
 
         # Check action_tag_filter if specified
         if action_tag_pattern:
-            action_tags = yaml_data.get('jira', {}).get('action_tags', [])
-            if action_tags:
-                # Check if any action_tag matches the pattern
-                tag_matched = any(action_tag_pattern.fullmatch(tag) for tag in action_tags)
-                if not tag_matched:
-                    logger.debug(
-                        f'Filtering {yaml_file.name} (no action_tags match filter)')
-                    return True
-            else:
-                # No action_tags in the file, filter it out
+            from newa.cli.filter_helpers import should_filter_by_action_tags
+            action_tags = yaml_data.get('jira', {}).get('action_tags')
+            if should_filter_by_action_tags(action_tags, action_tag_pattern):
                 logger.debug(
-                    f'Filtering {yaml_file.name} (no action_tags found)')
+                    f'Filtering {yaml_file.name} (no action_tags match filter)')
                 return True
 
         # Check event_filter if specified

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -38,21 +38,25 @@ def _should_filter_yaml_file(
         action_id_pattern: Optional[Pattern[str]],
         issue_id_pattern: Optional[Pattern[str]],
         event_filter_pattern: Optional['EventFilter'],
+        action_tag_pattern: Optional[Pattern[str]],
         logger: logging.Logger) -> bool:
     """
-    Check if a YAML file should be filtered out based on action_id, issue_id, and event patterns.
+    Check if a YAML file should be filtered out based on action_id, issue_id,
+    tag, and event patterns.
 
     Args:
         yaml_file: Path to the YAML file to check
         action_id_pattern: Compiled regex pattern for action_id filtering (or None)
         issue_id_pattern: Compiled regex pattern for issue_id filtering (or None)
         event_filter_pattern: EventFilter for event/artifact filtering (or None)
+        action_tag_pattern: Compiled regex pattern for tag filtering (or None)
         logger: Logger instance for debug messages
 
     Returns:
         True if the file should be filtered out (skipped), False if it should be kept
     """
-    if not action_id_pattern and not issue_id_pattern and not event_filter_pattern:
+    if (not action_id_pattern and not issue_id_pattern
+            and not event_filter_pattern and not action_tag_pattern):
         return False  # No filters, keep the file
 
     try:
@@ -77,6 +81,22 @@ def _should_filter_yaml_file(
                 logger.debug(
                     f'Filtering {yaml_file.name} (issue_id "{issue_id}" '
                     f'does not match filter)')
+                return True
+
+        # Check action_tag_filter if specified
+        if action_tag_pattern:
+            action_tags = yaml_data.get('jira', {}).get('action_tags', [])
+            if action_tags:
+                # Check if any action_tag matches the pattern
+                tag_matched = any(action_tag_pattern.fullmatch(tag) for tag in action_tags)
+                if not tag_matched:
+                    logger.debug(
+                        f'Filtering {yaml_file.name} (no action_tags match filter)')
+                    return True
+            else:
+                # No action_tags in the file, filter it out
+                logger.debug(
+                    f'Filtering {yaml_file.name} (no action_tags found)')
                 return True
 
         # Check event_filter if specified
@@ -176,6 +196,12 @@ def _should_filter_yaml_file(
          'or "erratum.release=RHEL-9.5". '
          'Supported: compose.id, erratum.id, erratum.release, rog.id.',
     )
+@click.option(
+    '--action-tag-filter',
+    default='',
+    help='Regular expression matching issue-config action tags to process (only). '
+         'Matches if any tag matches the pattern.',
+    )
 @click.pass_context
 def main(click_context: click.Context,
          state_dir: str,
@@ -190,7 +216,8 @@ def main(click_context: click.Context,
          force: bool,
          action_id_filter: str,
          issue_id_filter: str,
-         event_filter: str) -> None:
+         event_filter: str,
+         action_tag_filter: str) -> None:
     """NEWA - New Errata Workflow Automation."""
     import io
     import tarfile
@@ -254,6 +281,12 @@ def main(click_context: click.Context,
         raise Exception(
             f'Cannot compile --issue-id-filter regular expression. {e!r}') from e
 
+    try:
+        tag_pattern = re.compile(action_tag_filter) if action_tag_filter else None
+    except re.error as e:
+        raise Exception(
+            f'Cannot compile --action-tag-filter regular expression. {e!r}') from e
+
     # Parse event filter if provided
     event_filter_obj = parse_event_filter(event_filter) if event_filter else None
 
@@ -268,6 +301,7 @@ def main(click_context: click.Context,
         action_id_filter_pattern=pattern,
         issue_id_filter_pattern=issue_pattern,
         event_filter_pattern=event_filter_obj,
+        action_tag_filter_pattern=tag_pattern,
         )
     click_context.obj = ctx
 
@@ -311,7 +345,7 @@ def main(click_context: click.Context,
         initialize_state_dir(ctx)
 
         # Apply filters if specified - delete non-matching YAML files
-        if pattern or issue_pattern or event_filter_obj:
+        if pattern or issue_pattern or event_filter_obj or tag_pattern:
             yaml_files = list(ctx.state_dirpath.glob('*.yaml'))
             deleted_count = 0
             kept_count = 0
@@ -321,6 +355,7 @@ def main(click_context: click.Context,
                         pattern,
                         issue_pattern,
                         event_filter_obj,
+                        tag_pattern,
                         ctx.logger):
                     yaml_file.unlink()
                     deleted_count += 1
@@ -360,6 +395,7 @@ def main(click_context: click.Context,
                         pattern,
                         issue_pattern,
                         event_filter_obj,
+                        tag_pattern,
                         ctx.logger):
                     skipped_count += 1
                     continue

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -23,6 +23,7 @@ from newa.cli.commands.summarize_cmd import cmd_summarize
 from newa.cli.constants import NEWA_DEFAULT_CONFIG
 from newa.cli.event_helpers import parse_event_filter, should_filter_by_event
 from newa.cli.filter_helpers import should_filter_by_action_tags
+from newa.cli.tag_filter import TagFilter, parse_tag_filter
 from newa.cli.utils import get_state_dir, initialize_state_dir
 
 if TYPE_CHECKING:
@@ -39,7 +40,7 @@ def _should_filter_yaml_file(
         action_id_pattern: Optional[Pattern[str]],
         issue_id_pattern: Optional[Pattern[str]],
         event_filter_pattern: Optional['EventFilter'],
-        action_tag_pattern: Optional[Pattern[str]],
+        action_tag_filter: Optional[TagFilter],
         logger: logging.Logger) -> bool:
     """
     Check if a YAML file should be filtered out based on action_id, issue_id,
@@ -50,14 +51,14 @@ def _should_filter_yaml_file(
         action_id_pattern: Compiled regex pattern for action_id filtering (or None)
         issue_id_pattern: Compiled regex pattern for issue_id filtering (or None)
         event_filter_pattern: EventFilter for event/artifact filtering (or None)
-        action_tag_pattern: Compiled regex pattern for tag filtering (or None)
+        action_tag_filter: TagFilter for tag filtering (or None)
         logger: Logger instance for debug messages
 
     Returns:
         True if the file should be filtered out (skipped), False if it should be kept
     """
     if (not action_id_pattern and not issue_id_pattern
-            and not event_filter_pattern and not action_tag_pattern):
+            and not event_filter_pattern and not action_tag_filter):
         return False  # No filters, keep the file
 
     try:
@@ -85,9 +86,9 @@ def _should_filter_yaml_file(
                 return True
 
         # Check action_tag_filter if specified
-        if action_tag_pattern:
+        if action_tag_filter:
             action_tags = yaml_data.get('jira', {}).get('action_tags')
-            if should_filter_by_action_tags(action_tags, action_tag_pattern):
+            if should_filter_by_action_tags(action_tags, action_tag_filter):
                 logger.debug(
                     f'Filtering {yaml_file.name} (no action_tags match filter)')
                 return True
@@ -192,8 +193,11 @@ def _should_filter_yaml_file(
 @click.option(
     '--action-tag-filter',
     default='',
-    help='Regular expression matching issue-config action tags to process (only). '
-         'Matches if any tag matches the pattern.',
+    help='Filter by action tags using expression syntax. '
+         'Use "|" for OR (e.g., "regression|security"), '
+         '"," for AND (e.g., "smoke,rhel-9"), '
+         'and "!" for NOT (e.g., "!slow"). '
+         'Can combine: "regression|security,!slow".',
     )
 @click.pass_context
 def main(click_context: click.Context,
@@ -274,11 +278,12 @@ def main(click_context: click.Context,
         raise Exception(
             f'Cannot compile --issue-id-filter regular expression. {e!r}') from e
 
+    # Parse tag filter if provided
     try:
-        tag_pattern = re.compile(action_tag_filter) if action_tag_filter else None
-    except re.error as e:
-        raise Exception(
-            f'Cannot compile --action-tag-filter regular expression. {e!r}') from e
+        tag_filter_obj = parse_tag_filter(action_tag_filter) if action_tag_filter else None
+    except ValueError as e:
+        raise click.ClickException(
+            f'Cannot parse --action-tag-filter expression: {e}') from e
 
     # Parse event filter if provided
     event_filter_obj = parse_event_filter(event_filter) if event_filter else None
@@ -294,7 +299,7 @@ def main(click_context: click.Context,
         action_id_filter_pattern=pattern,
         issue_id_filter_pattern=issue_pattern,
         event_filter_pattern=event_filter_obj,
-        action_tag_filter_pattern=tag_pattern,
+        action_tag_filter_pattern=tag_filter_obj,
         )
     click_context.obj = ctx
 
@@ -338,7 +343,7 @@ def main(click_context: click.Context,
         initialize_state_dir(ctx)
 
         # Apply filters if specified - delete non-matching YAML files
-        if pattern or issue_pattern or event_filter_obj or tag_pattern:
+        if pattern or issue_pattern or event_filter_obj or tag_filter_obj:
             yaml_files = list(ctx.state_dirpath.glob('*.yaml'))
             deleted_count = 0
             kept_count = 0
@@ -348,7 +353,7 @@ def main(click_context: click.Context,
                         pattern,
                         issue_pattern,
                         event_filter_obj,
-                        tag_pattern,
+                        tag_filter_obj,
                         ctx.logger):
                     yaml_file.unlink()
                     deleted_count += 1
@@ -388,7 +393,7 @@ def main(click_context: click.Context,
                         pattern,
                         issue_pattern,
                         event_filter_obj,
-                        tag_pattern,
+                        tag_filter_obj,
                         ctx.logger):
                     skipped_count += 1
                     continue

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -22,6 +22,7 @@ from newa.cli.commands.schedule_cmd import cmd_schedule
 from newa.cli.commands.summarize_cmd import cmd_summarize
 from newa.cli.constants import NEWA_DEFAULT_CONFIG
 from newa.cli.event_helpers import parse_event_filter, should_filter_by_event
+from newa.cli.filter_helpers import should_filter_by_action_tags
 from newa.cli.utils import get_state_dir, initialize_state_dir
 
 if TYPE_CHECKING:
@@ -85,7 +86,6 @@ def _should_filter_yaml_file(
 
         # Check action_tag_filter if specified
         if action_tag_pattern:
-            from newa.cli.filter_helpers import should_filter_by_action_tags
             action_tags = yaml_data.get('jira', {}).get('action_tags')
             if should_filter_by_action_tags(action_tags, action_tag_pattern):
                 logger.debug(

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -195,7 +195,7 @@ def _process_jira_job(
     # Check auto_schedule setting unless overridden by filters or --schedule-all
     #
     # Priority order for scheduling decisions:
-    # 1. Filters (--action-id-filter, --issue-id-filter)
+    # 1. Filters (--action-id-filter, --issue-id-filter, --action-tag-filter)
     #    - If present, load_jira_jobs() only loads matching jobs
     #    - We then override auto_schedule=False for those matching jobs
     # 2. --schedule-all flag
@@ -205,10 +205,12 @@ def _process_jira_job(
     auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
     if not schedule_all and not auto_schedule:
         # Check if filters are being used - they override auto_schedule
-        if not (ctx.action_id_filter_pattern or ctx.issue_id_filter_pattern):
+        if not (ctx.action_id_filter_pattern or ctx.issue_id_filter_pattern
+                or ctx.action_tag_filter_pattern):
             ctx.logger.info(
                 f'Skipping jira job {jira_job.jira.id} - auto_schedule is disabled. '
-                f'Use --schedule-all or --action-id-filter/--issue-id-filter to override.')
+                f'Use --schedule-all or --action-id-filter/--issue-id-filter/'
+                f'--action-tag-filter to override.')
             return
         # Filters are present, so we override auto_schedule
         ctx.logger.info(

--- a/newa/cli/tag_filter.py
+++ b/newa/cli/tag_filter.py
@@ -1,0 +1,156 @@
+"""Tag filter expression parser and evaluator.
+
+Supports a simple expression syntax for filtering by action tags:
+- "|" = OR (match any of these tags)
+- "," = AND (match all of these conditions)
+- "!" = NOT (exclude these tags)
+
+Examples:
+    "regression|security"        - Match if action has 'regression' OR 'security' tag
+    "smoke,rhel-9"              - Match if action has BOTH 'smoke' AND 'rhel-9' tags
+    "!slow"                     - Match if action does NOT have 'slow' tag
+    "regression|security,!slow" - Match if has (regression OR security) AND NOT slow
+    "smoke,rhel-.*"             - Match if has 'smoke' AND a tag matching 'rhel-.*' regex
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TagFilter:
+    """Parsed tag filter expression."""
+    any_patterns: list[re.Pattern[str]]  # OR conditions (at least one must match)
+    all_patterns: list[re.Pattern[str]]  # AND conditions (all must match)
+    none_patterns: list[re.Pattern[str]]  # NOT conditions (none can match)
+
+    def matches(self, action_tags: Optional[list[str]]) -> bool:
+        """
+        Check if the given action_tags match this filter.
+
+        Args:
+            action_tags: List of action tags (or None/empty if no tags)
+
+        Returns:
+            True if the tags match the filter, False otherwise.
+        """
+        if not action_tags:
+            # No tags on the action
+            # If we only have NONE patterns, consider it a match (nothing to exclude)
+            # If we have ANY or ALL patterns, it's not a match (missing required tags)
+            if self.none_patterns and not (self.any_patterns or self.all_patterns):
+                return True
+            # Only matches if we have no requirements (empty filter)
+            return not (self.any_patterns or self.all_patterns or self.none_patterns)
+
+        # Check NOT conditions first (highest priority)
+        for pattern in self.none_patterns:
+            if any(pattern.fullmatch(tag) for tag in action_tags):
+                return False
+
+        # Check ALL conditions (all patterns must match at least one tag)
+        for pattern in self.all_patterns:
+            if not any(pattern.fullmatch(tag) for tag in action_tags):
+                return False
+
+        # Check ANY conditions (at least one pattern must match at least one tag)
+        # If no ANY patterns, this is a match. Otherwise, at least one must match.
+        return not self.any_patterns or any(
+            pattern.fullmatch(tag)
+            for pattern in self.any_patterns
+            for tag in action_tags
+            )
+
+
+def parse_tag_filter(filter_str: str) -> TagFilter:
+    """
+    Parse a tag filter expression into a TagFilter object.
+
+    The expression format is: "pattern1|pattern2,pattern3,!pattern4"
+    - "|" separates OR patterns (match any)
+    - "," separates AND groups (match all)
+    - "!" prefix indicates NOT patterns (exclude)
+
+    Each pattern is treated as a regex pattern for matching tags.
+
+    Args:
+        filter_str: The filter expression string
+
+    Returns:
+        TagFilter object with compiled regex patterns
+
+    Raises:
+        ValueError: If the filter expression is invalid or contains bad regex patterns
+
+    Examples:
+        >>> f = parse_tag_filter("regression|security")
+        >>> f.matches(["regression"])
+        True
+        >>> f.matches(["other"])
+        False
+
+        >>> f = parse_tag_filter("smoke,rhel-9")
+        >>> f.matches(["smoke", "rhel-9"])
+        True
+        >>> f.matches(["smoke"])
+        False
+
+        >>> f = parse_tag_filter("!slow")
+        >>> f.matches(["fast"])
+        True
+        >>> f.matches(["slow"])
+        False
+    """
+    if not filter_str or not filter_str.strip():
+        return TagFilter(any_patterns=[], all_patterns=[], none_patterns=[])
+
+    any_patterns: list[re.Pattern[str]] = []
+    all_patterns: list[re.Pattern[str]] = []
+    none_patterns: list[re.Pattern[str]] = []
+
+    # Split by comma to get AND groups
+    and_groups = [g.strip() for g in filter_str.split(',') if g.strip()]
+
+    for group in and_groups:
+        # Check if this is a NOT pattern
+        if group.startswith('!'):
+            pattern_str = group[1:].strip()
+            if not pattern_str:
+                raise ValueError(f"Empty pattern after '!' in filter: {filter_str}")
+            # Check for invalid combination of NOT with OR
+            if '|' in pattern_str:
+                raise ValueError(
+                    f"NOT patterns (!) cannot be combined with OR (|): {group}")
+            try:
+                none_patterns.append(re.compile(pattern_str))
+            except re.error as e:
+                raise ValueError(
+                    f"Invalid regex pattern '{pattern_str}' in filter: {e}") from e
+        # Check if this group contains OR patterns
+        elif '|' in group:
+            or_patterns = [p.strip() for p in group.split('|') if p.strip()]
+            for pattern_str in or_patterns:
+                if pattern_str.startswith('!'):
+                    raise ValueError(
+                        f"NOT patterns (!) cannot be combined with OR (|): {group}")
+                try:
+                    any_patterns.append(re.compile(pattern_str))
+                except re.error as e:
+                    raise ValueError(
+                        f"Invalid regex pattern '{pattern_str}' in filter: {e}") from e
+        # Regular AND pattern
+        else:
+            pattern_str = group.strip()
+            if not pattern_str:
+                continue
+            try:
+                all_patterns.append(re.compile(pattern_str))
+            except re.error as e:
+                raise ValueError(
+                    f"Invalid regex pattern '{pattern_str}' in filter: {e}") from e
+
+    return TagFilter(
+        any_patterns=any_patterns,
+        all_patterns=all_patterns,
+        none_patterns=none_patterns)

--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -47,6 +47,38 @@ def _default_action_id_generator() -> Generator[str, int, None]:
 default_action_id = _default_action_id_generator()
 
 
+def _normalize_action_tags(tags: Optional[Union[str, list[str]]]) -> Optional[list[str]]:
+    """
+    Normalize action_tags to always be a list[str] or None.
+
+    Handles the common mistake of providing a single string instead of a list.
+
+    Args:
+        tags: Either None, a string, or a list of strings
+
+    Returns:
+        None if tags is None, otherwise a list of strings
+
+    Raises:
+        TypeError: If tags is not None, str, or list[str]
+    """
+    if tags is None:
+        return None
+    if isinstance(tags, str):
+        # Auto-correct: wrap single string in a list
+        return [tags]
+    if isinstance(tags, list):
+        # Validate all elements are strings
+        for i, tag in enumerate(tags):
+            if not isinstance(tag, str):
+                raise TypeError(
+                    f"action_tags must be a list of strings, but element at index {i} "
+                    f"is {type(tag).__name__}: {tag!r}")
+        return tags
+    raise TypeError(
+        f"action_tags must be a string or list of strings, got {type(tags).__name__}: {tags!r}")
+
+
 @define
 class Issue(Serializable):  # type: ignore[no-untyped-def]
     """Issue - a key in Jira (eg. NEWA-123)."""
@@ -68,7 +100,8 @@ class Issue(Serializable):  # type: ignore[no-untyped-def]
     transition_processed: Optional[str] = None
     transition_passed: Optional[str] = None
     action_id: Optional[str] = None
-    action_tags: Optional[list[str]] = None
+    action_tags: Optional[list[str]] = field(
+        converter=_normalize_action_tags, default=None)
 
     def __str__(self) -> str:
         return self.id
@@ -102,7 +135,8 @@ class IssueAction(Serializable):  # type: ignore[no-untyped-def]
     environment: Optional[RecipeEnvironment] = None
     links: Optional[dict[str, list[str]]] = None
     schedule: Union[bool, str] = True
-    action_tags: Optional[list[str]] = None
+    action_tags: Optional[list[str]] = field(
+        converter=_normalize_action_tags, default=None)
 
     # function to handle issue-config file defaults
 

--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -68,6 +68,7 @@ class Issue(Serializable):  # type: ignore[no-untyped-def]
     transition_processed: Optional[str] = None
     transition_passed: Optional[str] = None
     action_id: Optional[str] = None
+    action_tags: Optional[list[str]] = field(factory=list)
 
     def __str__(self) -> str:
         return self.id
@@ -101,6 +102,7 @@ class IssueAction(Serializable):  # type: ignore[no-untyped-def]
     environment: Optional[RecipeEnvironment] = None
     links: Optional[dict[str, list[str]]] = None
     schedule: Union[bool, str] = True
+    action_tags: Optional[list[str]] = field(factory=list)
 
     # function to handle issue-config file defaults
 

--- a/newa/models/issues.py
+++ b/newa/models/issues.py
@@ -68,7 +68,7 @@ class Issue(Serializable):  # type: ignore[no-untyped-def]
     transition_processed: Optional[str] = None
     transition_passed: Optional[str] = None
     action_id: Optional[str] = None
-    action_tags: Optional[list[str]] = field(factory=list)
+    action_tags: Optional[list[str]] = None
 
     def __str__(self) -> str:
         return self.id
@@ -102,7 +102,7 @@ class IssueAction(Serializable):  # type: ignore[no-untyped-def]
     environment: Optional[RecipeEnvironment] = None
     links: Optional[dict[str, list[str]]] = None
     schedule: Union[bool, str] = True
-    action_tags: Optional[list[str]] = field(factory=list)
+    action_tags: Optional[list[str]] = None
 
     # function to handle issue-config file defaults
 

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -521,12 +521,21 @@ class CLIContext:  # type: ignore[no-untyped-def]
         if should_filter:
             # Action should be filtered out - log it
             if not action_tags:
-                self.logger.debug(
-                    "Skipping action with no tags as --action-tag-filter is specified.")
+                if log_message:
+                    self.logger.info(
+                        "Skipping action with no tags as --action-tag-filter is specified.")
+                else:
+                    self.logger.debug(
+                        "Skipping action with no tags as --action-tag-filter is specified.")
             else:
-                self.logger.debug(
-                    f"Skipping action with tags {action_tags} as none match "
-                    "the --action-tag-filter regular expression.")
+                if log_message:
+                    self.logger.info(
+                        f"Skipping action with tags {action_tags} as none match "
+                        "the --action-tag-filter regular expression.")
+                else:
+                    self.logger.debug(
+                        f"Skipping action with tags {action_tags} as none match "
+                        "the --action-tag-filter regular expression.")
         else:
             # Action matches - log the matching tag at debug level
             if action_tags:
@@ -541,22 +550,23 @@ class CLIContext:  # type: ignore[no-untyped-def]
 
     def skip_action(self,
                     action_id: Optional[str],
-                    filtered_id_list: Optional[list[str]] = None,
-                    log_message: bool = True) -> bool:
+                    filtered_id_list: Optional[list[str]] = None) -> bool:
+        """Check if action should be skipped based on filtered list.
+
+        Args:
+            action_id: The action ID to check
+            filtered_id_list: List of action IDs that should be processed (not skipped)
+
+        Returns:
+            True if action should be skipped, False if it should be processed
+        """
         if filtered_id_list is None:
             return False
         if action_id and action_id in filtered_id_list:
-            self.logger.debug(
-                f"Action {action_id} matches the filter regular expression.")
+            self.logger.debug(f"Action {action_id} matches the user provided filter.")
             return False
-        if log_message:
-            self.logger.info(
-                f"Skipping action {action_id} as it doesn't match "
-                "the filter regular expression.")
-        else:
-            self.logger.debug(
-                f"Skipping action {action_id} as it doesn't match "
-                "the filter regular expression.")
+        self.logger.info(
+            f"Skipping action {action_id} as it doesn't match the user provided filter.")
         return True
 
     def get_jira_connection(self) -> 'JiraConnection':

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -236,6 +236,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
     action_id_filter_pattern: Optional[Pattern[str]] = None
     issue_id_filter_pattern: Optional[Pattern[str]] = None
     event_filter_pattern: Optional[EventFilter] = None
+    action_tag_filter_pattern: Optional[Pattern[str]] = None
 
     # Jira connection instance (lazy initialized)
     jira_connection: Optional['JiraConnection'] = field(default=None, init=False, repr=False)
@@ -319,6 +320,8 @@ class CLIContext:  # type: ignore[no-untyped-def]
                     continue
                 if self._should_filter_by_issue_id(job.jira.id):
                     continue
+                if self._should_filter_by_action_tags(job.jira.action_tags):
+                    continue
                 if self.should_filter_job(job):
                     continue
             yield job
@@ -345,6 +348,8 @@ class CLIContext:  # type: ignore[no-untyped-def]
                     continue
                 if self._should_filter_by_issue_id(job.jira.id):
                     continue
+                if self._should_filter_by_action_tags(job.jira.action_tags):
+                    continue
                 if self.should_filter_job(job):
                     continue
             yield job
@@ -370,6 +375,8 @@ class CLIContext:  # type: ignore[no-untyped-def]
                 if self._should_filter_by_action_id(job.jira.action_id):
                     continue
                 if self._should_filter_by_issue_id(job.jira.id):
+                    continue
+                if self._should_filter_by_action_tags(job.jira.action_tags):
                     continue
                 if self.should_filter_job(job):
                     continue
@@ -494,6 +501,46 @@ class CLIContext:  # type: ignore[no-untyped-def]
             f"Issue {issue_id} matches the --issue-id-filter "
             "regular expression.")
         return False
+
+    def _should_filter_by_action_tags(
+            self,
+            action_tags: Optional[list[str]],
+            log_message: bool = True) -> bool:
+        """Check if job should be filtered out based on action_tags pattern.
+
+        Returns True if the job should be skipped, False if it should be processed.
+        """
+        if not self.action_tag_filter_pattern:
+            return False
+
+        if not action_tags:
+            # No tags, filter it out
+            if log_message:
+                self.logger.info(
+                    "Skipping action with no tags as --action-tag-filter is specified.")
+            else:
+                self.logger.debug(
+                    "Skipping action with no tags as --action-tag-filter is specified.")
+            return True
+
+        # Check if any tag matches the pattern
+        for tag in action_tags:
+            if self.action_tag_filter_pattern.fullmatch(tag):
+                self.logger.debug(
+                    f"Action tag '{tag}' matches the --action-tag-filter "
+                    "regular expression.")
+                return False
+
+        # No tags matched
+        if log_message:
+            self.logger.info(
+                f"Skipping action with tags {action_tags} as none match "
+                "the --action-tag-filter regular expression.")
+        else:
+            self.logger.debug(
+                f"Skipping action with tags {action_tags} as none match "
+                "the --action-tag-filter regular expression.")
+        return True
 
     def skip_action(self,
                     action_id: Optional[str],

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -513,34 +513,31 @@ class CLIContext:  # type: ignore[no-untyped-def]
         if not self.action_tag_filter_pattern:
             return False
 
-        if not action_tags:
-            # No tags, filter it out
-            if log_message:
-                self.logger.info(
+        from newa.cli.filter_helpers import should_filter_by_action_tags
+
+        # Use shared helper for the actual filtering logic
+        should_filter = should_filter_by_action_tags(action_tags, self.action_tag_filter_pattern)
+
+        if should_filter:
+            # Action should be filtered out - log it
+            if not action_tags:
+                self.logger.debug(
                     "Skipping action with no tags as --action-tag-filter is specified.")
             else:
                 self.logger.debug(
-                    "Skipping action with no tags as --action-tag-filter is specified.")
-            return True
-
-        # Check if any tag matches the pattern
-        for tag in action_tags:
-            if self.action_tag_filter_pattern.fullmatch(tag):
-                self.logger.debug(
-                    f"Action tag '{tag}' matches the --action-tag-filter "
-                    "regular expression.")
-                return False
-
-        # No tags matched
-        if log_message:
-            self.logger.info(
-                f"Skipping action with tags {action_tags} as none match "
-                "the --action-tag-filter regular expression.")
+                    f"Skipping action with tags {action_tags} as none match "
+                    "the --action-tag-filter regular expression.")
         else:
-            self.logger.debug(
-                f"Skipping action with tags {action_tags} as none match "
-                "the --action-tag-filter regular expression.")
-        return True
+            # Action matches - log the matching tag at debug level
+            if action_tags:
+                for tag in action_tags:
+                    if self.action_tag_filter_pattern.fullmatch(tag):
+                        self.logger.debug(
+                            f"Action tag '{tag}' matches the --action-tag-filter "
+                            "regular expression.")
+                        break
+
+        return should_filter
 
     def skip_action(self,
                     action_id: Optional[str],
@@ -550,16 +547,16 @@ class CLIContext:  # type: ignore[no-untyped-def]
             return False
         if action_id and action_id in filtered_id_list:
             self.logger.debug(
-                f"Action {action_id} matches the --action-id-filter regular expression.")
+                f"Action {action_id} matches the filter regular expression.")
             return False
         if log_message:
             self.logger.info(
                 f"Skipping action {action_id} as it doesn't match "
-                "the --action-id-filter regular expression.")
+                "the filter regular expression.")
         else:
             self.logger.debug(
                 f"Skipping action {action_id} as it doesn't match "
-                "the --action-id-filter regular expression.")
+                "the filter regular expression.")
         return True
 
     def get_jira_connection(self) -> 'JiraConnection':

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -18,6 +18,7 @@ from newa.models.execution import RequestResult
 from newa.models.recipes import RecipeContext, RecipeEnvironment
 
 if TYPE_CHECKING:
+    from newa.cli.tag_filter import TagFilter
     from newa.models.jobs import ArtifactJob, ExecuteJob, JiraJob, ScheduleJob
     from newa.services.jira_connection import JiraConnection
 
@@ -236,7 +237,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
     action_id_filter_pattern: Optional[Pattern[str]] = None
     issue_id_filter_pattern: Optional[Pattern[str]] = None
     event_filter_pattern: Optional[EventFilter] = None
-    action_tag_filter_pattern: Optional[Pattern[str]] = None
+    action_tag_filter_pattern: Optional['TagFilter'] = None
 
     # Jira connection instance (lazy initialized)
     jira_connection: Optional['JiraConnection'] = field(default=None, init=False, repr=False)
@@ -506,7 +507,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
             self,
             action_tags: Optional[list[str]],
             log_message: bool = True) -> bool:
-        """Check if job should be filtered out based on action_tags pattern.
+        """Check if job should be filtered out based on action_tags filter.
 
         Returns True if the job should be skipped, False if it should be processed.
         """
@@ -530,21 +531,16 @@ class CLIContext:  # type: ignore[no-untyped-def]
             else:
                 if log_message:
                     self.logger.info(
-                        f"Skipping action with tags {action_tags} as none match "
-                        "the --action-tag-filter regular expression.")
+                        f"Skipping action with tags {action_tags} as they don't match "
+                        "the --action-tag-filter expression.")
                 else:
                     self.logger.debug(
-                        f"Skipping action with tags {action_tags} as none match "
-                        "the --action-tag-filter regular expression.")
+                        f"Skipping action with tags {action_tags} as they don't match "
+                        "the --action-tag-filter expression.")
         else:
-            # Action matches - log the matching tag at debug level
-            if action_tags:
-                for tag in action_tags:
-                    if self.action_tag_filter_pattern.fullmatch(tag):
-                        self.logger.debug(
-                            f"Action tag '{tag}' matches the --action-tag-filter "
-                            "regular expression.")
-                        break
+            # Action matches - log at debug level
+            self.logger.debug(
+                f"Action tags {action_tags} match the --action-tag-filter expression.")
 
         return should_filter
 

--- a/tests/unit/test_action_tag_filter_cli.py
+++ b/tests/unit/test_action_tag_filter_cli.py
@@ -1,0 +1,269 @@
+"""Tests for --action-tag-filter CLI option and YAML file filtering."""
+import re
+from unittest import mock
+
+import pytest
+
+from newa import CLIContext, Settings
+from newa.cli.main import _should_filter_yaml_file
+
+
+@pytest.fixture
+def mock_logger():
+    """Return a mocked logger."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def temp_yaml_files(tmp_path):
+    """Create temporary YAML files for testing."""
+    # Create YAML file with action_tags
+    yaml_with_tags = tmp_path / 'jira-001.yaml'
+    yaml_with_tags.write_text("""
+jira:
+  id: RHEL-12345
+  action_id: tier1_tests
+  action_tags:
+    - tier1
+    - regression
+  summary: Test Issue 1
+""")
+
+    # Create YAML file with different action_tags
+    yaml_with_other_tags = tmp_path / 'jira-002.yaml'
+    yaml_with_other_tags.write_text("""
+jira:
+  id: RHEL-12346
+  action_id: tier2_tests
+  action_tags:
+    - tier2
+    - performance
+  summary: Test Issue 2
+""")
+
+    # Create YAML file without action_tags
+    yaml_without_tags = tmp_path / 'jira-003.yaml'
+    yaml_without_tags.write_text("""
+jira:
+  id: RHEL-12347
+  action_id: build_tests
+  summary: Test Issue 3
+""")
+
+    # Create YAML file with empty action_tags
+    yaml_with_empty_tags = tmp_path / 'jira-004.yaml'
+    yaml_with_empty_tags.write_text("""
+jira:
+  id: RHEL-12348
+  action_id: other_tests
+  action_tags: []
+  summary: Test Issue 4
+""")
+
+    return {
+        'with_tags': yaml_with_tags,
+        'with_other_tags': yaml_with_other_tags,
+        'without_tags': yaml_without_tags,
+        'with_empty_tags': yaml_with_empty_tags,
+        }
+
+
+class TestShouldFilterYamlFile:
+    """Tests for _should_filter_yaml_file with action_tag_filter."""
+
+    def test_no_filters_keeps_all_files(self, temp_yaml_files, mock_logger):
+        """When no filters are specified, all files should be kept."""
+        for yaml_file in temp_yaml_files.values():
+            result = _should_filter_yaml_file(
+                yaml_file, None, None, None, None, mock_logger)
+            assert result is False
+
+    def test_tag_filter_matches_keeps_file(self, temp_yaml_files, mock_logger):
+        """When tag filter matches, file should be kept."""
+        tag_pattern = re.compile(r'tier1')
+        result = _should_filter_yaml_file(
+            temp_yaml_files['with_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result is False
+
+    def test_tag_filter_no_match_filters_file(self, temp_yaml_files, mock_logger):
+        """When tag filter doesn't match, file should be filtered."""
+        tag_pattern = re.compile(r'tier1')
+        result = _should_filter_yaml_file(
+            temp_yaml_files['with_other_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result is True
+
+    def test_tag_filter_pattern_matches_multiple(self, temp_yaml_files, mock_logger):
+        """When tag filter pattern matches multiple tags, file should be kept."""
+        tag_pattern = re.compile(r'tier.*')
+        # Should match both tier1 and tier2
+        result1 = _should_filter_yaml_file(
+            temp_yaml_files['with_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result1 is False
+
+        result2 = _should_filter_yaml_file(
+            temp_yaml_files['with_other_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result2 is False
+
+    def test_tag_filter_with_no_tags_filters_file(self, temp_yaml_files, mock_logger):
+        """When file has no action_tags field, it should be filtered."""
+        tag_pattern = re.compile(r'tier.*')
+        result = _should_filter_yaml_file(
+            temp_yaml_files['without_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result is True
+
+    def test_tag_filter_with_empty_tags_filters_file(self, temp_yaml_files, mock_logger):
+        """When file has empty action_tags list, it should be filtered."""
+        tag_pattern = re.compile(r'tier.*')
+        result = _should_filter_yaml_file(
+            temp_yaml_files['with_empty_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result is True
+
+    def test_tag_filter_matches_any_tag(self, temp_yaml_files, mock_logger):
+        """When any tag matches pattern, file should be kept."""
+        # Pattern matches 'regression' in the tag list ['tier1', 'regression']
+        tag_pattern = re.compile(r'regression')
+        result = _should_filter_yaml_file(
+            temp_yaml_files['with_tags'],
+            None, None, None, tag_pattern, mock_logger)
+        assert result is False
+
+    def test_combined_action_id_and_tag_filters(self, temp_yaml_files, mock_logger):
+        """When both action_id and tag filters are specified, both must match."""
+        action_id_pattern = re.compile(r'tier1.*')
+        tag_pattern = re.compile(r'regression')
+
+        # File with matching action_id and matching tag
+        result = _should_filter_yaml_file(
+            temp_yaml_files['with_tags'],
+            action_id_pattern, None, None, tag_pattern, mock_logger)
+        assert result is False
+
+        # File with non-matching action_id but matching tag - should be filtered
+        result2 = _should_filter_yaml_file(
+            temp_yaml_files['with_other_tags'],
+            action_id_pattern, None, None, tag_pattern, mock_logger)
+        assert result2 is True
+
+
+class TestActionTagFilterWithCLIContext:
+    """Integration tests for action_tag_filter with CLIContext."""
+
+    def test_ctx_with_tag_filter_loads_matching_jobs(self, tmp_path, mock_logger):
+        """Test that CLIContext only loads jobs matching tag filter."""
+        from newa.models.events import Event, EventType
+        from newa.models.issues import Issue
+        from newa.models.jobs import JiraJob
+        from newa.models.recipes import Recipe
+
+        # Create two jira jobs with different tags
+        job1 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-123',
+                summary='Test 1',
+                url='http://test.com/RHEL-123',
+                action_tags=['tier1', 'regression']),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job1.to_yaml_file(tmp_path / 'jira-001.yaml')
+
+        job2 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-456',
+                summary='Test 2',
+                url='http://test.com/RHEL-456',
+                action_tags=['tier2', 'performance']),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job2.to_yaml_file(tmp_path / 'jira-002.yaml')
+
+        job3 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-789',
+                summary='Test 3',
+                url='http://test.com/RHEL-789'),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job3.to_yaml_file(tmp_path / 'jira-003.yaml')
+
+        # Create context with tag filter for 'tier1'
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_tag_filter_pattern=re.compile(r'tier1'))
+
+        # Load jira jobs with filter_actions=True - should only get job1
+        jobs = list(ctx.load_jira_jobs('jira', filter_actions=True))
+        assert len(jobs) == 1
+        assert jobs[0].jira.id == 'RHEL-123'
+
+    def test_ctx_with_tag_filter_pattern_matches_multiple(self, tmp_path, mock_logger):
+        """Test that tag filter pattern can match multiple jobs."""
+        from newa.models.events import Event, EventType
+        from newa.models.issues import Issue
+        from newa.models.jobs import JiraJob
+        from newa.models.recipes import Recipe
+
+        job1 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-123',
+                summary='Test 1',
+                url='http://test.com/RHEL-123',
+                action_tags=['tier1']),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job1.to_yaml_file(tmp_path / 'jira-001.yaml')
+
+        job2 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-456',
+                summary='Test 2',
+                url='http://test.com/RHEL-456',
+                action_tags=['tier2']),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job2.to_yaml_file(tmp_path / 'jira-002.yaml')
+
+        job3 = JiraJob(
+            event=Event(id='test', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=None,
+            jira=Issue(
+                'RHEL-789',
+                summary='Test 3',
+                url='http://test.com/RHEL-789',
+                action_tags=['performance']),
+            recipe=Recipe(url='http://example.com/recipe.yaml'))
+        job3.to_yaml_file(tmp_path / 'jira-003.yaml')
+
+        # Create context with tag filter for 'tier.*'
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_tag_filter_pattern=re.compile(r'tier.*'))
+
+        # Load jira jobs with filter_actions=True - should get job1 and job2
+        jobs = list(ctx.load_jira_jobs('jira', filter_actions=True))
+        assert len(jobs) == 2
+        assert {job.jira.id for job in jobs} == {'RHEL-123', 'RHEL-456'}

--- a/tests/unit/test_action_tag_filter_cli.py
+++ b/tests/unit/test_action_tag_filter_cli.py
@@ -1,11 +1,11 @@
 """Tests for --action-tag-filter CLI option and YAML file filtering."""
-import re
 from unittest import mock
 
 import pytest
 
 from newa import CLIContext, Settings
 from newa.cli.main import _should_filter_yaml_file
+from newa.cli.tag_filter import parse_tag_filter
 
 
 @pytest.fixture
@@ -80,74 +80,75 @@ class TestShouldFilterYamlFile:
 
     def test_tag_filter_matches_keeps_file(self, temp_yaml_files, mock_logger):
         """When tag filter matches, file should be kept."""
-        tag_pattern = re.compile(r'tier1')
+        tag_filter = parse_tag_filter('tier1')
         result = _should_filter_yaml_file(
             temp_yaml_files['with_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result is False
 
     def test_tag_filter_no_match_filters_file(self, temp_yaml_files, mock_logger):
         """When tag filter doesn't match, file should be filtered."""
-        tag_pattern = re.compile(r'tier1')
+        tag_filter = parse_tag_filter('tier1')
         result = _should_filter_yaml_file(
             temp_yaml_files['with_other_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result is True
 
     def test_tag_filter_pattern_matches_multiple(self, temp_yaml_files, mock_logger):
         """When tag filter pattern matches multiple tags, file should be kept."""
-        tag_pattern = re.compile(r'tier.*')
+        tag_filter = parse_tag_filter('tier.*')
         # Should match both tier1 and tier2
         result1 = _should_filter_yaml_file(
             temp_yaml_files['with_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result1 is False
 
         result2 = _should_filter_yaml_file(
             temp_yaml_files['with_other_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result2 is False
 
     def test_tag_filter_with_no_tags_filters_file(self, temp_yaml_files, mock_logger):
         """When file has no action_tags field, it should be filtered."""
-        tag_pattern = re.compile(r'tier.*')
+        tag_filter = parse_tag_filter('tier.*')
         result = _should_filter_yaml_file(
             temp_yaml_files['without_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result is True
 
     def test_tag_filter_with_empty_tags_filters_file(self, temp_yaml_files, mock_logger):
         """When file has empty action_tags list, it should be filtered."""
-        tag_pattern = re.compile(r'tier.*')
+        tag_filter = parse_tag_filter('tier.*')
         result = _should_filter_yaml_file(
             temp_yaml_files['with_empty_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result is True
 
     def test_tag_filter_matches_any_tag(self, temp_yaml_files, mock_logger):
         """When any tag matches pattern, file should be kept."""
         # Pattern matches 'regression' in the tag list ['tier1', 'regression']
-        tag_pattern = re.compile(r'regression')
+        tag_filter = parse_tag_filter('regression')
         result = _should_filter_yaml_file(
             temp_yaml_files['with_tags'],
-            None, None, None, tag_pattern, mock_logger)
+            None, None, None, tag_filter, mock_logger)
         assert result is False
 
     def test_combined_action_id_and_tag_filters(self, temp_yaml_files, mock_logger):
         """When both action_id and tag filters are specified, both must match."""
+        import re
         action_id_pattern = re.compile(r'tier1.*')
-        tag_pattern = re.compile(r'regression')
+        tag_filter = parse_tag_filter('regression')
 
         # File with matching action_id and matching tag
         result = _should_filter_yaml_file(
             temp_yaml_files['with_tags'],
-            action_id_pattern, None, None, tag_pattern, mock_logger)
+            action_id_pattern, None, None, tag_filter, mock_logger)
         assert result is False
 
         # File with non-matching action_id but matching tag - should be filtered
         result2 = _should_filter_yaml_file(
             temp_yaml_files['with_other_tags'],
-            action_id_pattern, None, None, tag_pattern, mock_logger)
+            action_id_pattern, None, None, tag_filter, mock_logger)
         assert result2 is True
 
 
@@ -204,7 +205,7 @@ class TestActionTagFilterWithCLIContext:
             state_dirpath=tmp_path,
             cli_environment={},
             cli_context={},
-            action_tag_filter_pattern=re.compile(r'tier1'))
+            action_tag_filter_pattern=parse_tag_filter('tier1'))
 
         # Load jira jobs with filter_actions=True - should only get job1
         jobs = list(ctx.load_jira_jobs('jira', filter_actions=True))
@@ -261,7 +262,7 @@ class TestActionTagFilterWithCLIContext:
             state_dirpath=tmp_path,
             cli_environment={},
             cli_context={},
-            action_tag_filter_pattern=re.compile(r'tier.*'))
+            action_tag_filter_pattern=parse_tag_filter('tier.*'))
 
         # Load jira jobs with filter_actions=True - should get job1 and job2
         jobs = list(ctx.load_jira_jobs('jira', filter_actions=True))

--- a/tests/unit/test_combined_filters.py
+++ b/tests/unit/test_combined_filters.py
@@ -1,0 +1,307 @@
+"""Tests for combined action-id and action-tag filtering."""
+import re
+from unittest import mock
+
+import pytest
+
+from newa import CLIContext, Settings
+from newa.cli.jira_helpers import _build_combined_action_filtered_list
+from newa.models.issues import IssueAction
+
+
+@pytest.fixture
+def mock_logger():
+    """Return a mocked logger."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def sample_actions():
+    """Return a sample list of IssueAction objects for testing."""
+    return [
+        # Parent action with tier1 tag
+        IssueAction(id='setup', action_tags=['tier1', 'setup']),
+
+        # Child actions with various tags and IDs
+        IssueAction(id='test_tier1_security', parent_id='setup',
+                    action_tags=['tier1', 'security']),
+        IssueAction(id='test_tier2_security', parent_id='setup',
+                    action_tags=['tier2', 'security']),
+        IssueAction(id='test_tier1_performance', parent_id='setup',
+                    action_tags=['tier1', 'performance']),
+        IssueAction(id='test_tier2_performance', parent_id='setup',
+                    action_tags=['tier2', 'performance']),
+
+        # Actions with tier1 in ID but not in tags
+        IssueAction(id='build_tier1', action_tags=['build', 'nightly']),
+
+        # Actions with tier1 in tags but not in ID
+        IssueAction(id='regression_tests', action_tags=['tier1', 'regression']),
+
+        # Actions with neither tier1 in ID nor tags
+        IssueAction(id='cleanup', action_tags=['maintenance']),
+
+        # Grandparent-parent-child hierarchy
+        IssueAction(id='grandparent', action_tags=['base']),
+        IssueAction(id='parent', parent_id='grandparent',
+                    action_tags=['tier2']),
+        IssueAction(id='child_tier1_smoke', parent_id='parent',
+                    action_tags=['tier1', 'smoke']),
+        ]
+
+
+class TestCombinedFilters:
+    """Tests for _build_combined_action_filtered_list with various filter combinations."""
+
+    def test_no_filters_returns_none(self, tmp_path, mock_logger, sample_actions):
+        """When no filters are specified, should return None."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=None,
+            action_tag_filter_pattern=None)
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+        assert result is None
+
+    def test_only_action_id_filter(self, tmp_path, mock_logger, sample_actions):
+        """When only action-id filter is specified, should return matching actions."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier1_.*'),
+            action_tag_filter_pattern=None)
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match test_tier1_security and test_tier1_performance, plus parent
+        assert result is not None
+        assert set(result) == {'test_tier1_security', 'test_tier1_performance', 'setup'}
+
+    def test_only_action_tag_filter(self, tmp_path, mock_logger, sample_actions):
+        """When only action-tag filter is specified, should return matching actions."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=None,
+            action_tag_filter_pattern=re.compile(r'security'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match test_tier1_security and test_tier2_security, plus parent
+        assert result is not None
+        assert set(result) == {'test_tier1_security', 'test_tier2_security', 'setup'}
+
+    def test_both_filters_intersection(self, tmp_path, mock_logger, sample_actions):
+        """When both filters are specified, should return intersection."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier1_.*'),
+            action_tag_filter_pattern=re.compile(r'security'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match only test_tier1_security (matches both filters), plus parent
+        assert result is not None
+        assert set(result) == {'test_tier1_security', 'setup'}
+
+    def test_both_filters_no_intersection(self, tmp_path, mock_logger, sample_actions):
+        """When both filters specified but no intersection, should return empty list."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier1_.*'),
+            action_tag_filter_pattern=re.compile(r'maintenance'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # No actions match both criteria
+        assert result is not None
+        assert result == []
+
+    def test_id_filter_matches_tag_filter_doesnt(self, tmp_path, mock_logger, sample_actions):
+        """When ID filter matches but tag filter doesn't, should return empty."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'build_tier1'),
+            action_tag_filter_pattern=re.compile(r'tier1'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # build_tier1 matches ID filter but has tags ['build', 'nightly'], not 'tier1'
+        assert result is not None
+        assert result == []
+
+    def test_tag_filter_matches_id_filter_doesnt(self, tmp_path, mock_logger, sample_actions):
+        """When tag filter matches but ID filter doesn't, should return empty."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier2_.*'),
+            action_tag_filter_pattern=re.compile(r'tier1'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Tag filter matches setup (has tier1 tag) and regression_tests (has tier1 tag)
+        # ID filter matches test_tier2_security and test_tier2_performance
+        # Since tier2 tests have 'setup' as parent, setup is in id_filtered_list too
+        # Intersection will include 'setup' (appears in both lists)
+        assert result is not None
+        assert set(result) == {'setup'}
+
+    def test_both_filters_with_pattern_matching(self, tmp_path, mock_logger, sample_actions):
+        """Test both filters with regex patterns."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier[12]_.*'),
+            action_tag_filter_pattern=re.compile(r'tier1'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match test_tier1_security and test_tier1_performance
+        # (match ID pattern test_tier[12]_.* AND have tier1 tag)
+        # Plus parent 'setup'
+        assert result is not None
+        assert set(result) == {'test_tier1_security', 'test_tier1_performance', 'setup'}
+
+    def test_grandparent_included_when_grandchild_matches(
+            self, tmp_path, mock_logger, sample_actions):
+        """Test that grandparents are included when grandchild matches both filters."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'.*tier1.*'),
+            action_tag_filter_pattern=re.compile(r'smoke'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # child_tier1_smoke matches both (has tier1 in ID and smoke tag)
+        # Should include child, parent, and grandparent
+        assert result is not None
+        assert set(result) == {'child_tier1_smoke', 'parent', 'grandparent'}
+
+    def test_multiple_tags_any_matches(self, tmp_path, mock_logger, sample_actions):
+        """Test that tag filter matches if ANY tag matches the pattern."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=None,
+            action_tag_filter_pattern=re.compile(r'performance'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match both tier1 and tier2 performance tests, plus parent
+        assert result is not None
+        assert set(result) == {'test_tier1_performance', 'test_tier2_performance', 'setup'}
+
+    def test_combined_filters_with_or_pattern(self, tmp_path, mock_logger, sample_actions):
+        """Test combined filters where tag filter uses OR pattern."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier1_.*'),
+            action_tag_filter_pattern=re.compile(r'security|performance'))
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should match test_tier1_security and test_tier1_performance
+        # (both match ID pattern AND have security OR performance tag)
+        assert result is not None
+        assert set(result) == {'test_tier1_security', 'test_tier1_performance', 'setup'}
+
+    def test_parent_included_even_if_no_tags(self, tmp_path, mock_logger):
+        """Test that parent is included even if it doesn't match filters itself."""
+        actions = [
+            IssueAction(id='parent_no_tags'),  # No tags, wouldn't match tag filter
+            IssueAction(id='test_child', parent_id='parent_no_tags',
+                        action_tags=['tier1']),
+            ]
+
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_.*'),
+            action_tag_filter_pattern=re.compile(r'tier1'))
+
+        result = _build_combined_action_filtered_list(ctx, actions)
+
+        # Parent should be included even though it has no tags
+        assert result is not None
+        assert set(result) == {'test_child', 'parent_no_tags'}
+
+    def test_exact_match_required(self, tmp_path, mock_logger, sample_actions):
+        """Test that filters require full match, not partial."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test'),  # Partial match
+            action_tag_filter_pattern=re.compile(r'tier'))  # Partial match
+
+        result = _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should not match anything (patterns don't fully match)
+        assert result is not None
+        assert result == []
+
+    def test_logging_behavior(self, tmp_path, mock_logger, sample_actions):
+        """Test that appropriate debug logs are generated."""
+        ctx = CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_id_filter_pattern=re.compile(r'test_tier1_.*'),
+            action_tag_filter_pattern=re.compile(r'security'))
+
+        _build_combined_action_filtered_list(ctx, sample_actions)
+
+        # Should log filtered lists and intersection
+        assert mock_logger.debug.call_count >= 3
+
+        # Check that intersection log was called
+        call_args = [str(call) for call in mock_logger.debug.call_args_list]
+        intersection_logged = any('intersection' in arg.lower() for arg in call_args)
+        assert intersection_logged

--- a/tests/unit/test_combined_filters.py
+++ b/tests/unit/test_combined_filters.py
@@ -6,6 +6,7 @@ import pytest
 
 from newa import CLIContext, Settings
 from newa.cli.jira_helpers import _build_combined_action_filtered_list
+from newa.cli.tag_filter import parse_tag_filter
 from newa.models.issues import IssueAction
 
 
@@ -93,7 +94,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=None,
-            action_tag_filter_pattern=re.compile(r'security'))
+            action_tag_filter_pattern=parse_tag_filter(r'security'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -110,7 +111,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier1_.*'),
-            action_tag_filter_pattern=re.compile(r'security'))
+            action_tag_filter_pattern=parse_tag_filter(r'security'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -127,7 +128,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier1_.*'),
-            action_tag_filter_pattern=re.compile(r'maintenance'))
+            action_tag_filter_pattern=parse_tag_filter(r'maintenance'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -144,7 +145,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'build_tier1'),
-            action_tag_filter_pattern=re.compile(r'tier1'))
+            action_tag_filter_pattern=parse_tag_filter(r'tier1'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -161,7 +162,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier2_.*'),
-            action_tag_filter_pattern=re.compile(r'tier1'))
+            action_tag_filter_pattern=parse_tag_filter(r'tier1'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -181,7 +182,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier[12]_.*'),
-            action_tag_filter_pattern=re.compile(r'tier1'))
+            action_tag_filter_pattern=parse_tag_filter(r'tier1'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -201,7 +202,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'.*tier1.*'),
-            action_tag_filter_pattern=re.compile(r'smoke'))
+            action_tag_filter_pattern=parse_tag_filter(r'smoke'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -219,7 +220,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=None,
-            action_tag_filter_pattern=re.compile(r'performance'))
+            action_tag_filter_pattern=parse_tag_filter(r'performance'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -236,7 +237,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier1_.*'),
-            action_tag_filter_pattern=re.compile(r'security|performance'))
+            action_tag_filter_pattern=parse_tag_filter(r'security|performance'))
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -260,7 +261,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_.*'),
-            action_tag_filter_pattern=re.compile(r'tier1'))
+            action_tag_filter_pattern=parse_tag_filter(r'tier1'))
 
         result = _build_combined_action_filtered_list(ctx, actions)
 
@@ -277,7 +278,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test'),  # Partial match
-            action_tag_filter_pattern=re.compile(r'tier'))  # Partial match
+            action_tag_filter_pattern=parse_tag_filter(r'tier'))  # Partial match
 
         result = _build_combined_action_filtered_list(ctx, sample_actions)
 
@@ -294,7 +295,7 @@ class TestCombinedFilters:
             cli_environment={},
             cli_context={},
             action_id_filter_pattern=re.compile(r'test_tier1_.*'),
-            action_tag_filter_pattern=re.compile(r'security'))
+            action_tag_filter_pattern=parse_tag_filter(r'security'))
 
         _build_combined_action_filtered_list(ctx, sample_actions)
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -417,3 +417,197 @@ class TestEventFilter:
 
         result = should_filter_by_event(filter_obj, job, mock_logger)
         assert result is True  # Should be filtered (wrong artifact type)
+
+
+class TestActionTagFilter:
+    """Tests for _should_filter_by_action_tags method."""
+
+    @pytest.fixture
+    def ctx_no_tag_filter(self, tmp_path, mock_logger):
+        """Return a CLIContext without tag filter."""
+        return CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_tag_filter_pattern=None)
+
+    @pytest.fixture
+    def ctx_with_tag_filter(self, tmp_path, mock_logger):
+        """Return a CLIContext with action_tag filter."""
+        return CLIContext(
+            logger=mock_logger,
+            settings=Settings(),
+            state_dirpath=tmp_path,
+            cli_environment={},
+            cli_context={},
+            action_tag_filter_pattern=re.compile(r'tier.*'))
+
+    def test_no_filter_returns_false(self, ctx_no_tag_filter):
+        """When no filter pattern is set, should not filter."""
+        result = ctx_no_tag_filter._should_filter_by_action_tags(['tier1', 'regression'])
+        assert result is False
+
+    def test_matching_single_tag_returns_false(self, ctx_with_tag_filter):
+        """When one tag matches pattern, should not filter (return False)."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags(['tier1'])
+        assert result is False
+        # Check debug log was called
+        ctx_with_tag_filter.logger.debug.assert_called_once()
+
+    def test_matching_tag_in_list_returns_false(self, ctx_with_tag_filter):
+        """When any tag in list matches pattern, should not filter (return False)."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags(
+            ['performance', 'tier2', 'nightly'])
+        assert result is False
+        # Check debug log was called
+        ctx_with_tag_filter.logger.debug.assert_called_once()
+
+    def test_non_matching_tags_returns_true(self, ctx_with_tag_filter):
+        """When no tags match pattern, should filter (return True)."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags(
+            ['performance', 'nightly'])
+        assert result is True
+        # Check info log was called (log_message=True by default)
+        ctx_with_tag_filter.logger.info.assert_called_once()
+
+    def test_none_action_tags_returns_true(self, ctx_with_tag_filter):
+        """When action_tags is None, should filter (return True)."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags(None)
+        assert result is True
+
+    def test_empty_action_tags_returns_true(self, ctx_with_tag_filter):
+        """When action_tags is empty list, should filter (return True)."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags([])
+        assert result is True
+
+    def test_log_message_false_uses_debug(self, ctx_with_tag_filter):
+        """When log_message=False, should use debug log for skips."""
+        result = ctx_with_tag_filter._should_filter_by_action_tags(
+            ['performance', 'nightly'], log_message=False)
+        assert result is True
+        # Check debug log was called, not info
+        # Note: debug is called for the filter check
+        ctx_with_tag_filter.logger.info.assert_not_called()
+
+    def test_pattern_matches_full_tag_only(self, ctx_with_tag_filter):
+        """Pattern should match full tag, not partial."""
+        # Pattern is 'tier.*', so 'tier1' matches but 'mytier' doesn't
+        result_match = ctx_with_tag_filter._should_filter_by_action_tags(['tier1'])
+        assert result_match is False
+
+        # Reset logger mock for second call
+        ctx_with_tag_filter.logger.reset_mock()
+
+        result_no_match = ctx_with_tag_filter._should_filter_by_action_tags(['mytier'])
+        assert result_no_match is True
+
+
+class TestBuildActionTagFilteredList:
+    """Tests for _build_action_tag_filtered_list function."""
+
+    def test_empty_action_list(self):
+        """Test with empty action list."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+
+        result = _build_action_tag_filtered_list([], re.compile(r'tier.*'))
+        assert result == []
+
+    def test_no_matching_tags(self):
+        """Test when no tags match the pattern."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='action1', action_tags=['performance', 'nightly']),
+            IssueAction(id='action2', action_tags=['regression']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        assert result == []
+
+    def test_single_matching_tag(self):
+        """Test when one action has a matching tag."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='action1', action_tags=['tier1']),
+            IssueAction(id='action2', action_tags=['performance']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        assert result == ['action1']
+
+    def test_multiple_matching_tags(self):
+        """Test when multiple actions have matching tags."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='action1', action_tags=['tier1']),
+            IssueAction(id='action2', action_tags=['tier2', 'performance']),
+            IssueAction(id='action3', action_tags=['regression']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        assert set(result) == {'action1', 'action2'}
+
+    def test_includes_parent_actions(self):
+        """Test that parent actions are included when child matches."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='parent', action_tags=['setup']),
+            IssueAction(id='child1', parent_id='parent', action_tags=['tier1']),
+            IssueAction(id='child2', parent_id='parent', action_tags=['performance']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        # Should include child1 (matches) and parent (parent of child1)
+        assert set(result) == {'child1', 'parent'}
+
+    def test_includes_grandparent_actions(self):
+        """Test that grandparent actions are included when grandchild matches."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='grandparent', action_tags=['setup']),
+            IssueAction(id='parent', parent_id='grandparent', action_tags=['prepare']),
+            IssueAction(id='child', parent_id='parent', action_tags=['tier1']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        # Should include all three: child (matches), parent, and grandparent
+        assert set(result) == {'child', 'parent', 'grandparent'}
+
+    def test_actions_without_tags(self):
+        """Test that actions without tags are not included unless they're parents."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='action1'),  # No tags
+            IssueAction(id='action2', action_tags=['tier1']),
+            IssueAction(id='action3'),  # No tags
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        assert result == ['action2']
+
+    def test_actions_with_explicit_id(self):
+        """Test that only actions with matching tags are included."""
+        from newa.cli.jira_helpers import _build_action_tag_filtered_list
+        from newa.models.issues import IssueAction
+
+        actions = [
+            IssueAction(id='action1', action_tags=['performance']),
+            IssueAction(id='action2', action_tags=['tier2']),
+            IssueAction(id='action3', action_tags=['nightly']),
+            ]
+
+        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        assert result == ['action2']

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -469,27 +469,32 @@ class TestActionTagFilter:
         result = ctx_with_tag_filter._should_filter_by_action_tags(
             ['performance', 'nightly'])
         assert result is True
-        # Check info log was called (log_message=True by default)
-        ctx_with_tag_filter.logger.info.assert_called_once()
+        # Check debug log was called for skip message
+        ctx_with_tag_filter.logger.debug.assert_called_once()
 
     def test_none_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is None, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags(None)
         assert result is True
+        # Check debug log was called with "no tags" message
+        ctx_with_tag_filter.logger.debug.assert_called_once_with(
+            "Skipping action with no tags as --action-tag-filter is specified.")
 
     def test_empty_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is empty list, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags([])
         assert result is True
+        # Check debug log was called with "no tags" message
+        ctx_with_tag_filter.logger.debug.assert_called_once_with(
+            "Skipping action with no tags as --action-tag-filter is specified.")
 
     def test_log_message_false_uses_debug(self, ctx_with_tag_filter):
         """When log_message=False, should use debug log for skips."""
         result = ctx_with_tag_filter._should_filter_by_action_tags(
             ['performance', 'nightly'], log_message=False)
         assert result is True
-        # Check debug log was called, not info
-        # Note: debug is called for the filter check
-        ctx_with_tag_filter.logger.info.assert_not_called()
+        # Check debug log was called (logging now always uses debug)
+        ctx_with_tag_filter.logger.debug.assert_called_once()
 
     def test_pattern_matches_full_tag_only(self, ctx_with_tag_filter):
         """Pattern should match full tag, not partial."""

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -469,23 +469,23 @@ class TestActionTagFilter:
         result = ctx_with_tag_filter._should_filter_by_action_tags(
             ['performance', 'nightly'])
         assert result is True
-        # Check debug log was called for skip message
-        ctx_with_tag_filter.logger.debug.assert_called_once()
+        # Check info log was called for skip message (log_message=True by default)
+        ctx_with_tag_filter.logger.info.assert_called_once()
 
     def test_none_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is None, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags(None)
         assert result is True
-        # Check debug log was called with "no tags" message
-        ctx_with_tag_filter.logger.debug.assert_called_once_with(
+        # Check info log was called with "no tags" message (log_message=True by default)
+        ctx_with_tag_filter.logger.info.assert_called_once_with(
             "Skipping action with no tags as --action-tag-filter is specified.")
 
     def test_empty_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is empty list, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags([])
         assert result is True
-        # Check debug log was called with "no tags" message
-        ctx_with_tag_filter.logger.debug.assert_called_once_with(
+        # Check info log was called with "no tags" message (log_message=True by default)
+        ctx_with_tag_filter.logger.info.assert_called_once_with(
             "Skipping action with no tags as --action-tag-filter is specified.")
 
     def test_log_message_false_uses_debug(self, ctx_with_tag_filter):

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from newa import CLIContext, Settings
+from newa.cli.tag_filter import parse_tag_filter
 
 
 @pytest.fixture
@@ -436,13 +437,14 @@ class TestActionTagFilter:
     @pytest.fixture
     def ctx_with_tag_filter(self, tmp_path, mock_logger):
         """Return a CLIContext with action_tag filter."""
+        from newa.cli.tag_filter import parse_tag_filter
         return CLIContext(
             logger=mock_logger,
             settings=Settings(),
             state_dirpath=tmp_path,
             cli_environment={},
             cli_context={},
-            action_tag_filter_pattern=re.compile(r'tier.*'))
+            action_tag_filter_pattern=parse_tag_filter(r'tier.*'))
 
     def test_no_filter_returns_false(self, ctx_no_tag_filter):
         """When no filter pattern is set, should not filter."""
@@ -516,7 +518,7 @@ class TestBuildActionTagFilteredList:
         """Test with empty action list."""
         from newa.cli.jira_helpers import _build_action_tag_filtered_list
 
-        result = _build_action_tag_filtered_list([], re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list([], parse_tag_filter(r'tier.*'))
         assert result == []
 
     def test_no_matching_tags(self):
@@ -529,7 +531,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='action2', action_tags=['regression']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         assert result == []
 
     def test_single_matching_tag(self):
@@ -542,7 +544,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='action2', action_tags=['performance']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         assert result == ['action1']
 
     def test_multiple_matching_tags(self):
@@ -556,7 +558,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='action3', action_tags=['regression']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         assert set(result) == {'action1', 'action2'}
 
     def test_includes_parent_actions(self):
@@ -570,7 +572,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='child2', parent_id='parent', action_tags=['performance']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         # Should include child1 (matches) and parent (parent of child1)
         assert set(result) == {'child1', 'parent'}
 
@@ -585,7 +587,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='child', parent_id='parent', action_tags=['tier1']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         # Should include all three: child (matches), parent, and grandparent
         assert set(result) == {'child', 'parent', 'grandparent'}
 
@@ -600,7 +602,7 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='action3'),  # No tags
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         assert result == ['action2']
 
     def test_actions_with_explicit_id(self):
@@ -614,5 +616,5 @@ class TestBuildActionTagFilteredList:
             IssueAction(id='action3', action_tags=['nightly']),
             ]
 
-        result = _build_action_tag_filtered_list(actions, re.compile(r'tier.*'))
+        result = _build_action_tag_filtered_list(actions, parse_tag_filter(r'tier.*'))
         assert result == ['action2']

--- a/tests/unit/test_jira_summary_and_schedule.py
+++ b/tests/unit/test_jira_summary_and_schedule.py
@@ -390,7 +390,8 @@ class TestScheduleAndRecipeFunctionality:
         # Verify skip log message
         mock_ctx.logger.info.assert_called_with(
             f'Skipping jira job {JIRA_NONE_ID}-123 - auto_schedule is disabled. '
-            f'Use --schedule-all or --action-id-filter/--issue-id-filter to override.',
+            f'Use --schedule-all or --action-id-filter/--issue-id-filter/'
+            f'--action-tag-filter to override.',
             )
 
         # Verify no schedule job files were created

--- a/tests/unit/test_jira_summary_and_schedule.py
+++ b/tests/unit/test_jira_summary_and_schedule.py
@@ -474,6 +474,53 @@ class TestScheduleAndRecipeFunctionality:
         schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
         assert len(schedule_job_files) > 0
 
+    def test_schedule_command_processes_auto_schedule_false_with_tag_filter(self, mock_ctx):
+        """Test that action_tag filter overrides auto_schedule=False."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        # Set action_tag_filter_pattern to match
+        mock_ctx.action_tag_filter_pattern = re.compile(r'tier1')
+
+        # Create a jira job with recipe but auto_schedule=False and matching action_tags
+        jira_job = JiraJob(
+            event=Event(
+                id='12345',
+                type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(
+                f'{JIRA_NONE_ID}-123',
+                summary='Test Issue',
+                action_tags=[
+                    'tier1',
+                    'smoke']),
+            recipe=Recipe(
+                url='tests/unit/data/sample_recipe.yaml',
+                auto_schedule=False),
+            )
+
+        # Process with action_tag_filter (no --schedule-all flag)
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=False,
+            )
+
+        # Verify override log message
+        mock_ctx.logger.info.assert_any_call(
+            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+            )
+
+        # Verify schedule job files WERE created (filter overrides auto_schedule=False)
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
     def test_schedule_command_processes_auto_schedule_false_with_schedule_all(self, mock_ctx):
         """Test that --schedule-all flag overrides auto_schedule=False."""
         from newa import Compose, Recipe

--- a/tests/unit/test_tag_filter.py
+++ b/tests/unit/test_tag_filter.py
@@ -1,0 +1,283 @@
+"""Tests for tag filter expression parser and evaluator."""
+import pytest
+
+from newa.cli.tag_filter import TagFilter, parse_tag_filter
+
+
+class TestParseTagFilter:
+    """Tests for parse_tag_filter function."""
+
+    def test_empty_string(self):
+        """Empty filter string should return empty TagFilter."""
+        result = parse_tag_filter("")
+        assert result.any_patterns == []
+        assert result.all_patterns == []
+        assert result.none_patterns == []
+
+    def test_whitespace_only(self):
+        """Whitespace-only filter string should return empty TagFilter."""
+        result = parse_tag_filter("   ")
+        assert result.any_patterns == []
+        assert result.all_patterns == []
+        assert result.none_patterns == []
+
+    def test_single_pattern(self):
+        """Single pattern should be treated as AND pattern."""
+        result = parse_tag_filter("regression")
+        assert len(result.all_patterns) == 1
+        assert result.all_patterns[0].pattern == "regression"
+        assert result.any_patterns == []
+        assert result.none_patterns == []
+
+    def test_or_patterns(self):
+        """Pipe-separated patterns should be treated as OR."""
+        result = parse_tag_filter("regression|security")
+        assert len(result.any_patterns) == 2
+        assert {p.pattern for p in result.any_patterns} == {"regression", "security"}
+        assert result.all_patterns == []
+        assert result.none_patterns == []
+
+    def test_and_patterns(self):
+        """Comma-separated patterns should be treated as AND."""
+        result = parse_tag_filter("smoke,rhel-9")
+        assert len(result.all_patterns) == 2
+        assert {p.pattern for p in result.all_patterns} == {"smoke", "rhel-9"}
+        assert result.any_patterns == []
+        assert result.none_patterns == []
+
+    def test_not_pattern(self):
+        """Exclamation prefix should create NOT pattern."""
+        result = parse_tag_filter("!slow")
+        assert len(result.none_patterns) == 1
+        assert result.none_patterns[0].pattern == "slow"
+        assert result.any_patterns == []
+        assert result.all_patterns == []
+
+    def test_combined_or_and_not(self):
+        """Complex expression with OR, AND, and NOT."""
+        result = parse_tag_filter("regression|security,!slow")
+        assert len(result.any_patterns) == 2
+        assert {p.pattern for p in result.any_patterns} == {"regression", "security"}
+        assert len(result.none_patterns) == 1
+        assert result.none_patterns[0].pattern == "slow"
+        assert result.all_patterns == []
+
+    def test_regex_patterns(self):
+        """Regex patterns should be compiled correctly."""
+        result = parse_tag_filter("rhel-.*,tier[12]")
+        assert len(result.all_patterns) == 2
+        # Verify patterns can match
+        assert result.all_patterns[0].fullmatch("rhel-9")
+        assert result.all_patterns[1].fullmatch("tier1")
+        assert not result.all_patterns[1].fullmatch("tier3")
+
+    def test_invalid_regex_raises_error(self):
+        """Invalid regex pattern should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            parse_tag_filter("tier[")
+
+    def test_empty_not_pattern_raises_error(self):
+        """Empty pattern after ! should raise ValueError."""
+        with pytest.raises(ValueError, match="Empty pattern after '!'"):
+            parse_tag_filter("!")
+
+    def test_not_with_or_raises_error(self):
+        """NOT cannot be combined with OR in same group."""
+        with pytest.raises(ValueError, match="NOT patterns.*cannot be combined with OR"):
+            parse_tag_filter("!slow|fast")
+
+    def test_whitespace_handling(self):
+        """Whitespace around patterns should be stripped."""
+        result = parse_tag_filter(" regression | security , !slow ")
+        assert len(result.any_patterns) == 2
+        assert len(result.none_patterns) == 1
+
+
+class TestTagFilterMatches:
+    """Tests for TagFilter.matches() method."""
+
+    def test_empty_filter_matches_empty_tags(self):
+        """Empty filter matches empty/no tags."""
+        f = TagFilter(any_patterns=[], all_patterns=[], none_patterns=[])
+        assert f.matches(None) is True
+        assert f.matches([]) is True
+
+    def test_empty_filter_matches_any_tags(self):
+        """Empty filter matches any tags."""
+        f = TagFilter(any_patterns=[], all_patterns=[], none_patterns=[])
+        assert f.matches(["foo", "bar"]) is True
+
+    def test_any_pattern_matches(self):
+        """ANY pattern matches if at least one tag matches."""
+        import re
+        f = TagFilter(
+            any_patterns=[re.compile("regression"), re.compile("security")],
+            all_patterns=[],
+            none_patterns=[])
+
+        assert f.matches(["regression"]) is True
+        assert f.matches(["security"]) is True
+        assert f.matches(["regression", "other"]) is True
+        assert f.matches(["other"]) is False
+        assert f.matches([]) is False
+        assert f.matches(None) is False
+
+    def test_all_pattern_matches(self):
+        """ALL patterns must all match at least one tag each."""
+        import re
+        f = TagFilter(
+            any_patterns=[],
+            all_patterns=[re.compile("smoke"), re.compile("rhel-9")],
+            none_patterns=[])
+
+        assert f.matches(["smoke", "rhel-9"]) is True
+        assert f.matches(["smoke", "rhel-9", "tier1"]) is True
+        assert f.matches(["smoke"]) is False
+        assert f.matches(["rhel-9"]) is False
+        assert f.matches([]) is False
+        assert f.matches(None) is False
+
+    def test_none_pattern_excludes(self):
+        """NONE pattern excludes tags that match."""
+        import re
+        f = TagFilter(
+            any_patterns=[],
+            all_patterns=[],
+            none_patterns=[re.compile("slow")])
+
+        assert f.matches(["fast"]) is True
+        assert f.matches(["regression"]) is True
+        assert f.matches(["slow"]) is False
+        assert f.matches(["fast", "slow"]) is False
+        assert f.matches([]) is True  # No tags = no match to exclude
+        assert f.matches(None) is True
+
+    def test_combined_any_and_none(self):
+        """Combined ANY and NONE patterns."""
+        import re
+        f = TagFilter(
+            any_patterns=[re.compile("regression"), re.compile("security")],
+            all_patterns=[],
+            none_patterns=[re.compile("slow")])
+
+        # Has matching ANY tag and no NONE tag
+        assert f.matches(["regression"]) is True
+        assert f.matches(["security", "fast"]) is True
+
+        # Has matching ANY tag but also has NONE tag
+        assert f.matches(["regression", "slow"]) is False
+        assert f.matches(["security", "slow"]) is False
+
+        # No matching ANY tag
+        assert f.matches(["fast"]) is False
+        assert f.matches([]) is False
+
+    def test_combined_all_and_none(self):
+        """Combined ALL and NONE patterns."""
+        import re
+        f = TagFilter(
+            any_patterns=[],
+            all_patterns=[re.compile("smoke"), re.compile("rhel-9")],
+            none_patterns=[re.compile("slow")])
+
+        # Has all ALL tags and no NONE tag
+        assert f.matches(["smoke", "rhel-9"]) is True
+        assert f.matches(["smoke", "rhel-9", "tier1"]) is True
+
+        # Has all ALL tags but also has NONE tag
+        assert f.matches(["smoke", "rhel-9", "slow"]) is False
+
+        # Missing one ALL tag
+        assert f.matches(["smoke"]) is False
+
+    def test_complex_expression(self):
+        """Test complex expression: (regression|security),tier1,!slow"""
+        import re
+        f = TagFilter(
+            any_patterns=[re.compile("regression"), re.compile("security")],
+            all_patterns=[re.compile("tier1")],
+            none_patterns=[re.compile("slow")])
+
+        # Has (regression OR security) AND tier1 AND NOT slow
+        assert f.matches(["regression", "tier1"]) is True
+        assert f.matches(["security", "tier1"]) is True
+        assert f.matches(["regression", "security", "tier1"]) is True
+
+        # Missing tier1
+        assert f.matches(["regression"]) is False
+        assert f.matches(["security"]) is False
+
+        # Has slow
+        assert f.matches(["regression", "tier1", "slow"]) is False
+
+        # No regression or security
+        assert f.matches(["tier1"]) is False
+
+    def test_regex_patterns_in_matches(self):
+        """Test that regex patterns work correctly in matches."""
+        import re
+        f = TagFilter(
+            any_patterns=[],
+            all_patterns=[re.compile(r"rhel-\d+"), re.compile(r"tier[12]")],
+            none_patterns=[])
+
+        assert f.matches(["rhel-9", "tier1"]) is True
+        assert f.matches(["rhel-10", "tier2"]) is True
+        assert f.matches(["rhel-9", "tier3"]) is False  # tier3 doesn't match tier[12]
+        assert f.matches(["rhel-foo", "tier1"]) is False  # rhel-foo doesn't match rhel-\d+
+
+
+class TestTagFilterIntegration:
+    """Integration tests with real-world scenarios."""
+
+    def test_simple_or_filter(self):
+        """User wants: regression OR security tests."""
+        f = parse_tag_filter("regression|security")
+
+        assert f.matches(["regression"]) is True
+        assert f.matches(["security"]) is True
+        assert f.matches(["regression", "tier1"]) is True
+        assert f.matches(["tier1"]) is False
+        assert f.matches([]) is False
+
+    def test_simple_and_filter(self):
+        """User wants: smoke AND rhel-9 tests."""
+        f = parse_tag_filter("smoke,rhel-9")
+
+        assert f.matches(["smoke", "rhel-9"]) is True
+        assert f.matches(["smoke", "rhel-9", "tier1"]) is True
+        assert f.matches(["smoke"]) is False
+        assert f.matches(["rhel-9"]) is False
+
+    def test_exclusion_filter(self):
+        """User wants: anything except slow tests."""
+        f = parse_tag_filter("!slow")
+
+        assert f.matches(["fast"]) is True
+        assert f.matches(["regression"]) is True
+        assert f.matches(["slow"]) is False
+        assert f.matches(["fast", "slow"]) is False
+
+    def test_complex_real_world(self):
+        """User wants: (regression OR security) AND tier1 AND NOT slow."""
+        f = parse_tag_filter("regression|security,tier1,!slow")
+
+        # Valid combinations
+        assert f.matches(["regression", "tier1", "fast"]) is True
+        assert f.matches(["security", "tier1"]) is True
+        assert f.matches(["regression", "security", "tier1"]) is True
+
+        # Invalid combinations
+        assert f.matches(["regression", "tier2"]) is False  # wrong tier
+        assert f.matches(["security", "tier1", "slow"]) is False  # has slow
+        assert f.matches(["tier1"]) is False  # missing regression/security
+
+    def test_regex_real_world(self):
+        """User wants: rhel-9.* version AND (tier1 OR tier2) tests."""
+        f = parse_tag_filter("rhel-9.*,tier1|tier2")
+
+        assert f.matches(["rhel-9.5", "tier1"]) is True
+        assert f.matches(["rhel-9.10", "tier2"]) is True
+        assert f.matches(["rhel-9", "tier1"]) is True
+        assert f.matches(["rhel-8.10", "tier1"]) is False  # wrong rhel version
+        assert f.matches(["rhel-9.5", "tier3"]) is False  # wrong tier


### PR DESCRIPTION
Implement support for filtering actions by tags using --action-tag-filter option. This enables splitting test execution into logical parts based on action categorization (e.g., tier1, tier2, security, performance).

Key features:
- Add action_tags field to IssueAction and Issue models
- Implement --action-tag-filter CLI option with regex pattern matching
- Support "ANY" tag matching logic (action included if any tag matches)
- Automatically include parent actions when children match filters
- Combine with existing filters (--action-id-filter, --issue-id-filter) using AND logic (intersection)
- Override auto_schedule=False when filters are specified
- Display action tags in list command output

Implementation details:
- Created _build_action_tag_filtered_list() helper function
- Created _build_combined_action_filtered_list() to handle filter intersection logic consistently across all stages
- Added _should_filter_by_action_tags() method to CLIContext
- Applied filtering at YAML loading and issue-config processing stages
- Ensured consistent filter behavior across jira, schedule, execute, report, and list commands

Testing:
- 40 new unit tests covering all filtering scenarios
- Tests for single filters, combined filters, parent inclusion, pattern matching, and edge cases
- All 192 unit tests passing

Documentation:
- Updated README.md with detailed --action-tag-filter usage examples
- Added action_tags field documentation in issue-config section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tag-based action filtering across CLI, models, and scheduling to enable selective processing of tagged actions, including parent actions, and document the new behavior.

New Features:
- Introduce action_tags on Issue and IssueAction to categorize actions and surface them in generated jobs and list output.
- Add --action-tag-filter CLI option with a regex-based expression language (AND/OR/NOT) to selectively process actions by tags across all subcommands.
- Implement combined action ID and tag filtering with intersection semantics, ensuring parent and ancestor actions of matching children are included.
- Allow tag-based filters to override recipe auto_schedule=False so explicitly filtered actions are still scheduled.

Enhancements:
- Unify action filtering logic via shared helpers and a combined filtered-list builder, simplifying how filters are applied during YAML loading and issue-config processing.
- Improve logging messages around filtered actions to reflect generic user-provided filters rather than specific flag names.

Documentation:
- Extend README with documentation and examples for action_tags in issue-config and the new --action-tag-filter option, including expression syntax and usage patterns.

Tests:
- Add comprehensive unit tests for tag filter parsing/evaluation, tag-based YAML/job filtering, combined action-id and action-tag filtering, and CLIContext tag filtering behavior.