### PR TITLE
Add architecture info to list command TF request output

### DIFF
--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -221,13 +221,16 @@ def cmd_list(
                                     execute_job.execution, "result", RequestResult.NONE)
                                 url = getattr(
                                     execute_job.execution, "artifacts_url", "not available")
+                                # Get architecture if available
+                                arch = getattr(execute_job.request, "arch", None)
+                                arch_suffix = f', arch: {arch.value}' if arch else ''
                                 # Apply color formatting to state and result
                                 colored_state = colorize_state(state)
                                 colored_result = colorize_result(result.value)
                                 print(
                                     f' - state: {colored_state}, '
                                     f'result: {colored_result}, '
-                                    f'artifacts: {url}')
+                                    f'artifacts: {url}{arch_suffix}')
                     else:
                         # Apply color formatting to 'not executed' state
                         print(f' - {colorize_state("not executed")}')


### PR DESCRIPTION
Display architecture alongside artifacts URL in 'newa list' output to help users quickly identify which architecture a test request was executed on.

Resolves: https://github.com/RedHatQE/newa/issues/368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Display the architecture of each test request in the `newa list` command output when available.