### PR TITLE
Add --description option for state directory metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,55 @@ $ newa --conf-file ~/.newa.stage event --erratum=12345
 
 Enables debug level logging.
 
+#### Option `--description`, `-d`
+
+Adds a human-readable description to the state directory, stored in `.newa-metadata.yaml`. This is especially useful when you have multiple state directories for the same erratum (e.g., original run, debug sessions, retests) and need to distinguish between them.
+
+The description is displayed in the `newa list` output next to the state directory path.
+
+**Use cases:**
+- When creating a new state directory with `event`, `jira`, or other subcommands
+- When copying a state directory with `--copy-state-dir` (without explicit description, defaults to "Copied from <source>")
+- When extracting a state directory with `--extract-state-dir` (without explicit description, defaults to "Extracted from <source>")
+- When updating an existing state directory (using `-D` or `-P` with `--description`)
+
+Examples:
+```bash
+# Add description when creating a new run
+$ newa -d "Full RC1 validation" event --erratum 12345 jira --issue-config config.yaml
+
+# Add description when copying for debugging
+$ newa -D /var/tmp/newa/run-123 --copy-state-dir -d "Debug tier1 failures" \
+       --action-tag-filter 'tier1' schedule execute
+
+# Copy without explicit description (uses default)
+$ newa -D /var/tmp/newa/run-123 --copy-state-dir schedule
+# Creates description: "Copied from /var/tmp/newa/run-123"
+
+# Extract with description
+$ newa --extract-state-dir https://example.com/archive.tar.gz \
+       -d "From Jenkins job #456" list
+
+# Update description on existing state-dir
+$ newa -D /var/tmp/newa/run-123 -d "Updated description after fix"
+```
+
+**List output with descriptions:**
+```bash
+$ newa list
+/var/tmp/newa/run-789 (Updated after recipe fix):
+  event RHSA-2024:12345
+    ...
+
+/var/tmp/newa/run-456 (Debug tier1 failures):
+  event RHSA-2024:12345
+    ...
+
+/var/tmp/newa/run-123 (Full RC1 validation):
+  event RHSA-2024:12345
+    ...
+```
+
 #### Option `--help`
 
 Prints `newa` usage help to a console.

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -19,6 +19,7 @@ from newa.cli.color_utils import (
     colorize_text,
     init_colors,
     )
+from newa.cli.metadata import StateMetadata
 from newa.cli.report_helpers import _update_all_tf_request_statuses
 
 
