### PR TITLE
Improve Jira connection error messages for better user experience

### DIFF
--- a/newa/services/jira_connection.py
+++ b/newa/services/jira_connection.py
@@ -205,28 +205,64 @@ class JiraConnection:
         if self._connection is None:
             # Configure API version (use v2 for both Cloud and Server)
             options = {'rest_api_version': '2'}
+            auth_type = 'email + API token' if self.is_cloud else 'Personal Access Token'
 
-            if self.is_cloud:
-                # Jira Cloud requires email + API token for basic auth
-                if not self.email:
-                    raise Exception(
-                        'Jira Cloud (atlassian.net) requires email to be configured. '
-                        'Please set jira/email in config file or '
-                        'NEWA_JIRA_EMAIL environment variable.')
-                self._connection = jira.JIRA(
-                    self.url, basic_auth=(self.email, self.token), options=options)
-            else:
-                # Jira Server uses Personal Access Token
-                self._connection = jira.JIRA(self.url, token_auth=self.token, options=options)
-
-            # Verify connection works
             try:
+                if self.is_cloud:
+                    # Jira Cloud requires email + API token for basic auth
+                    if not self.email:
+                        raise Exception(
+                            'Jira Cloud (atlassian.net) requires email to be configured. '
+                            'Please set jira/email in config file or '
+                            'NEWA_JIRA_EMAIL environment variable.')
+                    self._connection = jira.JIRA(
+                        self.url, basic_auth=(self.email, self.token), options=options)
+                else:
+                    # Jira Server uses Personal Access Token
+                    self._connection = jira.JIRA(self.url, token_auth=self.token, options=options)
+
+                # Verify connection works
                 self._connection.myself()
                 short_sleep()
+
             except jira.JIRAError as e:
-                auth_type = 'email + API token' if self.is_cloud else 'Personal Access Token'
-                raise Exception(
-                    f'Could not authenticate to Jira. Wrong {auth_type}?') from e
+                # Extract useful information from the error
+                error_msg = f'Failed to connect to Jira at {self.url}'
+
+                # Check HTTP status code
+                if hasattr(e, 'status_code'):
+                    status = e.status_code
+                    if status == 401:
+                        error_msg = (
+                            f'Authentication failed (HTTP 401): Invalid credentials.\n'
+                            f'Please check your {auth_type}.\n'
+                            f'Jira URL: {self.url}'
+                            )
+                    elif status == 403:
+                        error_msg = (
+                            f'Access forbidden (HTTP 403): Authentication successful but '
+                            f'insufficient permissions.\n'
+                            f'Jira URL: {self.url}'
+                            )
+                    elif status == 404:
+                        error_msg = (
+                            f'Jira instance not found (HTTP 404): Check the URL.\n'
+                            f'Jira URL: {self.url}'
+                            )
+                    else:
+                        error_msg = (
+                            f'HTTP {status} error connecting to Jira.\n'
+                            f'Jira URL: {self.url}'
+                            )
+                else:
+                    # No status code available, use generic message
+                    error_msg = (
+                        f'Failed to connect to Jira: {str(e)[:200]}\n'
+                        f'Authentication type: {auth_type}\n'
+                        f'Jira URL: {self.url}'
+                        )
+
+                raise Exception(error_msg) from e
 
         return self._connection
 


### PR DESCRIPTION
Replace verbose HTML error dumps with concise, actionable error messages when Jira connection fails. The new error handling:
- Extracts HTTP status codes from JIRAError exceptions
- Provides specific guidance for common errors (401/403/404)
- Shows authentication type and URL without HTML page dumps
- Limits error text to 200 chars for unknown errors

This significantly improves debugging experience by showing users exactly what went wrong instead of 500+ lines of HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Jira connection error handling to provide concise, user-friendly feedback when authentication or connectivity fails.

Bug Fixes:
- Clarify Jira authentication failures by mapping HTTP status codes (401/403/404) to specific, actionable error messages instead of generic exceptions.

Enhancements:
- Replace verbose HTML error dumps from Jira connection failures with short, context-rich messages that include authentication type, URL, and truncated error details for unknown errors.