### PR TITLE
add newa search subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ Using --state-dir=/var/tmp/newa/run-123
 
 #### Option `--prev-state-dir`, `-P`
 
-Similar to `--state-dir`, however no directory is specified. Instead, `newa` will use the most recent (modified) directory used by `newa` process issued from the current shell.
+Similar to `--state-dir`, however no directory is specified. Instead, `newa` will use the most recently modified directory used by `newa` processes invoked from the current shell.
 
 **Multi-Terminal Support:** This option is intentionally shell-scoped to support running multiple NEWA sessions in parallel across different terminals. Each terminal maintains its own "previous state-dir" context, allowing you to run different test campaigns simultaneously without interference:
 

--- a/README.md
+++ b/README.md
@@ -2371,6 +2371,54 @@ $ newa search --erratum "jira_issues=RHEL-1951" --jira "action_id=.*regression"
 
 The object search recursively searches through nested dictionaries and lists within each object type.
 
+#### Output detail levels
+
+The search command provides three levels of output detail, controlled by `--brief` and `--full` options:
+
+**`--brief`** - Show only state directory headers (with description and modification time):
+```bash
+$ newa search --text keylime --brief
+/var/tmp/newa/run-271 (modified 2 hours ago)
+/var/tmp/newa/run-254 (Copied from stage, modified 6 days ago)
+Found 2 state directories matching --text "keylime"
+```
+
+**Default (no flag)** - Intelligent default based on search criteria:
+- Searching with `--event`, `--erratum`, `--rog-mr`, or `--text`: Shows event-level details
+- Searching with `--jira`: Shows event-level and Jira issue details
+
+```bash
+$ newa search --text keylime
+/var/tmp/newa/run-271 (modified 2 hours ago):
+  event E: 155199 @ RHEL-10.2.GA - keylime update
+  https://errata.devel.redhat.com/advisory/155199
+
+$ newa search --jira SECENGSP-10172
+/var/tmp/newa/run-254:
+  event E: 154960 @ RHEL-10.2.GA - keylime-agent-rust update
+  https://errata.devel.redhat.com/advisory/154960
+    issue SECENGSP-10172 (tier1) - Test keylime-agent-rust
+    https://issues.redhat.com/browse/SECENGSP-10172
+    tags: tier1, baseline
+```
+
+**`--full`** - Show complete details including events, Jira issues, and execution status (like `newa list` default):
+```bash
+$ newa search --erratum keylime --full
+/var/tmp/newa/run-271 (modified 2 hours ago):
+  event E: 155199 @ RHEL-10.2.GA - keylime update
+  https://errata.devel.redhat.com/advisory/155199
+    issue SECENGSP-10173 (tier1) - Test keylime
+    https://issues.redhat.com/browse/SECENGSP-10173
+      recipe: https://gitlab.com/redhat/.../plans/tier1.fmf
+      ReportPortal launch: keylime_RHEL-10.2_tier1
+      https://reportportal.example.com/ui/#runs/...
+      abc123-def456
+        - state: complete, result: passed, artifacts: https://artifacts.dev.testing-farm.io/...
+```
+
+The `--brief` and `--full` options are mutually exclusive.
+
 #### Use cases
 
 - Find all state directories for a specific package or component

--- a/README.md
+++ b/README.md
@@ -2250,11 +2250,20 @@ $ newa --event-filter erratum.id=167842 list --all --refresh
 
 The `search` subcommand allows you to search for text or patterns across all metadata files in all state directories. This is useful for finding state directories related to specific packages, errata, issues, or any other metadata.
 
-The search supports regular expressions and is case-insensitive by default. It searches through all YAML files in each state directory. For matching directories, it displays event-level details (similar to `newa list --events`).
+The search supports regular expressions and is case-insensitive by default. For matching directories, it displays event-level details (similar to `newa list --events`).
+
+**Search options:**
+- `--text PATTERN` - Search across all YAML files
+- `--event PATTERN` - Search within event objects (event-* files)
+- `--erratum PATTERN` - Search within erratum objects (event-* files)
+- `--rog-mr PATTERN` - Search within RoG MR objects (event-* files)
+- `--jira PATTERN` - Search within Jira issue objects (jira-* files)
+
+At least one search option is required. When multiple options are specified, all conditions must match (AND logic).
 
 #### Option `--text`
 
-Specifies the text or regular expression pattern to search for (required). The search is performed case-insensitively across all YAML files.
+Specifies the text or regular expression pattern to search for across all YAML files. The search is performed case-insensitively.
 
 **Simple text search examples:**
 ```
@@ -2312,12 +2321,64 @@ If a state directory has a description (set via `--description` or `-d`), it wil
   https://errata.devel.redhat.com/advisory/154960
 ```
 
-**Use cases:**
+#### Object-specific search options
 
