### PR TITLE
Enable --refresh with --event-filter for list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Instructs NEWA to process only jobs associated with events/artifacts that match 
 - For **event** subcommand: Only creates YAML files for events/artifacts matching the filter
 - For **jira, schedule, execute, report, summarize, and list** subcommands: Only processes existing jobs where the event/artifact matches the filter
 
+**Note:** When using `--event-filter` with the `list` command, the filter is applied to state directories in scope. By default, `newa list` only processes the last 10 state directories (unless a specific state directory is specified via `-D/--state-dir` or `-P/--prev-state-dir`). To ensure the event filter is applied across all state directories, it is recommended to use `newa list --all` when combined with `--event-filter`.
+
 This option can be combined with `--action-id-filter` and `--issue-id-filter` for fine-grained control. It also works with `--copy-state-dir` and `--extract-state-dir` to filter which YAML files are copied or extracted.
 
 Use with caution.
@@ -2090,27 +2092,33 @@ $ newa list --issues
 
 #### Option `--refresh`
 
-Refreshes Testing Farm request statuses before listing (only incomplete requests where `result == NONE`). This option requires a specific state directory to be specified via `-D/--state-dir` or `-P/--prev-state-dir`. It cannot be used when listing multiple state directories for performance reasons.
+Refreshes Testing Farm request statuses before listing (only incomplete requests where `result == NONE`). This option requires either:
+- A specific state directory via `-D/--state-dir` or `-P/--prev-state-dir`, or
+- An event filter via `--event-filter` to refresh multiple matching state directories
 
 When `--refresh` is used, NEWA will:
 1. Check the current status of incomplete Testing Farm requests
 2. Update the state directory with fresh data
 3. Display the updated status information
 
-Example:
+Examples:
 ```
 $ newa -D /var/tmp/newa/run-123 list --refresh
+$ newa --event-filter erratum.id=167842 list --all --refresh
 ```
 
 #### Option `--refresh-all`
 
-Refreshes all Testing Farm request statuses before listing, regardless of their current status. This option overrides `--refresh` and also requires a specific state directory to be specified via `-D/--state-dir` or `-P/--prev-state-dir`.
+Refreshes all Testing Farm request statuses before listing, regardless of their current status. This option overrides `--refresh` and requires either:
+- A specific state directory via `-D/--state-dir` or `-P/--prev-state-dir`, or
+- An event filter via `--event-filter` to refresh multiple matching state directories
 
 Use this option when you want to force a status update for all requests, including those that have already completed.
 
-Example:
+Examples:
 ```
 $ newa -P list --refresh-all
+$ newa --event-filter erratum.id=167842 list --all --refresh-all
 ```
 
 Basic usage examples:
@@ -2130,6 +2138,9 @@ $ newa -D /var/tmp/newa/run-123 list --refresh
 
 # List previous state directory with all requests refreshed
 $ newa -P list --refresh-all
+
+# List and refresh all state directories matching an event filter
+$ newa --event-filter erratum.id=167842 list --all --refresh
 ```
 
 ## Bash Auto-Completion

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -53,14 +53,14 @@ from newa.cli.report_helpers import _update_all_tf_request_statuses
     is_flag=True,
     default=False,
     help='Refresh Testing Farm request statuses before listing (only incomplete requests). '
-         'Requires -D/--state-dir or -P/--prev-state-dir.',
+         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
     )
 @click.option(
     '--refresh-all',
     is_flag=True,
     default=False,
     help='Refresh all Testing Farm request statuses before listing (overrides --refresh). '
-         'Requires -D/--state-dir or -P/--prev-state-dir.',
+         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
     )
 @click.pass_obj
 def cmd_list(
@@ -81,11 +81,13 @@ def cmd_list(
     # Validate --last parameter
     if last < 1:
         raise click.UsageError("'--last' must be >= 1")
-    # Ensure --refresh and --refresh-all are only used with a specific state-dir
-    if (refresh or refresh_all) and not ctx.state_dirpath.is_dir():
+    # Ensure --refresh and --refresh-all are only used with a specific state-dir or event filter
+    if ((refresh or refresh_all) and not ctx.state_dirpath.is_dir() and
+            not ctx.event_filter_pattern):
         raise click.UsageError(
-            '--refresh and --refresh-all require a specific state directory. '
-            'Use -D/--state-dir or -P/--prev-state-dir to specify one.')
+            '--refresh and --refresh-all require a specific state directory or --event-filter. '
+            'Use -D/--state-dir, -P/--prev-state-dir, or --event-filter '
+            'to specify what to refresh.')
     # save current logger level and statedir
     saved_logger_level = ctx.logger.level
     saved_state_dir = ctx.state_dirpath
@@ -94,7 +96,8 @@ def cmd_list(
     if ctx.logger.level != logging.DEBUG:
         ctx.logger.setLevel(logging.WARN)
     # when existing state-dir has been provided, use it
-    if ctx.state_dirpath.is_dir():
+    specific_state_dir = saved_state_dir.is_dir()
+    if specific_state_dir:
         state_dirs = [ctx.state_dirpath]
     # otherwise choose last N dirs or all dirs
     else:
@@ -112,10 +115,15 @@ def cmd_list(
         print(f'{" " * indent}{s}', end=end)
 
     for state_dir in state_dirs:
-        state_dir_color = Colors.STATE_DIR or Colors.ORANGE
-        print(f'{colorize_text(str(state_dir), state_dir_color)}:')
         ctx.state_dirpath = state_dir
         event_jobs = list(ctx.load_artifact_jobs(filter_events=True))
+        # Skip this state dir if no events match the filter, but only when listing
+        # multiple directories. Always show explicitly specified state dir.
+        if not event_jobs and not specific_state_dir:
+            continue
+        # Print state dir header only if there are events to show
+        state_dir_color = Colors.STATE_DIR or Colors.ORANGE
+        print(f'{colorize_text(str(state_dir), state_dir_color)}:')
         event_color = Colors.EVENT or Colors.RED
         for event_job in event_jobs:
             if event_job.erratum:


### PR DESCRIPTION
Allow --refresh and --refresh-all options to work with --event-filter when listing multiple state directories. This enables refreshing Testing Farm request statuses across all state directories matching an event filter.

Also improve list output by skipping empty state directories when using event filters, while preserving the behavior of always showing explicitly specified state directories.

Update documentation with usage examples and recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable the list command to refresh Testing Farm request statuses when using event filters and improve how filtered state directories are displayed.

New Features:
- Allow --refresh and --refresh-all to be used with --event-filter to refresh Testing Farm request statuses across multiple matching state directories.

Enhancements:
- Skip empty state directories when listing with event filters while still always showing an explicitly specified state directory.
- Clarify and expand README documentation for list command refresh options and event-filter usage with examples and recommendations.

Documentation:
- Document combined usage of --event-filter with list, including recommendation to use --all to cover all state directories and new examples for --refresh/--refresh-all with filters.