@@ -123,7 +124,13 @@ def cmd_list(
             continue
         # Print state dir header only if there are events to show
         state_dir_color = Colors.STATE_DIR or Colors.ORANGE
-        print(f'{colorize_text(str(state_dir), state_dir_color)}:')
+        # Read metadata to get description
+        metadata = StateMetadata(state_dir)
+        description = metadata.get_description()
+        if description:
+            print(f'{colorize_text(str(state_dir), state_dir_color)} ({description}):')
+        else:
+            print(f'{colorize_text(str(state_dir), state_dir_color)}:')
         event_color = Colors.EVENT or Colors.RED
         for event_job in event_jobs:
             if event_job.erratum:

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -23,6 +23,7 @@ from newa.cli.commands.summarize_cmd import cmd_summarize
 from newa.cli.constants import NEWA_DEFAULT_CONFIG
 from newa.cli.event_helpers import parse_event_filter, should_filter_by_event
 from newa.cli.filter_helpers import should_filter_by_action_tags
+from newa.cli.metadata import setup_state_metadata
 from newa.cli.tag_filter import TagFilter, parse_tag_filter
 from newa.cli.utils import get_state_dir, initialize_state_dir
 
@@ -205,6 +206,11 @@ def _should_filter_yaml_file(
     default=False,
     help='Disable all comments (Errata Tool, RoG MR, and Jira).',
     )
+@click.option(
+    '--description', '-d',
+    default='',
+    help='Description for the state directory (stored in .newa-metadata.yaml).',
+    )
 @click.pass_context
 def main(click_context: click.Context,
          state_dir: str,
@@ -221,7 +227,8 @@ def main(click_context: click.Context,
          issue_id_filter: str,
          event_filter: str,
          action_tag_filter: str,
-         no_comments: bool) -> None:
+         no_comments: bool,
+         description: str) -> None:
     """NEWA - New Errata Workflow Automation."""
     import io
     import tarfile
@@ -304,6 +311,7 @@ def main(click_context: click.Context,
         prev_state_dirpath=prev_state_dirpath,
         force=force,
         no_comments=no_comments,
+        description=description,
         action_id_filter_pattern=pattern,
         issue_id_filter_pattern=issue_pattern,
         event_filter_pattern=event_filter_obj,
@@ -378,6 +386,14 @@ def main(click_context: click.Context,
             ctx.logger.info(
                 f'Kept {kept_count} YAML file(s), deleted {deleted_count} non-matching')
 
+        # Handle metadata for extracted state-dir
+        setup_state_metadata(
+            ctx.state_dirpath,
+            description=description,
+            parent_state_dir=extract_state_dir,
+            operation='extract',
+            logger=ctx.logger)
+
     # copy YAML files from the given state directory to a new state-dir
     if copy_state_dir:
         assert source_state_dir is not None  # guaranteed by validation above
@@ -421,6 +437,14 @@ def main(click_context: click.Context,
             ctx.logger.info(
                 f'Copied {copied_count} YAML file(s), skipped {skipped_count}')
 
+        # Handle metadata for copied state-dir
+        setup_state_metadata(
+            ctx.state_dirpath,
+            description=description,
+            parent_state_dir=str(source_dir),
+            operation='copy',
+            logger=ctx.logger)
+
     def _split(s: str) -> tuple[str, str]:
         """Split key='some value' into a tuple (key, value)."""
         r = re.match(r"""^\s*([a-zA-Z0-9_][a-zA-Z0-9_\-]*)=["']?(.*?)["']?\s*$""", s)
@@ -433,6 +457,16 @@ def main(click_context: click.Context,
     # store environment variables and context provided on a cmdline
     ctx.cli_environment.update(dict(_split(s) for s in envvars))
     ctx.cli_context.update(dict(_split(s) for s in contexts))
+
+    # Handle description update for existing state-dir (when using -D or -P with --description)
+    # This allows updating description without running other subcommands
+    if (description and (state_dir or prev_state_dir) and not copy_state_dir
+            and not extract_state_dir and ctx.state_dirpath.exists() and not ctx.new_state_dir):
+        setup_state_metadata(
+            ctx.state_dirpath,
+            description=description,
+            operation='update',
+            logger=ctx.logger)
 
     # If no subcommand was specified, invoke the list command by default.
     # Avoid doing this during resilient parsing (e.g., shell completion).

--- a/newa/cli/metadata.py
+++ b/newa/cli/metadata.py
@@ -1,0 +1,92 @@
+"""State directory metadata utilities."""
+
+import logging
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from newa.utils.yaml_utils import yaml_parser
+
+METADATA_FILENAME = '.newa-metadata.yaml'
+
+OperationType = Literal['copy', 'extract', 'new', 'update']
+
+
+class StateMetadata:
+    """Manages state directory metadata."""
+
+    def __init__(self, state_dir: Path):
+        """Initialize metadata for a state directory."""
+        self.state_dir = state_dir
+        self.metadata_file = state_dir / METADATA_FILENAME
+
+    def read(self) -> dict[str, Any]:
+        """Read metadata from the state directory."""
+        if not self.metadata_file.exists():
+            return {}
+        return yaml_parser().load(self.metadata_file.read_text()) or {}
+
+    def write(self, data: dict[str, Any]) -> None:
+        """Write metadata to the state directory."""
+        import io
+        yaml = yaml_parser()
+        stream = io.StringIO()
+        yaml.dump(data, stream)
+        self.metadata_file.write_text(stream.getvalue())
+
+    def update(self, **kwargs: Any) -> None:
+        """Update metadata fields."""
+        data = self.read()
+        data.update(kwargs)
+        self.write(data)
+
+    def get_description(self) -> Optional[str]:
+        """Get the description from metadata."""
+        return self.read().get('description')
+
+    def set_description(self, description: str) -> None:
+        """Set the description in metadata."""
+        self.update(description=description)
+
+    def set_parent_state_dir(self, parent_dir: Path) -> None:
+        """Set the parent state directory (for copied state dirs)."""
+        self.update(parent_state_dir=str(parent_dir))
+
+
+def setup_state_metadata(
+        state_dir: Path,
+        description: str = '',
+        parent_state_dir: Optional[str] = None,
+        operation: Optional[OperationType] = None,
+        logger: Optional[logging.Logger] = None) -> None:
+    """Setup metadata for a state directory with appropriate defaults.
+
+    Centralizes metadata setup logic to ensure consistent behavior across
+    all state-dir operations (new, copy, extract, update).
+
+    Args:
+        state_dir: Path to the state directory
+        description: User-provided description (optional)
+        parent_state_dir: Source path/URL for copied/extracted state-dirs
+        operation: Type of operation ('copy', 'extract', 'new', 'update')
+        logger: Logger for debug messages
+    """
+    metadata = StateMetadata(state_dir)
+
+    # Set parent if provided (copy/extract operations)
+    if parent_state_dir:
+        metadata.update(parent_state_dir=parent_state_dir)
+
+    # Determine final description
+    final_description = None
+    if description:
+        final_description = description
+    elif operation == 'copy' and parent_state_dir:
+        final_description = f'Copied from {parent_state_dir}'
+    elif operation == 'extract' and parent_state_dir:
+        final_description = f'Extracted from {parent_state_dir}'
+
+    # Set description if we have one
+    if final_description:
+        metadata.set_description(final_description)
+        if logger:
+            logger.debug(f'Description set: "{final_description}"')

--- a/newa/cli/utils.py
+++ b/newa/cli/utils.py
@@ -60,6 +60,19 @@ def initialize_state_dir(ctx: CLIContext) -> None:
     with open(os.path.join(ctx.state_dirpath, f'{os.getppid()}.ppid'), 'w'):
         pass
 
+    # Set description for new state-dir if provided and not already set
+    # (copy and extract operations handle their own descriptions)
+    if ctx.description and ctx.new_state_dir:
+        from newa.cli.metadata import StateMetadata, setup_state_metadata
+        metadata = StateMetadata(ctx.state_dirpath)
+        # Only set if metadata file doesn't exist yet (avoid overwriting copy/extract descriptions)
+        if not metadata.metadata_file.exists():
+            setup_state_metadata(
+                ctx.state_dirpath,
+                description=ctx.description,
+                operation='new',
+                logger=ctx.logger)
+
 
 def test_file_presence(statedir: Path, prefix: str) -> bool:
     """Check if files with given prefix exist in state directory."""

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -242,6 +242,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
     prev_state_dirpath: Optional[Path] = None
     force: bool = False
     no_comments: bool = False
+    description: str = ''
     action_id_filter_pattern: Optional[Pattern[str]] = None
     issue_id_filter_pattern: Optional[Pattern[str]] = None
     event_filter_pattern: Optional[EventFilter] = None

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -1,0 +1,242 @@
+"""Tests for state directory metadata functionality."""
+
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from newa.cli.metadata import METADATA_FILENAME, StateMetadata, setup_state_metadata
+
+
+@pytest.fixture
+def temp_state_dir(tmp_path):
+    """Create a temporary state directory."""
+    state_dir = tmp_path / "run-123"
+    state_dir.mkdir()
+    return state_dir
+
+
+def test_metadata_file_creation(temp_state_dir):
+    """Test that metadata file is created correctly."""
+    metadata = StateMetadata(temp_state_dir)
+    assert metadata.metadata_file == temp_state_dir / METADATA_FILENAME
+    assert not metadata.metadata_file.exists()
+
+    metadata.set_description("Test description")
+    assert metadata.metadata_file.exists()
+
+
+def test_set_and_get_description(temp_state_dir):
+    """Test setting and getting description."""
+    metadata = StateMetadata(temp_state_dir)
+
+    # Initially no description
+    assert metadata.get_description() is None
+
+    # Set description
+    metadata.set_description("My test run")
+    assert metadata.get_description() == "My test run"
+
+    # Update description
+    metadata.set_description("Updated description")
+    assert metadata.get_description() == "Updated description"
+
+
+def test_set_parent_state_dir(temp_state_dir):
+    """Test setting parent state directory."""
+    metadata = StateMetadata(temp_state_dir)
+    parent_dir = Path("/var/tmp/newa/run-100")
+
+    metadata.set_parent_state_dir(parent_dir)
+
+    data = metadata.read()
+    assert data['parent_state_dir'] == str(parent_dir)
+
+
+def test_metadata_persistence(temp_state_dir):
+    """Test that metadata persists across instances."""
+    metadata1 = StateMetadata(temp_state_dir)
+    metadata1.set_description("Persistent test")
+    metadata1.set_parent_state_dir(Path("/tmp/parent"))
+
+    # Create new instance and verify data persists
+    metadata2 = StateMetadata(temp_state_dir)
+    assert metadata2.get_description() == "Persistent test"
+    data = metadata2.read()
+    assert data['parent_state_dir'] == "/tmp/parent"
+
+
+def test_update_multiple_fields(temp_state_dir):
+    """Test updating multiple metadata fields at once."""
+    metadata = StateMetadata(temp_state_dir)
+
+    metadata.update(
+        description="Test run",
+        parent_state_dir="/tmp/source",
+        custom_field="custom_value",
+        )
+
+    data = metadata.read()
+    assert data['description'] == "Test run"
+    assert data['parent_state_dir'] == "/tmp/source"
+    assert data['custom_field'] == "custom_value"
+
+
+def test_read_nonexistent_metadata(temp_state_dir):
+    """Test reading metadata when file doesn't exist."""
+    metadata = StateMetadata(temp_state_dir)
+    data = metadata.read()
+    assert data == {}
+    assert metadata.get_description() is None
+
+
+def test_metadata_yaml_format(temp_state_dir):
+    """Test that metadata is stored as valid YAML."""
+    metadata = StateMetadata(temp_state_dir)
+    metadata.set_description("Test description")
+    metadata.set_parent_state_dir(Path("/tmp/parent"))
+
+    # Read the file content directly
+    content = metadata.metadata_file.read_text()
+
+    # Verify it contains expected YAML structure
+    assert "description:" in content
+    assert "parent_state_dir:" in content
+    assert "Test description" in content
+    assert "/tmp/parent" in content
+
+
+def test_description_with_special_characters(temp_state_dir):
+    """Test description with special characters."""
+    metadata = StateMetadata(temp_state_dir)
+    special_desc = "Test: with 'quotes' and \"double quotes\" & symbols!"
+
+    metadata.set_description(special_desc)
+    assert metadata.get_description() == special_desc
+
+
+def test_parent_state_dir_with_url(temp_state_dir):
+    """Test parent_state_dir with URL (for extracted archives)."""
+    metadata = StateMetadata(temp_state_dir)
+    url = "https://example.com/archive.tar.gz"
+
+    # For URLs, we pass them directly without Path() wrapper
+    metadata.update(parent_state_dir=url)
+
+    data = metadata.read()
+    assert data['parent_state_dir'] == url
+
+
+class TestSetupStateMetadata:
+    """Tests for the centralized setup_state_metadata helper."""
+
+    def test_new_operation_with_description(self, temp_state_dir):
+        """Test new state-dir with user-provided description."""
+        setup_state_metadata(
+            temp_state_dir,
+            description="New test run",
+            operation='new')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == "New test run"
+        data = metadata.read()
+        assert 'parent_state_dir' not in data
+
+    def test_new_operation_without_description(self, temp_state_dir):
+        """Test new state-dir without description (no metadata created)."""
+        setup_state_metadata(
+            temp_state_dir,
+            operation='new')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert not metadata.metadata_file.exists()
+
+    def test_copy_operation_with_custom_description(self, temp_state_dir):
+        """Test copy operation with user-provided description."""
+        parent = "/var/tmp/newa/run-100"
+        setup_state_metadata(
+            temp_state_dir,
+            description="Custom copy description",
+            parent_state_dir=parent,
+            operation='copy')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == "Custom copy description"
+        data = metadata.read()
+        assert data['parent_state_dir'] == parent
+
+    def test_copy_operation_with_default_description(self, temp_state_dir):
+        """Test copy operation with auto-generated description."""
+        parent = "/var/tmp/newa/run-100"
+        setup_state_metadata(
+            temp_state_dir,
+            parent_state_dir=parent,
+            operation='copy')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == f"Copied from {parent}"
+        data = metadata.read()
+        assert data['parent_state_dir'] == parent
+
+    def test_extract_operation_with_custom_description(self, temp_state_dir):
+        """Test extract operation with user-provided description."""
+        archive_url = "https://example.com/archive.tar.gz"
+        setup_state_metadata(
+            temp_state_dir,
+            description="From Jenkins build",
+            parent_state_dir=archive_url,
+            operation='extract')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == "From Jenkins build"
+        data = metadata.read()
+        assert data['parent_state_dir'] == archive_url
+
+    def test_extract_operation_with_default_description(self, temp_state_dir):
+        """Test extract operation with auto-generated description."""
+        archive_url = "https://example.com/archive.tar.gz"
+        setup_state_metadata(
+            temp_state_dir,
+            parent_state_dir=archive_url,
+            operation='extract')
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == f"Extracted from {archive_url}"
+        data = metadata.read()
+        assert data['parent_state_dir'] == archive_url
+
+    def test_update_operation(self, temp_state_dir):
+        """Test update operation to change existing description."""
+        # Create initial metadata
+        metadata = StateMetadata(temp_state_dir)
+        metadata.set_description("Old description")
+
+        # Update with new description
+        setup_state_metadata(
+            temp_state_dir,
+            description="Updated description",
+            operation='update')
+
+        assert metadata.get_description() == "Updated description"
+
+    def test_logger_debug_called(self, temp_state_dir):
+        """Test that logger.debug is called when description is set."""
+        mock_logger = mock.MagicMock(spec=logging.Logger)
+
+        setup_state_metadata(
+            temp_state_dir,
+            description="Test description",
+            operation='new',
+            logger=mock_logger)
+
+        mock_logger.debug.assert_called_once_with('Description set: "Test description"')
+
+    def test_no_operation_specified(self, temp_state_dir):
+        """Test behavior when operation is not specified."""
+        setup_state_metadata(
+            temp_state_dir,
+            description="Description without operation")
+
+        metadata = StateMetadata(temp_state_dir)
+        assert metadata.get_description() == "Description without operation"


### PR DESCRIPTION
Adds support for human-readable descriptions on state directories, stored in .newa-metadata.yaml files. This helps users distinguish between multiple state directories for the same erratum (e.g., original runs, debug sessions, retests).

Features:
- New --description/-d option to set description on state directories
- Automatic default descriptions for copied/extracted state directories
- Displays descriptions in 'newa list' output
- Tracks parent state directory for lineage tracking
- Support for updating descriptions on existing state directories

Usage examples:
- New run: newa -d "Full RC1 validation" event --erratum 12345
- Copy: newa -D /path/run-123 --copy-state-dir -d "Debug session"
- Extract: newa -E archive.tar.gz -d "From Jenkins job #456"
- Update: newa -D /path/run-123 -d "Updated description"

## Summary by Sourcery

Add support for human-readable metadata on state directories and surface it in CLI behavior and list output.

New Features:
- Introduce a --description / -d CLI option to attach human-readable descriptions to state directories, stored in a .newa-metadata.yaml file.
- Add a StateMetadata helper for reading and writing per-state-directory metadata, including descriptions and parent state directory information.
- Display state directory descriptions alongside paths in the newa list command output.

Enhancements:
- Automatically populate default descriptions and parent state directory metadata when copying or extracting state directories, and allow updating descriptions on existing state directories.

Tests:
- Add unit tests covering StateMetadata behavior, including description handling, parent state directory tracking, persistence, YAML format, and special characters in descriptions.