### PR TITLE
Add s390 architecture support and exclude from testing

### DIFF
--- a/newa/models/base.py
+++ b/newa/models/base.py
@@ -28,6 +28,7 @@ class Arch(Enum):
     I686 = 'i686'
     X86_64 = 'x86_64'
     AARCH64 = 'aarch64'
+    S390 = 's390'
     S390X = 's390x'
     PPC64LE = 'ppc64le'
     PPC64 = 'ppc64'
@@ -40,7 +41,7 @@ class Arch(Enum):
                       preset: Optional[list['Arch']] = None,
                       compose: Optional[str] = None) -> list['Arch']:
 
-        _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH, Arch.I386, Arch.I686]
+        _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH, Arch.I386, Arch.I686, Arch.S390]
         _all = [Arch(a) for a in Arch.__members__.values() if a not in _exclude]
         _default = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'aarch64']]
         _default_rhel7 = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'ppc64']]


### PR DESCRIPTION
This adds the s390 architecture to the Arch enum and excludes it from the testing architecture lists, similar to how i386 and i686 are handled. This fixes ValueError when parsing RoG/GitLab build logs that contain s390 architecture references, while ensuring only modern s390x is used for actual testing.

Resolves: https://github.com/RedHatQE/newa/issues/364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for the s390 architecture while excluding it from the set of architectures used for testing.

Bug Fixes:
- Prevent ValueError when parsing build logs that reference the s390 architecture.

Enhancements:
- Extend the architecture enumeration to include the s390 architecture and update default architecture filtering accordingly.