### PR TITLE
Improve condition handling and rendering

### DIFF
--- a/docs/agents/claude-newa.md
+++ b/docs/agents/claude-newa.md
@@ -172,6 +172,18 @@ You are a NEWA Test Orchestration Specialist, an expert in managing complex asyn
 - When tests complete, lead with the outcome summary before providing details
 - If user intervention is needed, clearly state what action is required and why
 
+**Critical Response Format:**
+- **ALWAYS include the state directory path in your final response when working with NEWA sessions**
+- This is ESSENTIAL for enabling the main Claude Code instance to track sessions across multiple user interactions
+- **Format:** Clearly identify the state directory path, e.g., "State directory: /var/tmp/newa/run-123456"
+- **Typical state-dir pattern:** `/var/tmp/newa/run-[0-9]+`
+- Include the state-dir path when:
+  - Starting new test runs (after NEWA creates the state directory)
+  - Working with existing runs (monitoring, rescheduling, reporting)
+  - Listing or searching for runs (when specific state-dirs are identified)
+- Make the state directory path easily identifiable and parseable in your response
+- This allows seamless context preservation for follow-up commands like "restart failed requests" or "check status"
+
 **Quality Assurance:**
 - Before finalizing, verify that the state directory contains expected results using `newa --state-dir <path> list` output
 - **CRITICAL:** Use ONLY `newa list` to verify state - DO NOT read YAML files to check results

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -260,6 +260,8 @@ def _process_jira_job(
     jinja_vars: dict[str, Any] = {
         'EVENT': jira_job.event,
         'ERRATUM': jira_job.erratum,
+        'COMPOSE': jira_job.compose,
+        'ROG': jira_job.rog,
         }
     requests = list(config.build_requests(initial_config, cli_config, jinja_vars))
     ctx.logger.info(f'{len(requests)} requests have been generated')

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -114,7 +114,12 @@ def _configure_recipe(
 def _render_request_attributes(
         request: Request,
         jinja_vars: dict[str, Any]) -> None:
-    """Render request attributes as Jinja templates in place."""
+    """Render request attributes as Jinja templates in place.
+
+    Note: 'when' attribute is intentionally not rendered as it was already
+    evaluated during build_requests() and contains references to variables
+    that may be None, which would cause errors if re-rendered.
+    """
     for attr in ("reportportal", "tmt", "testingfarm", "environment", "context", "compose"):
         # compose value is a string, not dict
         if attr == 'compose':
@@ -126,6 +131,9 @@ def _render_request_attributes(
             # getattr(request, attr) could also be None due to 'attr' being None
             mapping = getattr(request, attr, {}) or {}
             for (key, value) in mapping.items():
+                # Skip 'when' key - it was already evaluated and is just metadata
+                if key == 'when':
+                    continue
                 # launch_attributes is a dict
                 if key == 'launch_attributes':
                     for (k, v) in value.items():

--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -433,15 +433,17 @@ class RecipeConfig(Cloneable, Serializable):
             condition = combination.get('when', '')
             if condition:
                 compose: Optional[str] = combination.get('compose', '')
-                # we will expose COMPOSE, ENVIRONMENT, CONTEXT to evaluate a condition
                 arch = combination.get('arch', None)
-                test_result = eval_test(
-                    condition,
-                    COMPOSE=Compose(compose) if compose else None,
-                    ARCH=arch.value if arch else None,
-                    ENVIRONMENT=combination.get('environment', None),
-                    CONTEXT=combination.get('context', None),
-                    **(jinja_vars or {}))
+                # Start with jinja_vars (EVENT, ERRATUM, ROG, etc), then override with
+                # combination-specific values (COMPOSE, ENVIRONMENT, CONTEXT, ARCH)
+                test_vars = dict(jinja_vars or {})
+                test_vars.update({
+                    'COMPOSE': Compose(compose) if compose else None,
+                    'ARCH': arch.value if arch else None,
+                    'ENVIRONMENT': combination.get('environment', None),
+                    'CONTEXT': combination.get('context', None),
+                    })
+                test_result = eval_test(condition, **test_vars)
                 if not test_result:
                     continue
             filtered_combinations.append(combination)

--- a/newa/utils/templates.py
+++ b/newa/utils/templates.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import jinja2
@@ -55,11 +56,17 @@ def render_template(
     # Our common tests for each render_template call
     # Register if not already present
     if 'match' not in environment.tests:
-        def _test_match(s: str, pattern: str) -> bool:
-            logger.debug(
-                f"Match test: checking if '{s}' (type: {
-                    type(s).__name__}) matches pattern '{pattern}'")
-            return re.match(pattern, s) is not None
+        def _test_match(s: Any, pattern: str) -> bool:
+            # Convert to string for regex matching
+            # For Enums, use the underlying enum value; otherwise use str()
+            str_value = str(s.value) if isinstance(s, Enum) else str(s)
+
+            if logger.isEnabledFor(logging.DEBUG):
+                type_name = type(s).__name__
+                logger.debug(
+                    f"Match test: checking if '{str_value}' (type: {type_name}) "
+                    f"matches pattern '{pattern}'")
+            return re.match(pattern, str_value) is not None
 
         environment.tests['match'] = _test_match
 

--- a/newa/utils/templates.py
+++ b/newa/utils/templates.py
@@ -1,5 +1,6 @@
 """Jinja2 template rendering utilities."""
 
+import logging
 import re
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -8,6 +9,8 @@ import jinja2
 if TYPE_CHECKING:
     from newa.models.events import Event
     from newa.models.jobs import ArtifactJob
+
+logger = logging.getLogger(__name__)
 
 
 def default_template_environment() -> jinja2.Environment:
@@ -53,6 +56,9 @@ def render_template(
     # Register if not already present
     if 'match' not in environment.tests:
         def _test_match(s: str, pattern: str) -> bool:
+            logger.debug(
+                f"Match test: checking if '{s}' (type: {
+                    type(s).__name__}) matches pattern '{pattern}'")
             return re.match(pattern, s) is not None
 
         environment.tests['match'] = _test_match
@@ -130,6 +136,8 @@ def eval_test(
     environment.tests['erratum'] = _test_erratum
     environment.tests['RoG'] = _test_rog
 
+    logger.debug(f"Evaluating test condition: {test}")
+
     try:
         outcome = render_template(
             f'{{% if {test} %}}true{{% else %}}false{{% endif %}}',
@@ -140,4 +148,6 @@ def eval_test(
     except Exception as exc:
         raise Exception(f"Could not evaluate test '{test}'") from exc
 
-    return bool(outcome == 'true')
+    result = bool(outcome == 'true')
+    logger.debug(f"Test condition result: {result}")
+    return result

--- a/tests/unit/test_eval_test.py
+++ b/tests/unit/test_eval_test.py
@@ -66,3 +66,9 @@ def test_expressions():
     assert test('JOB.erratum.release is not match("RHEL-.*")', False)
     assert test('JOB.erratum.release is not match("(?i)rhel-.*")', False)
     assert test('JOB.erratum.release is not match("RHEL-9.7.0")', True)
+
+    # Test EventType enum matching (regression test for enum handling)
+    assert test('EVENT.type_ is match("erratum")', True)
+    assert test('EVENT.type_ is match("compose")', False)
+    assert test('EVENT.type_ is not match("erratum")', False)
+    assert test('EVENT.type_ is not match("compose")', True)


### PR DESCRIPTION
## Summary by Sourcery

Improve condition evaluation and request rendering by enhancing Jinja test handling, propagating correct template variables, and clarifying when and how attributes are rendered.

Bug Fixes:
- Fix condition evaluation for Enum values by converting them to strings before regex matching in the Jinja match test.
- Prevent re-rendering of the already-evaluated when attribute to avoid errors from missing variables in request templates.

Enhancements:
- Add debug logging around Jinja test evaluation and results to aid troubleshooting of conditional logic.
- Ensure build_requests merges global Jinja variables with combination-specific context when evaluating conditions.
- Include COMPOSE and ROG objects in the Jinja variable context for Jira job processing.
- Clarify request attribute rendering behavior in schedule helpers and skip when metadata keys during template expansion.

Documentation:
- Update the Claude NEWA agent documentation to require explicitly surfacing the NEWA state directory path in responses for better session tracking.

Tests:
- Extend eval_test unit tests to cover Enum-based condition matching and guard against regressions in match handling.