### PR TITLE
control jira comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ deduplicate_releases = 1
 [jira]
 url = https://...
 token = *JIRATOKEN*
+# enable_comments = 1  # (enabled by default, set to 0 to disable)
 # For Jira Cloud (atlassian.net), also specify email:
 # email = your-email@example.com
 [reportportal]
@@ -126,6 +127,7 @@ NEWA_ET_DEDUPLICATE_RELEASES
 NEWA_JIRA_URL
 NEWA_JIRA_TOKEN
 NEWA_JIRA_EMAIL
+NEWA_JIRA_ENABLE_COMMENTS
 NEWA_JIRA_PROJECT
 NEWA_REPORTPORTAL_URL
 NEWA_REPORTPORTAL_TOKEN

--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,20 @@ $ newa --environment FOO=bar event --compose Fedora-40 ...
 
 Enables YAML files rewrite when they already exist in state-dir.
 
+#### Option `--no-comments`
+
+Disables all comment additions to Errata Tool, RoG merge requests, and Jira issues. This option overrides all comment-related settings from both configuration files and environment variables:
+- `erratatool/enable_comments` (or `NEWA_ET_ENABLE_COMMENTS`)
+- `rog/enable_comments` (or `NEWA_ROG_ENABLE_COMMENTS`)
+- `jira/enable_comments` (or `NEWA_JIRA_ENABLE_COMMENTS`)
+
+This is useful when you want to run NEWA workflows without posting any comments, regardless of how the configuration is set.
+
+Example:
+```
+$ newa --no-comments jira --issue-config my-config.yaml schedule execute report
+```
+
 ### Subcommand `event`
 
 This subcommand is associated with a particular event (like an erratum) and it attempts to read details about it so that this data can be utilized in later parts of the workflow. While we are using erratum as an event example, other event types could be supported in the future (e.g. compose, build, GitLab MR, Jira issue etc.).

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -184,19 +184,20 @@ def process_execute_job_for_summary(
     comment = jira_connection.sanitize_comment(comment)
 
     # Add comment to Jira issue
-    ctx.logger.info(f'Adding AI summary comment to {jira_id}')
-    try:
-        jira_client = jira_connection.get_connection()
-        jira_client.add_comment(
-            jira_id,
-            comment,
-            visibility={
-                'type': 'group',
-                'value': execute_job.jira.group}
-            if execute_job.jira.group else None)
-        ctx.logger.info(f'Successfully added AI summary to {jira_id}')
-    except Exception as e:
-        ctx.logger.error(f'Error adding comment to Jira issue {jira_id}: {e}')
+    if ctx.settings.jira_enable_comments:
+        ctx.logger.info(f'Adding AI summary comment to {jira_id}')
+        try:
+            jira_client = jira_connection.get_connection()
+            jira_client.add_comment(
+                jira_id,
+                comment,
+                visibility={
+                    'type': 'group',
+                    'value': execute_job.jira.group}
+                if execute_job.jira.group else None)
+            ctx.logger.info(f'Successfully added AI summary to {jira_id}')
+        except Exception as e:
+            ctx.logger.error(f'Error adding comment to Jira issue {jira_id}: {e}')
 
 
 @click.command(name='summarize')

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -330,8 +330,9 @@ def _process_rp_launches_and_jira_updates(
         # Update Jira issue if not using execute --continue
         if not (jira_id.startswith(JIRA_NONE_ID) or ctx.continue_execution):
             jira_connection = ctx.get_jira_connection().get_connection()
-            _add_jira_comment_for_execution(
-                ctx, jira_connection, jira_id, job, launch_url)
+            if ctx.settings.jira_enable_comments:
+                _add_jira_comment_for_execution(
+                    ctx, jira_connection, jira_id, job, launch_url)
 
             # Update Errata Tool if needed
             if et and launch_url:

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -199,6 +199,12 @@ def _should_filter_yaml_file(
          'and "!" for NOT (e.g., "!slow"). '
          'Can combine: "regression|security,!slow".',
     )
+@click.option(
+    '--no-comments',
+    is_flag=True,
+    default=False,
+    help='Disable all comments (Errata Tool, RoG MR, and Jira).',
+    )
 @click.pass_context
 def main(click_context: click.Context,
          state_dir: str,
@@ -214,7 +220,8 @@ def main(click_context: click.Context,
          action_id_filter: str,
          issue_id_filter: str,
          event_filter: str,
-         action_tag_filter: str) -> None:
+         action_tag_filter: str,
+         no_comments: bool) -> None:
     """NEWA - New Errata Workflow Automation."""
     import io
     import tarfile
@@ -296,12 +303,20 @@ def main(click_context: click.Context,
         cli_context={},
         prev_state_dirpath=prev_state_dirpath,
         force=force,
+        no_comments=no_comments,
         action_id_filter_pattern=pattern,
         issue_id_filter_pattern=issue_pattern,
         event_filter_pattern=event_filter_obj,
         action_tag_filter_pattern=tag_filter_obj,
         )
     click_context.obj = ctx
+
+    # Override comment settings when --no-comments is specified
+    # This takes precedence over config file and environment variable settings
+    if no_comments:
+        ctx.settings.et_enable_comments = False
+        ctx.settings.rog_enable_comments = False
+        ctx.settings.jira_enable_comments = False
 
     # In case of '--help' we are going to end here
     if '--help' in sys.argv:

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -385,17 +385,18 @@ def _process_jira_id_reports(
             ctx.logger.info(f'Updating Jira issue {jira_id} with test results')
 
         # Add Jira comments - more might be needed if we have exceeded comment length limit
-        for jira_description in jira_descriptions:
-            comment = _build_jira_comment(
-                launch_uuid,
-                launch_url,
-                jira_description,
-                footer,
-                first_comment=jira_description == jira_descriptions[0],
-                progress_mode=progress_mode)
-            _add_jira_comment_for_report(
-                ctx, jira_connection, jira_id, execute_jobs[0], comment)
-            short_sleep()
+        if ctx.settings.jira_enable_comments:
+            for jira_description in jira_descriptions:
+                comment = _build_jira_comment(
+                    launch_uuid,
+                    launch_url,
+                    jira_description,
+                    footer,
+                    first_comment=jira_description == jira_descriptions[0],
+                    progress_mode=progress_mode)
+                _add_jira_comment_for_report(
+                    ctx, jira_connection, jira_id, execute_jobs[0], comment)
+                short_sleep()
 
         # Transition Jira issue if needed (skip in progress mode)
         if not progress_mode:

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -241,6 +241,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
     new_state_dir: bool = False
     prev_state_dirpath: Optional[Path] = None
     force: bool = False
+    no_comments: bool = False
     action_id_filter_pattern: Optional[Pattern[str]] = None
     issue_id_filter_pattern: Optional[Pattern[str]] = None
     event_filter_pattern: Optional[EventFilter] = None

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -55,6 +55,7 @@ class Settings:  # type: ignore[no-untyped-def]
     et_enable_comments: bool = False
     et_deduplicate_releases: bool = False
     rog_enable_comments: bool = False
+    jira_enable_comments: bool = True
     rp_url: str = ''
     rp_token: str = ''
     rp_project: str = ''
@@ -130,6 +131,12 @@ class Settings:  # type: ignore[no-untyped-def]
                     cp,
                     'rog/enable_comments',
                     'NEWA_ROG_ENABLE_COMMENTS')),
+            jira_enable_comments=_str_to_bool(
+                _get(
+                    cp,
+                    'jira/enable_comments',
+                    'NEWA_JIRA_ENABLE_COMMENTS',
+                    '1')),
             rp_url=_get(
                 cp,
                 'reportportal/url',


### PR DESCRIPTION
## Summary by Sourcery

Add configuration and CLI controls to enable or disable automated Jira and other external comments, and gate Jira comment posting accordingly.

New Features:
- Introduce a global --no-comments CLI option to disable posting comments to Errata Tool, RoG merge requests, and Jira issues regardless of configuration.
- Add a jira_enable_comments setting, configurable via config file or NEWA_JIRA_ENABLE_COMMENTS, to control whether Jira comments are posted.

Enhancements:
- Guard Jira comment creation in execution, reporting, and summarization flows behind the jira_enable_comments setting.
- Document Jira comment configuration and the new --no-comments option in the README, including usage examples.

Documentation:
- Document the jira.enable_comments option and NEWA_JIRA_ENABLE_COMMENTS environment variable.
- Add README documentation for the --no-comments CLI flag and its precedence over configuration and environment settings.