-- Find all state directories related to a specific package or component
+The `--event`, `--erratum`, `--rog-mr`, and `--jira` options allow you to search within specific NEWA objects:
+
+- **`--event PATTERN`** - Search within **event** objects (metadata about the triggering event)
+- **`--erratum PATTERN`** - Search within **erratum** objects (advisory metadata from Errata Tool)
+- **`--rog-mr PATTERN`** - Search within **RoG merge request** objects (RoG metadata)
+- **`--jira PATTERN`** - Search within **Jira tracker** objects (testing issues created by NEWA)
+
+**Important distinction:**
+- `--jira SECENGSP-10172` finds state directories where NEWA created a Jira tracker with ID SECENGSP-10172 (i.e., the testing issue)
+- `--erratum SECENGSP-10172` finds state directories for advisories that **fix** Jira issue SECENGSP-10172 (listed in erratum's `jira_issues` field)
+
+Each option supports two formats:
+
+**Format 1: `PATTERN`** - Search for the pattern in any field within the object:
+```bash
+# Find errata containing "keylime" in any field
+$ newa search --erratum keylime
+
+# Find NEWA Jira trackers containing "SECENGSP-10172" in any field
+$ newa search --jira "SECENGSP-10172"
+```
+
+**Format 2: `KEY=PATTERN`** - Search only in fields where the key matches KEY:
+```bash
+# Find errata with id="154960"
+$ newa search --erratum "id=154960"
+
+# Find NEWA Jira trackers with action_id matching "tier1"
+$ newa search --jira "action_id=tier1"
+
+# Find events with type_="erratum"
+$ newa search --event "type_=erratum"
+```
+
+**Combining multiple search options** (all must match):
+```bash
+# Find keylime errata that have tier1 testing
+$ newa search --erratum keylime --jira "action_id=tier1"
+
+# Find erratum 154960 with specific NEWA tracker
+$ newa search --erratum "id=154960" --jira "id=SECENGSP-10172"
+
+# Find advisories fixing RHEL-1951 that have regression testing
+$ newa search --erratum "jira_issues=RHEL-1951" --jira "action_id=.*regression"
+```
+
+The object search recursively searches through nested dictionaries and lists within each object type.
+
+#### Use cases
+
+- Find all state directories for a specific package or component
 - Locate test runs for a particular erratum or advisory
-- Search for state directories containing specific Jira issues
-- Find runs related to a particular RHEL release or compose
+- Search for state directories containing specific NEWA Jira trackers
+- Find advisories that fix specific Jira issues
+- Filter by specific test action IDs (e.g., tier1, regression)
+- Combine multiple criteria to narrow down results (e.g., keylime errata with tier1 testing)
 
 ## Bash Auto-Completion
 

--- a/README.md
+++ b/README.md
@@ -2246,6 +2246,79 @@ $ newa -P list --refresh-all
 $ newa --event-filter erratum.id=167842 list --all --refresh
 ```
 
+### Subcommand `search`
+
+The `search` subcommand allows you to search for text or patterns across all metadata files in all state directories. This is useful for finding state directories related to specific packages, errata, issues, or any other metadata.
+
+The search supports regular expressions and is case-insensitive by default. It searches through all YAML files in each state directory. For matching directories, it displays event-level details (similar to `newa list --events`).
+
+#### Option `--text`
+
+Specifies the text or regular expression pattern to search for (required). The search is performed case-insensitively across all YAML files.
+
+**Simple text search examples:**
+```
+# Search for a specific package
+$ newa search --text keylime
+
+# Search for an erratum ID
+$ newa search --text 154960
+
+# Search for a RHEL release
+$ newa search --text "RHEL-10.2"
+
+# Search for a Jira issue
+$ newa search --text "PROJ-123"
+```
+
+**Regular expression pattern examples:**
+```
+# Search for multiple RHEL versions (9 or 10)
+$ newa search --text "RHEL-(9|10)\.2"
+
+# Search for erratum IDs starting with 154
+$ newa search --text "^154.*"
+
+# Search for keylime with optional agent or rust suffix
+$ newa search --text "keylime-(agent-)?rust"
+
+# Search for Jira issues matching a pattern
+$ newa search --text "SECENGSP-\d+"
+
+# Search for security-related updates
+$ newa search --text "security.*update"
+```
+
+**Output format:**
+
+The command displays matching state directories with event-level details:
+```
+$ newa search --text keylime
+/var/tmp/newa/run-271:
+  event E: 155199 @ RHEL-10.2.GA - keylime update
+  https://errata.devel.redhat.com/advisory/155199
+
+/var/tmp/newa/run-254:
+  event E: 154960 @ RHEL-10.2.GA - keylime-agent-rust update
+  https://errata.devel.redhat.com/advisory/154960
+
+Found 2 state directories with matches
+```
+
+If a state directory has a description (set via `--description` or `-d`), it will be displayed:
+```
+/var/tmp/newa/run-403 (Copied from /var/tmp/newa-stage/run-740):
+  event E: 154960 @ RHEL-10.2.GA - keylime-agent-rust update
+  https://errata.devel.redhat.com/advisory/154960
+```
+
+**Use cases:**
+
+- Find all state directories related to a specific package or component
+- Locate test runs for a particular erratum or advisory
+- Search for state directories containing specific Jira issues
+- Find runs related to a particular RHEL release or compose
+
 ## Bash Auto-Completion
 
 NEWA includes bash auto-completion support for all commands and options. When you install NEWA via the RPM package, bash completion is automatically installed.

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -34,7 +34,7 @@ def _get_relative_time(state_dir: Path) -> str:
 
     Returns:
         Relative time string like "2 days ago", "3 hours ago", etc.
-        Returns empty string if ppid file not found.
+        Returns empty string if ppid file not found or on error.
     """
     # Find .ppid file
     ppid_files = list(state_dir.glob('*.ppid'))
@@ -43,11 +43,11 @@ def _get_relative_time(state_dir: Path) -> str:
 
     # Get modification time from the most recently modified .ppid file
     try:
+        # Cache timezone to avoid potential time changes between calls
+        tz = datetime.now().astimezone().tzinfo
         mtime = max(ppid_file.stat().st_mtime for ppid_file in ppid_files)
-        # Use local timezone-aware datetime to avoid DTZ warnings
-        # We want local time since users think in their local timezone
-        mtime_dt = datetime.fromtimestamp(mtime, tz=datetime.now().astimezone().tzinfo)
-        now = datetime.now(tz=datetime.now().astimezone().tzinfo)
+        mtime_dt = datetime.fromtimestamp(mtime, tz=tz)
+        now = datetime.now(tz=tz)
         delta = now - mtime_dt
 
         # Calculate relative time
@@ -68,7 +68,8 @@ def _get_relative_time(state_dir: Path) -> str:
             return f'{weeks} week{"s" if weeks != 1 else ""} ago'
         months = int(seconds / 2592000)
         return f'{months} month{"s" if months != 1 else ""} ago'
-    except Exception:
+    except (OSError, ValueError):
+        # Failed to read or interpret the ppid file; treat as no relative time
         return ''
 
 

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -108,17 +108,13 @@ def print_state_dirs(
         # For brief mode, just print the header and continue
         if brief:
             if description and relative_time:
-                header = f'{
-                    colorize_text(
-                        str(state_dir),
-                        state_dir_color)} ({description}, modified {relative_time})'
+                header = (f'{colorize_text(str(state_dir), state_dir_color)} '
+                          f'({description}, modified {relative_time})')
             elif description:
                 header = f'{colorize_text(str(state_dir), state_dir_color)} ({description})'
             elif relative_time:
-                header = f'{
-                    colorize_text(
-                        str(state_dir),
-                        state_dir_color)} (modified {relative_time})'
+                header = (f'{colorize_text(str(state_dir), state_dir_color)} '
+                          f'(modified {relative_time})')
             else:
                 header = f'{colorize_text(str(state_dir), state_dir_color)}'
             print(header)
@@ -133,17 +129,13 @@ def print_state_dirs(
 
         # Build header with colon suffix for detailed view
         if description and relative_time:
-            header = f'{
-                colorize_text(
-                    str(state_dir),
-                    state_dir_color)} ({description}, modified {relative_time}):'
+            header = (f'{colorize_text(str(state_dir), state_dir_color)} '
+                      f'({description}, modified {relative_time}):')
         elif description:
             header = f'{colorize_text(str(state_dir), state_dir_color)} ({description}):'
         elif relative_time:
-            header = f'{
-                colorize_text(
-                    str(state_dir),
-                    state_dir_color)} (modified {relative_time}):'
+            header = (f'{colorize_text(str(state_dir), state_dir_color)} '
+                      f'(modified {relative_time}):')
         else:
             header = f'{colorize_text(str(state_dir), state_dir_color)}:'
         print(header)

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -23,95 +23,25 @@ from newa.cli.metadata import StateMetadata
 from newa.cli.report_helpers import _update_all_tf_request_statuses
 
 
-@click.command(name='list')
-@click.option(
-    '--last',
-    default=10,
-    help='Print details of recent newa executions.',
-    show_default=True,
-    )
-@click.option(
-    '--all', '-a',
-    'list_all',
-    is_flag=True,
-    default=False,
-    help='List all newa state directories (overrides --last).',
-    )
-@click.option(
-    '--events',
-    is_flag=True,
-    default=False,
-    help='List details only up to the event level.',
-    )
-@click.option(
-    '--issues',
-    is_flag=True,
-    default=False,
-    help='List details only up to the Jira issue level.',
-    )
-@click.option(
-    '--refresh',
-    is_flag=True,
-    default=False,
-    help='Refresh Testing Farm request statuses before listing (only incomplete requests). '
-         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
-    )
-@click.option(
-    '--refresh-all',
-    is_flag=True,
-    default=False,
-    help='Refresh all Testing Farm request statuses before listing (overrides --refresh). '
-         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
-    )
-@click.pass_obj
-def cmd_list(
+def print_state_dirs(
         ctx: CLIContext,
-        last: int,
-        list_all: bool,
-        events: bool,
-        issues: bool,
-        refresh: bool,
-        refresh_all: bool) -> None:
-    """List NEWA execution details from state directories."""
-    ctx.enter_command('list')
-    # Initialize colors based on environment, terminal capabilities, and config
-    init_colors(ctx.settings.newa_color_config)
-    # Ensure --events and --issues are not used together
-    if events and issues:
-        raise click.UsageError('--events and --issues cannot be used together')
-    # Validate --last parameter
-    if last < 1:
-        raise click.UsageError("'--last' must be >= 1")
-    # Ensure --refresh and --refresh-all are only used with a specific state-dir or event filter
-    if ((refresh or refresh_all) and not ctx.state_dirpath.is_dir() and
-            not ctx.event_filter_pattern):
-        raise click.UsageError(
-            '--refresh and --refresh-all require a specific state directory or --event-filter. '
-            'Use -D/--state-dir, -P/--prev-state-dir, or --event-filter '
-            'to specify what to refresh.')
-    # save current logger level and statedir
-    saved_logger_level = ctx.logger.level
-    saved_state_dir = ctx.state_dirpath
-    # when not in DEBUG, decrese log verbosity so it won't be too noisy
-    # when loading individual YAML files
-    if ctx.logger.level != logging.DEBUG:
-        ctx.logger.setLevel(logging.WARN)
-    # when existing state-dir has been provided, use it
-    specific_state_dir = saved_state_dir.is_dir()
-    if specific_state_dir:
-        state_dirs = [ctx.state_dirpath]
-    # otherwise choose last N dirs or all dirs
-    else:
-        try:
-            entries = os.scandir(ctx.settings.newa_statedir_topdir)
-        except FileNotFoundError as e:
-            raise Exception(f'{ctx.settings.newa_statedir_topdir} does not exist') from e
-        sorted_entries = sorted(entries, key=lambda entry: os.path.getmtime(Path(entry)))
-        if list_all:
-            state_dirs = [Path(e.path) for e in sorted_entries]
-        else:
-            state_dirs = [Path(e.path) for e in sorted_entries[-last:]]
+        state_dirs: list[Path],
+        events: bool = False,
+        issues: bool = False,
+        refresh: bool = False,
+        refresh_all: bool = False,
+        specific_state_dir: bool = False) -> None:
+    """Print state directories with their event/issue/execution details.
 
+    Args:
+        ctx: CLI context
+        state_dirs: List of state directories to print
+        events: Stop at event level (don't show issues)
+        issues: Stop at issue level (don't show executions)
+        refresh: Refresh incomplete TF request statuses
+        refresh_all: Refresh all TF request statuses
+        specific_state_dir: Whether printing a specific state dir (affects filtering)
+    """
     def _print(indent: int, s: str, end: str = '\n') -> None:
         print(f'{" " * indent}{s}', end=end)
 
@@ -242,6 +172,107 @@ def cmd_list(
                         # Apply color formatting to 'not executed' state
                         print(f' - {colorize_state("not executed")}')
         print()
+
+
+@click.command(name='list')
+@click.option(
+    '--last',
+    default=10,
+    help='Print details of recent newa executions.',
+    show_default=True,
+    )
+@click.option(
+    '--all', '-a',
+    'list_all',
+    is_flag=True,
+    default=False,
+    help='List all newa state directories (overrides --last).',
+    )
+@click.option(
+    '--events',
+    is_flag=True,
+    default=False,
+    help='List details only up to the event level.',
+    )
+@click.option(
+    '--issues',
+    is_flag=True,
+    default=False,
+    help='List details only up to the Jira issue level.',
+    )
+@click.option(
+    '--refresh',
+    is_flag=True,
+    default=False,
+    help='Refresh Testing Farm request statuses before listing (only incomplete requests). '
+         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
+    )
+@click.option(
+    '--refresh-all',
+    is_flag=True,
+    default=False,
+    help='Refresh all Testing Farm request statuses before listing (overrides --refresh). '
+         'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
+    )
+@click.pass_obj
+def cmd_list(
+        ctx: CLIContext,
+        last: int,
+        list_all: bool,
+        events: bool,
+        issues: bool,
+        refresh: bool,
+        refresh_all: bool) -> None:
+    """List NEWA execution details from state directories."""
+    ctx.enter_command('list')
+    # Initialize colors based on environment, terminal capabilities, and config
+    init_colors(ctx.settings.newa_color_config)
+    # Ensure --events and --issues are not used together
+    if events and issues:
+        raise click.UsageError('--events and --issues cannot be used together')
+    # Validate --last parameter
+    if last < 1:
+        raise click.UsageError("'--last' must be >= 1")
+    # Ensure --refresh and --refresh-all are only used with a specific state-dir or event filter
+    if ((refresh or refresh_all) and not ctx.state_dirpath.is_dir() and
+            not ctx.event_filter_pattern):
+        raise click.UsageError(
+            '--refresh and --refresh-all require a specific state directory or --event-filter. '
+            'Use -D/--state-dir, -P/--prev-state-dir, or --event-filter '
+            'to specify what to refresh.')
+    # save current logger level and statedir
+    saved_logger_level = ctx.logger.level
+    saved_state_dir = ctx.state_dirpath
+    # when not in DEBUG, decrese log verbosity so it won't be too noisy
+    # when loading individual YAML files
+    if ctx.logger.level != logging.DEBUG:
+        ctx.logger.setLevel(logging.WARN)
+    # when existing state-dir has been provided, use it
+    specific_state_dir = saved_state_dir.is_dir()
+    if specific_state_dir:
+        state_dirs = [ctx.state_dirpath]
+    # otherwise choose last N dirs or all dirs
+    else:
+        try:
+            entries = os.scandir(ctx.settings.newa_statedir_topdir)
+        except FileNotFoundError as e:
+            raise Exception(f'{ctx.settings.newa_statedir_topdir} does not exist') from e
+        sorted_entries = sorted(entries, key=lambda entry: os.path.getmtime(Path(entry)))
+        if list_all:
+            state_dirs = [Path(e.path) for e in sorted_entries]
+        else:
+            state_dirs = [Path(e.path) for e in sorted_entries[-last:]]
+
+    # Print all state directories
+    print_state_dirs(
+        ctx,
+        state_dirs,
+        events=events,
+        issues=issues,
+        refresh=refresh,
+        refresh_all=refresh_all,
+        specific_state_dir=specific_state_dir)
+
     # restore logger level and statedir
     ctx.logger.setLevel(saved_logger_level)
     ctx.state_dirpath = saved_state_dir

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 
 import click
@@ -23,6 +24,54 @@ from newa.cli.metadata import StateMetadata
 from newa.cli.report_helpers import _update_all_tf_request_statuses
 
 
+def _get_relative_time(state_dir: Path) -> str:
+    """Get relative time string for state directory.
+
+    Uses the modification time of the .ppid file in the state directory.
+
+    Args:
+        state_dir: Path to the state directory
+
+    Returns:
+        Relative time string like "2 days ago", "3 hours ago", etc.
+        Returns empty string if ppid file not found.
+    """
+    # Find .ppid file
+    ppid_files = list(state_dir.glob('*.ppid'))
+    if not ppid_files:
+        return ''
+
+    # Get modification time from the most recently modified .ppid file
+    try:
+        mtime = max(ppid_file.stat().st_mtime for ppid_file in ppid_files)
+        # Use local timezone-aware datetime to avoid DTZ warnings
+        # We want local time since users think in their local timezone
+        mtime_dt = datetime.fromtimestamp(mtime, tz=datetime.now().astimezone().tzinfo)
+        now = datetime.now(tz=datetime.now().astimezone().tzinfo)
+        delta = now - mtime_dt
+
+        # Calculate relative time
+        seconds = delta.total_seconds()
+        if seconds < 60:
+            return 'just now'
+        if seconds < 3600:  # Less than 1 hour
+            minutes = int(seconds / 60)
+            return f'{minutes} minute{"s" if minutes != 1 else ""} ago'
+        if seconds < 86400:  # Less than 1 day
+            hours = int(seconds / 3600)
+            return f'{hours} hour{"s" if hours != 1 else ""} ago'
+        if seconds < 604800:  # Less than 1 week
+            days = int(seconds / 86400)
+            return f'{days} day{"s" if days != 1 else ""} ago'
+        if seconds < 2592000:  # Less than 30 days
+            weeks = int(seconds / 604800)
+            return f'{weeks} week{"s" if weeks != 1 else ""} ago'
+        months = int(seconds / 2592000)
+        return f'{months} month{"s" if months != 1 else ""} ago'
+    except Exception:
+        return ''
+
+
 def print_state_dirs(
         ctx: CLIContext,
         state_dirs: list[Path],
@@ -30,7 +79,8 @@ def print_state_dirs(
         issues: bool = False,
         refresh: bool = False,
         refresh_all: bool = False,
-        specific_state_dir: bool = False) -> None:
+        specific_state_dir: bool = False,
+        brief: bool = False) -> None:
     """Print state directories with their event/issue/execution details.
 
     Args:
@@ -41,26 +91,62 @@ def print_state_dirs(
         refresh: Refresh incomplete TF request statuses
         refresh_all: Refresh all TF request statuses
         specific_state_dir: Whether printing a specific state dir (affects filtering)
+        brief: Only show state dir headers (no events/issues/executions)
     """
     def _print(indent: int, s: str, end: str = '\n') -> None:
         print(f'{" " * indent}{s}', end=end)
 
     for state_dir in state_dirs:
         ctx.state_dirpath = state_dir
+
+        # Build state dir header
+        state_dir_color = Colors.STATE_DIR or Colors.ORANGE
+        metadata = StateMetadata(state_dir)
+        description = metadata.get_description()
+        relative_time = _get_relative_time(state_dir)
+
+        # For brief mode, just print the header and continue
+        if brief:
+            if description and relative_time:
+                header = f'{
+                    colorize_text(
+                        str(state_dir),
+                        state_dir_color)} ({description}, modified {relative_time})'
+            elif description:
+                header = f'{colorize_text(str(state_dir), state_dir_color)} ({description})'
+            elif relative_time:
+                header = f'{
+                    colorize_text(
+                        str(state_dir),
+                        state_dir_color)} (modified {relative_time})'
+            else:
+                header = f'{colorize_text(str(state_dir), state_dir_color)}'
+            print(header)
+            continue
+
+        # For non-brief mode, load events and show details
         event_jobs = list(ctx.load_artifact_jobs(filter_events=True))
         # Skip this state dir if no events match the filter, but only when listing
         # multiple directories. Always show explicitly specified state dir.
         if not event_jobs and not specific_state_dir:
             continue
-        # Print state dir header only if there are events to show
-        state_dir_color = Colors.STATE_DIR or Colors.ORANGE
-        # Read metadata to get description
-        metadata = StateMetadata(state_dir)
-        description = metadata.get_description()
-        if description:
-            print(f'{colorize_text(str(state_dir), state_dir_color)} ({description}):')
+
+        # Build header with colon suffix for detailed view
+        if description and relative_time:
+            header = f'{
+                colorize_text(
+                    str(state_dir),
+                    state_dir_color)} ({description}, modified {relative_time}):'
+        elif description:
+            header = f'{colorize_text(str(state_dir), state_dir_color)} ({description}):'
+        elif relative_time:
+            header = f'{
+                colorize_text(
+                    str(state_dir),
+                    state_dir_color)} (modified {relative_time}):'
         else:
-            print(f'{colorize_text(str(state_dir), state_dir_color)}:')
+            header = f'{colorize_text(str(state_dir), state_dir_color)}:'
+        print(header)
         event_color = Colors.EVENT or Colors.RED
         for event_job in event_jobs:
             if event_job.erratum:

--- a/newa/cli/commands/search_cmd.py
+++ b/newa/cli/commands/search_cmd.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from typing import Any, Optional
 
 import click
 
@@ -10,21 +11,129 @@ from newa.cli.color_utils import init_colors
 from newa.cli.commands.list_cmd import print_state_dirs
 
 
+def _parse_search_spec(spec: str) -> tuple[Optional[str], str]:
+    """Parse search specification into key pattern and value pattern.
+
+    Args:
+        spec: Search specification, either 'PATTERN' or 'KEY=PATTERN'
+
+    Returns:
+        Tuple of (key_pattern, value_pattern). key_pattern is None for value-only search.
+    """
+    if '=' in spec:
+        # Split on first '=' only
+        key_pattern, value_pattern = spec.split('=', 1)
+        return (key_pattern.strip(), value_pattern.strip())
+    return (None, spec)
+
+
+def _search_object(
+        obj: Any,
+        key_pattern: Optional[re.Pattern[str]],
+        value_pattern: re.Pattern[str],
+        current_key: str = '') -> bool:
+    """Recursively search within an object for matching values.
+
+    Args:
+        obj: Object to search (can be dict, list, or scalar)
+        key_pattern: Compiled regex for key matching (None to match all keys)
+        value_pattern: Compiled regex for value matching
+        current_key: Current key name (for recursive calls)
+
+    Returns:
+        True if a match is found, False otherwise
+    """
+    # Check if current key matches (if key_pattern is specified)
+    if key_pattern and current_key:
+        key_matches = bool(key_pattern.search(current_key))
+    else:
+        # If no key_pattern, we search all keys
+        key_matches = key_pattern is None
+
+    # If this is a dict, recurse into its items
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if _search_object(value, key_pattern, value_pattern, current_key=key):
+                return True
+        return False
+
+    # If this is a list, recurse into its items
+    if isinstance(obj, list):
+        for item in obj:
+            if _search_object(item, key_pattern, value_pattern, current_key=current_key):
+                return True
+        return False
+
+    # Scalar value - check if we should search it
+    if key_matches:
+        # Convert value to string and search
+        str_value = str(obj) if obj is not None else ''
+        if value_pattern.search(str_value):
+            return True
+
+    return False
+
+
 @click.command(name='search')
 @click.option(
     '--text',
-    required=True,
     help='Regular expression pattern to search for across all metadata in state directories '
          '(case-insensitive).',
+    )
+@click.option(
+    '--event',
+    help='Search within event objects. Format: "PATTERN" or "KEY=PATTERN". '
+         'Searches event-* YAML files.',
+    )
+@click.option(
+    '--erratum',
+    help='Search within erratum objects. Format: "PATTERN" or "KEY=PATTERN". '
+         'Searches event-* YAML files.',
+    )
+@click.option(
+    '--rog-mr',
+    help='Search within RoG MR objects. Format: "PATTERN" or "KEY=PATTERN". '
+         'Searches event-* YAML files.',
+    )
+@click.option(
+    '--jira',
+    help='Search within Jira issue objects. Format: "PATTERN" or "KEY=PATTERN". '
+         'Searches jira-* YAML files.',
     )
 @click.pass_obj
 def cmd_search(
         ctx: CLIContext,
-        text: str) -> None:
+        text: Optional[str],
+        event: Optional[str],
+        erratum: Optional[str],
+        rog_mr: Optional[str],
+        jira: Optional[str]) -> None:
     """Search for text/pattern across all metadata in state directories.
 
     The search supports regular expressions and is case-insensitive by default.
+
+    Examples:
+        # Search all metadata
+        newa search --text keylime
+
+        # Search within event objects
+        newa search --event "type_=erratum"
+
+        # Search within erratum objects for specific key
+        newa search --erratum "id=154960"
+
+        # Search within jira objects
+        newa search --jira "PROJ-.*"
+
+        # Combine multiple filters
+        newa search --erratum "keylime" --jira "action_id=tier1"
     """
+    # Validate that at least one search option is provided
+    if not any([text, event, erratum, rog_mr, jira]):
+        raise click.UsageError(
+            'At least one search option is required: '
+            '--text, --event, --erratum, --rog-mr, or --jira')
+
     ctx.enter_command('search')
     init_colors(ctx.settings.newa_color_config)
 
@@ -36,12 +145,29 @@ def cmd_search(
     if ctx.logger.level != logging.DEBUG:
         ctx.logger.setLevel(logging.WARN)
 
-    # Compile regex pattern (case-insensitive)
-    try:
-        search_pattern = re.compile(text, re.IGNORECASE)
-    except re.error as e:
-        raise click.ClickException(
-            f'Invalid regular expression pattern: {e}') from e
+    # Parse and compile search specifications
+    search_specs: list[tuple[str, Optional[re.Pattern[str]], re.Pattern[str]]] = []
+
+    if text:
+        try:
+            search_specs.append(('text', None, re.compile(text, re.IGNORECASE)))
+        except re.error as e:
+            raise click.ClickException(
+                f'Invalid regular expression in --text: {e}') from e
+
+    for option_name, option_value in [
+            ('event', event), ('erratum', erratum),
+            ('rog', rog_mr), ('jira', jira)]:
+        if option_value:
+            key_pattern_str, value_pattern_str = _parse_search_spec(option_value)
+            try:
+                key_pat: Optional[re.Pattern[str]] = re.compile(
+                    key_pattern_str, re.IGNORECASE) if key_pattern_str else None
+                value_pat: re.Pattern[str] = re.compile(value_pattern_str, re.IGNORECASE)
+                search_specs.append((option_name, key_pat, value_pat))
+            except re.error as e:
+                raise click.ClickException(
+                    f'Invalid regular expression in --{option_name}: {e}') from e
 
     matching_state_dirs = []
 
@@ -58,22 +184,92 @@ def cmd_search(
         if not state_dir.is_dir():
             continue
 
-        # Search in all YAML files in the state directory
-        yaml_files = list(state_dir.glob('*.yaml'))
-        if not yaml_files:
-            continue
+        # Set context to this state directory
+        ctx.state_dirpath = state_dir
+        state_dir_matches = True  # All specs must match
 
-        # Check if any file contains the search pattern
-        for yaml_file in yaml_files:
-            try:
-                content = yaml_file.read_text()
-                if search_pattern.search(content):
-                    matching_state_dirs.append(state_dir)
-                    ctx.logger.debug(f'Match in {state_dir}: {yaml_file.name}')
-                    break  # Found match in this dir, move to next dir
-            except Exception as e:
-                ctx.logger.debug(f'Error reading {yaml_file}: {e}')
-                continue
+        # Process each search specification
+        for search_type, key_pattern, value_pattern in search_specs:
+            spec_matches = False
+
+            if search_type == 'text':
+                # Search in all YAML files
+                yaml_files = list(state_dir.glob('*.yaml'))
+                for yaml_file in yaml_files:
+                    try:
+                        content = yaml_file.read_text()
+                        if value_pattern.search(content):
+                            ctx.logger.debug(
+                                f'Text match in {state_dir}: {yaml_file.name}')
+                            spec_matches = True
+                            break
+                    except Exception as e:
+                        ctx.logger.debug(f'Error reading {yaml_file}: {e}')
+                        continue
+
+            elif search_type == 'jira':
+                # Load jira jobs and search in jira objects
+                try:
+                    from attrs import asdict
+                    jira_jobs = list(ctx.load_jira_jobs(filter_actions=False))
+                    for jira_job in jira_jobs:
+                        # Convert jira object to dict for searching
+                        try:
+                            jira_dict = asdict(jira_job.jira)
+                        except Exception:
+                            # Fallback to vars if asdict fails
+                            jira_dict = vars(jira_job.jira)
+
+                        if _search_object(jira_dict, key_pattern, value_pattern):
+                            ctx.logger.debug(
+                                f'Jira match in {state_dir}: {jira_job.jira.id}')
+                            spec_matches = True
+                            break
+                except Exception as e:
+                    ctx.logger.debug(f'Error loading jira jobs from {state_dir}: {e}')
+
+            elif search_type in ['event', 'erratum', 'rog']:
+                # Load artifact jobs and search in respective objects
+                try:
+                    from attrs import asdict
+                    artifact_jobs = list(ctx.load_artifact_jobs(filter_events=False))
+                    for artifact_job in artifact_jobs:
+                        # Get the appropriate object based on search type
+                        obj: Any = None
+                        if search_type == 'event':
+                            obj = artifact_job.event
+                        elif search_type == 'erratum':
+                            obj = artifact_job.erratum
+                        elif search_type == 'rog':
+                            obj = artifact_job.rog
+
+                        if obj is None:
+                            continue
+
+                        # Convert object to dict for searching
+                        try:
+                            obj_dict = asdict(obj)
+                        except Exception:
+                            # Fallback to vars if asdict fails
+                            obj_dict = vars(obj)
+
+                        if _search_object(obj_dict, key_pattern, value_pattern):
+                            ctx.logger.debug(
+                                f'{search_type.capitalize()} match in {state_dir}')
+                            spec_matches = True
+                            break
+                except Exception as e:
+                    ctx.logger.debug(
+                        f'Error loading artifact jobs from {state_dir}: {e}')
+
+            # If this spec didn't match, the directory doesn't match
+            if not spec_matches:
+                state_dir_matches = False
+                break
+
+        # Add directory if all search specs matched
+        if state_dir_matches:
+            matching_state_dirs.append(state_dir)
 
     # Print matching state directories with event-level details
     if matching_state_dirs:
@@ -85,12 +281,25 @@ def cmd_search(
             refresh=False,
             refresh_all=False,
             specific_state_dir=False)
+        # Build description of search criteria
+        search_desc_parts = []
+        if text:
+            search_desc_parts.append(f'--text "{text}"')
+        if event:
+            search_desc_parts.append(f'--event "{event}"')
+        if erratum:
+            search_desc_parts.append(f'--erratum "{erratum}"')
+        if rog_mr:
+            search_desc_parts.append(f'--rog-mr "{rog_mr}"')
+        if jira:
+            search_desc_parts.append(f'--jira "{jira}"')
+        search_desc = ', '.join(search_desc_parts)
         print(
             f'Found {
                 len(matching_state_dirs)} state director{
-                "y" if len(matching_state_dirs) == 1 else "ies"} with matches')
+                "y" if len(matching_state_dirs) == 1 else "ies"} matching {search_desc}')
     else:
-        print(f'No matches found for "{text}"')
+        print('No matches found')
 
     # Restore logger level and statedir
     ctx.logger.setLevel(saved_logger_level)

--- a/newa/cli/commands/search_cmd.py
+++ b/newa/cli/commands/search_cmd.py
@@ -173,9 +173,11 @@ def cmd_search(
             raise click.ClickException(
                 f'Invalid regular expression in --text: {e}') from e
 
-    for option_name, option_value in [
-            ('event', event), ('erratum', erratum),
-            ('rog', rog_mr), ('jira', jira)]:
+    for option_name, option_value, option_flag in [
+            ('event', event, 'event'),
+            ('erratum', erratum, 'erratum'),
+            ('rog', rog_mr, 'rog-mr'),
+            ('jira', jira, 'jira')]:
         if option_value:
             key_pattern_str, value_pattern_str = _parse_search_spec(option_value)
             try:
@@ -185,7 +187,7 @@ def cmd_search(
                 search_specs.append((option_name, key_pat, value_pat))
             except re.error as e:
                 raise click.ClickException(
-                    f'Invalid regular expression in --{option_name}: {e}') from e
+                    f'Invalid regular expression in --{option_flag}: {e}') from e
 
     matching_state_dirs = []
 
@@ -333,10 +335,9 @@ def cmd_search(
         if jira:
             search_desc_parts.append(f'--jira "{jira}"')
         search_desc = ', '.join(search_desc_parts)
-        print(
-            f'Found {
-                len(matching_state_dirs)} state director{
-                "y" if len(matching_state_dirs) == 1 else "ies"} matching {search_desc}')
+        count = len(matching_state_dirs)
+        plural = "y" if count == 1 else "ies"
+        print(f'Found {count} state director{plural} matching {search_desc}')
     else:
         print('No matches found')
 

--- a/newa/cli/commands/search_cmd.py
+++ b/newa/cli/commands/search_cmd.py
@@ -1,0 +1,97 @@
+"""Search command for NEWA CLI."""
+
+import logging
+import re
+
+import click
+
+from newa import CLIContext
+from newa.cli.color_utils import init_colors
+from newa.cli.commands.list_cmd import print_state_dirs
+
+
+@click.command(name='search')
+@click.option(
+    '--text',
+    required=True,
+    help='Regular expression pattern to search for across all metadata in state directories '
+         '(case-insensitive).',
+    )
+@click.pass_obj
+def cmd_search(
+        ctx: CLIContext,
+        text: str) -> None:
+    """Search for text/pattern across all metadata in state directories.
+
+    The search supports regular expressions and is case-insensitive by default.
+    """
+    ctx.enter_command('search')
+    init_colors(ctx.settings.newa_color_config)
+
+    # save current logger level and statedir
+    saved_logger_level = ctx.logger.level
+    saved_state_dir = ctx.state_dirpath
+    # when not in DEBUG, decrease log verbosity so it won't be too noisy
+    # when loading individual YAML files
+    if ctx.logger.level != logging.DEBUG:
+        ctx.logger.setLevel(logging.WARN)
+
+    # Compile regex pattern (case-insensitive)
+    try:
+        search_pattern = re.compile(text, re.IGNORECASE)
+    except re.error as e:
+        raise click.ClickException(
+            f'Invalid regular expression pattern: {e}') from e
+
+    matching_state_dirs = []
+
+    # Get all state directories
+    try:
+        entries = list(ctx.settings.newa_statedir_topdir.iterdir())
+    except FileNotFoundError as e:
+        raise Exception(f'{ctx.settings.newa_statedir_topdir} does not exist') from e
+
+    sorted_entries = sorted(entries, key=lambda entry: entry.stat().st_mtime)
+
+    # Find state directories with matches
+    for state_dir in sorted_entries:
+        if not state_dir.is_dir():
+            continue
+
+        # Search in all YAML files in the state directory
+        yaml_files = list(state_dir.glob('*.yaml'))
+        if not yaml_files:
+            continue
+
+        # Check if any file contains the search pattern
+        for yaml_file in yaml_files:
+            try:
+                content = yaml_file.read_text()
+                if search_pattern.search(content):
+                    matching_state_dirs.append(state_dir)
+                    ctx.logger.debug(f'Match in {state_dir}: {yaml_file.name}')
+                    break  # Found match in this dir, move to next dir
+            except Exception as e:
+                ctx.logger.debug(f'Error reading {yaml_file}: {e}')
+                continue
+
+    # Print matching state directories with event-level details
+    if matching_state_dirs:
+        print_state_dirs(
+            ctx,
+            matching_state_dirs,
+            events=True,  # Show event-level details like 'newa list --events'
+            issues=False,
+            refresh=False,
+            refresh_all=False,
+            specific_state_dir=False)
+        print(
+            f'Found {
+                len(matching_state_dirs)} state director{
+                "y" if len(matching_state_dirs) == 1 else "ies"} with matches')
+    else:
+        print(f'No matches found for "{text}"')
+
+    # Restore logger level and statedir
+    ctx.logger.setLevel(saved_logger_level)
+    ctx.state_dirpath = saved_state_dir

--- a/newa/cli/commands/search_cmd.py
+++ b/newa/cli/commands/search_cmd.py
@@ -100,6 +100,18 @@ def _search_object(
     help='Search within Jira issue objects. Format: "PATTERN" or "KEY=PATTERN". '
          'Searches jira-* YAML files.',
     )
+@click.option(
+    '--brief',
+    is_flag=True,
+    default=False,
+    help='Show only state directory headers without event/issue details.',
+    )
+@click.option(
+    '--full',
+    is_flag=True,
+    default=False,
+    help='Show full details including events, issues, and executions.',
+    )
 @click.pass_obj
 def cmd_search(
         ctx: CLIContext,
@@ -107,7 +119,9 @@ def cmd_search(
         event: Optional[str],
         erratum: Optional[str],
         rog_mr: Optional[str],
-        jira: Optional[str]) -> None:
+        jira: Optional[str],
+        brief: bool,
+        full: bool) -> None:
     """Search for text/pattern across all metadata in state directories.
 
     The search supports regular expressions and is case-insensitive by default.
@@ -133,6 +147,10 @@ def cmd_search(
         raise click.UsageError(
             'At least one search option is required: '
             '--text, --event, --erratum, --rog-mr, or --jira')
+
+    # Validate that --brief and --full are not used together
+    if brief and full:
+        raise click.UsageError('--brief and --full cannot be used together')
 
     ctx.enter_command('search')
     init_colors(ctx.settings.newa_color_config)
@@ -271,16 +289,37 @@ def cmd_search(
         if state_dir_matches:
             matching_state_dirs.append(state_dir)
 
-    # Print matching state directories with event-level details
+    # Determine display level based on flags and search criteria
+    # Dynamic default: choose detail level based on what was searched
+    show_brief = brief
+    show_events = False
+    show_issues = False
+
+    if not brief and not full:
+        # Dynamic behavior based on search criteria
+        if jira:
+            # Searching jira -> show issues level (events + jira issues)
+            show_issues = True
+        else:
+            # Searching events/erratum/rog/text -> show events level
+            show_events = True
+    elif full:
+        # Full mode: show everything (events + issues + executions)
+        show_events = False
+        show_issues = False
+    # brief mode: show_brief=True already set
+
+    # Print matching state directories
     if matching_state_dirs:
         print_state_dirs(
             ctx,
             matching_state_dirs,
-            events=True,  # Show event-level details like 'newa list --events'
-            issues=False,
+            events=show_events,
+            issues=show_issues,
             refresh=False,
             refresh_all=False,
-            specific_state_dir=False)
+            specific_state_dir=False,
+            brief=show_brief)
         # Build description of search criteria
         search_desc_parts = []
         if text:

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -19,6 +19,7 @@ from newa.cli.commands.jira_cmd import cmd_jira
 from newa.cli.commands.list_cmd import cmd_list
 from newa.cli.commands.report_cmd import cmd_report
 from newa.cli.commands.schedule_cmd import cmd_schedule
+from newa.cli.commands.search_cmd import cmd_search
 from newa.cli.commands.summarize_cmd import cmd_summarize
 from newa.cli.constants import NEWA_DEFAULT_CONFIG
 from newa.cli.event_helpers import parse_event_filter, should_filter_by_event
@@ -483,4 +484,5 @@ main.add_command(cmd_schedule)
 main.add_command(cmd_execute)
 main.add_command(cmd_report)
 main.add_command(cmd_cancel)
+main.add_command(cmd_search)
 main.add_command(cmd_summarize)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,623 @@
+"""Tests for search command."""
+
+import os
+
+from click.testing import CliRunner
+
+from newa import cli
+
+
+def test_search_basic(tmp_path):
+    """Test basic search functionality."""
+    runner = CliRunner()
+
+    # Create topdir with state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create first state directory with matching content
+    state_dir1 = topdir / "run-001"
+    state_dir1.mkdir()
+    (state_dir1 / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime security update
+  url: https://errata.example.com/12345
+  builds:
+    - keylime-1.2.3-4.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create second state directory with matching content
+    state_dir2 = topdir / "run-002"
+    state_dir2.mkdir()
+    (state_dir2 / "event-67890-RHEL-9.yaml").write_text("""
+event:
+  id: '67890'
+  type_: erratum
+erratum:
+  id: '67890'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime agent update
+  url: https://errata.example.com/67890
+  builds:
+    - keylime-agent-2.0.0-1.el9
+  release: RHEL-9.5.0
+compose:
+  id: RHEL-9.5.0-Nightly
+""")
+
+    # Create third state directory without matching content
+    state_dir3 = topdir / "run-003"
+    state_dir3.mkdir()
+    (state_dir3 / "event-11111-RHEL-9.yaml").write_text("""
+event:
+  id: '11111'
+  type_: erratum
+erratum:
+  id: '11111'
+  content_type: rpm
+  respin_count: 1
+  summary: systemd update
+  url: https://errata.example.com/11111
+  builds:
+    - systemd-1.0.0-1.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Run search command
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    # Should find 2 matching state directories
+    assert 'Found 2 state directories with matches' in result.output
+    # Should show the matching directories
+    assert str(state_dir1) in result.output
+    assert str(state_dir2) in result.output
+    # Should not show the non-matching directory
+    assert str(state_dir3) not in result.output
+
+
+def test_search_case_insensitive(tmp_path):
+    """Test that search is case-insensitive."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: KEYLIME Security Update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Search with lowercase
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'Found 1 state directory with matches' in result.output
+    assert str(state_dir) in result.output
+
+    # Search with uppercase
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'SECURITY'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'Found 1 state directory with matches' in result.output
+    assert str(state_dir) in result.output
+
+
+def test_search_no_matches(tmp_path):
+    """Test search with no matching results."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: systemd update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Search for non-existent text
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'nonexistent-package-xyz'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'No matches found for "nonexistent-package-xyz"' in result.output
+    assert str(state_dir) not in result.output
+
+
+def test_search_empty_topdir(tmp_path):
+    """Test search with empty topdir."""
+    runner = CliRunner()
+
+    # Create empty topdir
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Run search
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'No matches found for "keylime"' in result.output
+
+
+def test_search_with_description(tmp_path):
+    """Test search output includes state directory descriptions."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+
+    # Create event file
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create metadata file with description
+    (state_dir / ".newa-metadata.yaml").write_text("""
+description: Test state directory for keylime
+""")
+
+    # Run search
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert str(state_dir) in result.output
+    assert '(Test state directory for keylime)' in result.output
+
+
+def test_search_shows_event_details(tmp_path):
+    """Test that search shows event-level details like 'newa list --events'."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+
+    # Create event file
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime security update
+  url: https://errata.example.com/12345
+  builds:
+    - keylime-1.2.3-4.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Run search
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    # Should show event details
+    assert 'event E:' in result.output
+    assert 'keylime security update' in result.output
+    assert 'https://errata.example.com/12345' in result.output
+
+
+def test_search_multiple_yaml_files(tmp_path):
+    """Test search across multiple YAML files in same directory."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+
+    # Create event file without search term
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: systemd update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create jira file with search term
+    (state_dir / "jira-12345-RHEL-9-PROJ-123.yaml").write_text("""
+jira:
+  id: PROJ-123
+  action_id: keylime_test
+  summary: Test keylime package
+""")
+
+    # Run search
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'keylime'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    # Should find the state directory (match in jira file)
+    assert 'Found 1 state directory with matches' in result.output
+    assert str(state_dir) in result.output
+
+
+def test_search_partial_match(tmp_path):
+    """Test search with partial string matching."""
+    runner = CliRunner()
+
+    # Create topdir with state directory
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    state_dir = topdir / "run-001"
+    state_dir.mkdir()
+    (state_dir / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime security update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Search with partial match
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', 'RHEL-9.4'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'Found 1 state directory with matches' in result.output
+    assert str(state_dir) in result.output
+
+
+def test_search_required_text_option():
+    """Test that --text option is required."""
+    runner = CliRunner()
+
+    # Run search without --text option
+    result = runner.invoke(cli.main, ['search'])
+
+    # Should fail with missing option error
+    assert result.exit_code != 0
+    assert '--text' in result.output or 'required' in result.output.lower()
+
+
+def test_search_regex_pattern(tmp_path):
+    """Test search with regex patterns."""
+    runner = CliRunner()
+
+    # Create topdir with state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create state directory with RHEL-9 content
+    state_dir1 = topdir / "run-001"
+    state_dir1.mkdir()
+    (state_dir1 / "event-12345-RHEL-9.yaml").write_text("""
+event:
+  id: '12345'
+  type_: erratum
+erratum:
+  id: '12345'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime update
+  url: https://errata.example.com/12345
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create state directory with RHEL-10 content
+    state_dir2 = topdir / "run-002"
+    state_dir2.mkdir()
+    (state_dir2 / "event-67890-RHEL-10.yaml").write_text("""
+event:
+  id: '67890'
+  type_: erratum
+erratum:
+  id: '67890'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime update
+  url: https://errata.example.com/67890
+  builds: []
+  release: RHEL-10.2.0
+compose:
+  id: RHEL-10.2.0-Nightly
+""")
+
+    # Create state directory with RHEL-8 content (should not match)
+    state_dir3 = topdir / "run-003"
+    state_dir3.mkdir()
+    (state_dir3 / "event-11111-RHEL-8.yaml").write_text("""
+event:
+  id: '11111'
+  type_: erratum
+erratum:
+  id: '11111'
+  content_type: rpm
+  respin_count: 1
+  summary: systemd update
+  url: https://errata.example.com/11111
+  builds: []
+  release: RHEL-8.10.0
+compose:
+  id: RHEL-8.10.0-Nightly
+""")
+
+    # Search for RHEL-9 or RHEL-10 using regex
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', r'RHEL-(9|10)\.'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    # Should find 2 matching state directories (RHEL-9 and RHEL-10)
+    assert 'Found 2 state directories with matches' in result.output
+    assert str(state_dir1) in result.output
+    assert str(state_dir2) in result.output
+    assert str(state_dir3) not in result.output
+
+
+def test_search_regex_anchors(tmp_path):
+    """Test search with regex word boundaries."""
+    runner = CliRunner()
+
+    # Create topdir with state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create state directory with erratum 154960
+    state_dir1 = topdir / "run-001"
+    state_dir1.mkdir()
+    (state_dir1 / "event-154960-RHEL-9.yaml").write_text("""
+event:
+  id: '154960'
+  type_: erratum
+erratum:
+  id: '154960'
+  content_type: rpm
+  respin_count: 1
+  summary: Test erratum
+  url: https://errata.example.com/154960
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create state directory with erratum 1549601 (should not match exact ID)
+    state_dir2 = topdir / "run-002"
+    state_dir2.mkdir()
+    (state_dir2 / "event-1549601-RHEL-9.yaml").write_text("""
+event:
+  id: '1549601'
+  type_: erratum
+erratum:
+  id: '1549601'
+  content_type: rpm
+  respin_count: 1
+  summary: Test erratum
+  url: https://errata.example.com/1549601
+  builds: []
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Search for erratum IDs starting with 154 (should match both)
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', r"id: '154"],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'Found 2 state directories with matches' in result.output
+
+    # Search for exact erratum ID 154960 using word boundary
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', r"'154960'"],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    assert 'Found 1 state directory with matches' in result.output
+    assert str(state_dir1) in result.output
+    assert str(state_dir2) not in result.output
+
+
+def test_search_regex_optional_groups(tmp_path):
+    """Test search with optional regex groups."""
+    runner = CliRunner()
+
+    # Create topdir with state directories
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Create state directory with keylime
+    state_dir1 = topdir / "run-001"
+    state_dir1.mkdir()
+    (state_dir1 / "event-1.yaml").write_text("""
+event:
+  id: '1'
+  type_: erratum
+erratum:
+  id: '1'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime update
+  url: https://errata.example.com/1
+  builds:
+    - keylime-1.2.3-4.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create state directory with keylime-agent-rust
+    state_dir2 = topdir / "run-002"
+    state_dir2.mkdir()
+    (state_dir2 / "event-2.yaml").write_text("""
+event:
+  id: '2'
+  type_: erratum
+erratum:
+  id: '2'
+  content_type: rpm
+  respin_count: 1
+  summary: keylime-agent-rust update
+  url: https://errata.example.com/2
+  builds:
+    - keylime-agent-rust-2.0.0-1.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Create state directory with systemd (should not match)
+    state_dir3 = topdir / "run-003"
+    state_dir3.mkdir()
+    (state_dir3 / "event-3.yaml").write_text("""
+event:
+  id: '3'
+  type_: erratum
+erratum:
+  id: '3'
+  content_type: rpm
+  respin_count: 1
+  summary: systemd update
+  url: https://errata.example.com/3
+  builds:
+    - systemd-1.0.0-1.el9
+  release: RHEL-9.4.0
+compose:
+  id: RHEL-9.4.0-Nightly
+""")
+
+    # Search for keylime with optional agent-rust suffix
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', r'keylime(-agent-rust)?'],
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    assert result.exit_code == 0
+    # Should find both keylime and keylime-agent-rust
+    assert 'Found 2 state directories with matches' in result.output
+    assert str(state_dir1) in result.output
+    assert str(state_dir2) in result.output
+    assert str(state_dir3) not in result.output
+
+
+def test_search_invalid_regex(tmp_path):
+    """Test search with invalid regex pattern."""
+    runner = CliRunner()
+
+    # Create topdir
+    topdir = tmp_path / "topdir"
+    topdir.mkdir()
+
+    # Search with invalid regex pattern
+    result = runner.invoke(
+        cli.main,
+        ['search', '--text', r'RHEL-[9'],  # Unclosed bracket
+        env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
+
+    # Should fail with regex error
+    assert result.exit_code != 0
+    assert 'Invalid regular expression' in result.output or 'regex' in result.output.lower()

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -83,7 +83,7 @@ compose:
 
     assert result.exit_code == 0
     # Should find 2 matching state directories
-    assert 'Found 2 state directories with matches' in result.output
+    assert 'Found 2 state directories matching' in result.output
     # Should show the matching directories
     assert str(state_dir1) in result.output
     assert str(state_dir2) in result.output
@@ -124,7 +124,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'Found 1 state directory with matches' in result.output
+    assert 'Found 1 state directory matching' in result.output
     assert str(state_dir) in result.output
 
     # Search with uppercase
@@ -134,7 +134,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'Found 1 state directory with matches' in result.output
+    assert 'Found 1 state directory matching' in result.output
     assert str(state_dir) in result.output
 
 
@@ -171,7 +171,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'No matches found for "nonexistent-package-xyz"' in result.output
+    assert 'No matches found' in result.output
     assert str(state_dir) not in result.output
 
 
@@ -190,7 +190,7 @@ def test_search_empty_topdir(tmp_path):
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'No matches found for "keylime"' in result.output
+    assert 'No matches found' in result.output
 
 
 def test_search_with_description(tmp_path):
@@ -323,7 +323,7 @@ jira:
 
     assert result.exit_code == 0
     # Should find the state directory (match in jira file)
-    assert 'Found 1 state directory with matches' in result.output
+    assert 'Found 1 state directory matching' in result.output
     assert str(state_dir) in result.output
 
 
@@ -360,7 +360,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'Found 1 state directory with matches' in result.output
+    assert 'Found 1 state directory matching' in result.output
     assert str(state_dir) in result.output
 
 
@@ -449,7 +449,7 @@ compose:
 
     assert result.exit_code == 0
     # Should find 2 matching state directories (RHEL-9 and RHEL-10)
-    assert 'Found 2 state directories with matches' in result.output
+    assert 'Found 2 state directories matching' in result.output
     assert str(state_dir1) in result.output
     assert str(state_dir2) in result.output
     assert str(state_dir3) not in result.output
@@ -508,7 +508,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'Found 2 state directories with matches' in result.output
+    assert 'Found 2 state directories matching' in result.output
 
     # Search for exact erratum ID 154960 using word boundary
     result = runner.invoke(
@@ -517,7 +517,7 @@ compose:
         env={**os.environ, 'NEWA_STATEDIR_TOPDIR': str(topdir)})
 
     assert result.exit_code == 0
-    assert 'Found 1 state directory with matches' in result.output
+    assert 'Found 1 state directory matching' in result.output
     assert str(state_dir1) in result.output
     assert str(state_dir2) not in result.output
 
@@ -598,7 +598,7 @@ compose:
 
     assert result.exit_code == 0
     # Should find both keylime and keylime-agent-rust
-    assert 'Found 2 state directories with matches' in result.output
+    assert 'Found 2 state directories matching' in result.output
     assert str(state_dir1) in result.output
     assert str(state_dir2) in result.output
     assert str(state_dir3) not in result.output


### PR DESCRIPTION
## Summary by Sourcery

Add a searchable CLI for NEWA state directories and reuse listing logic for richer search output.

New Features:
- Introduce a `search` subcommand to query NEWA state directories by text, event, erratum, RoG MR, or Jira metadata with regex support and configurable output detail levels.

Enhancements:
- Refactor state directory listing into a reusable helper that adds relative modification timestamps and supports brief vs detailed output modes.
- Clarify and expand documentation for the `--prev-state-dir` option, including multi-terminal behavior and examples.

Tests:
- Add extensive unit tests for the new `search` command covering matching behavior, regex handling, output formatting, and error cases.