### PR TITLE
Add default compose mapping for RHEL-6-ELS-EXTENSION

### DIFF
--- a/newa/cli/utils.py
+++ b/newa/cli/utils.py
@@ -95,7 +95,8 @@ def apply_release_mapping(string: str,
             r'-draft$=',
             r'-z$=',
             r'$=-Nightly',
-            # ugly hack to narrow weird TF compose naming for RHEL-7
+            # ugly hack to narrow weird TF compose naming for RHEL-6 and RHEL-7
+            r'RHEL-6-ELS-EXTENSION-Nightly=RHEL-6.10-ZStream',
             r'RHEL-7-ELS-Nightly=RHEL-7.9-ZStream',
             ]
     new_string = string

--- a/tests/unit/test_release_mapping.py
+++ b/tests/unit/test_release_mapping.py
@@ -14,6 +14,7 @@ def test_release_mapping():
         ('RHEL-8.10.0.Z.MAIN+EUS', 'RHEL-8.10.0-Nightly'),
         ('RHEL-8.6.0.Z.AUS', 'RHEL-8.6.0-Nightly'),
         ('RHEL-8.4.0.Z.EUS.EXTENSION', 'RHEL-8.4.0-Nightly'),
+        ('RHEL-6-ELS-EXTENSION', 'RHEL-6.10-ZStream'),
         ('RHEL-7-ELS', 'RHEL-7.9-ZStream'),
         # build target mapping
         ('rhel-10.1-candidate', 'RHEL-10.1-Nightly'),


### PR DESCRIPTION
## Summary

- The release string `RHEL-6-ELS-EXTENSION` is not matched by existing regex rules in the default compose mapping, producing the invalid compose `RHEL-6-ELS-EXTENSION-Nightly`
- This adds an explicit mapping to `RHEL-6.10-ZStream`, following the same pattern as the existing `RHEL-7-ELS` → `RHEL-7.9-ZStream` mapping
- Adds a test case for the new mapping

## Context

When running `newa event -e <errata_id>` for an errata with release `RHEL-6-ELS-EXTENSION`, the compose resolution fails with:

```
Compose RHEL-6-ELS-EXTENSION-Nightly does not exist
```

The existing rules strip `.EXTENSION` only from versioned release strings like `RHEL-8.4.0.Z.EUS.EXTENSION` (via the `\.Z\.?...` pattern), but `RHEL-6-ELS-EXTENSION` doesn't match that pattern because it lacks the `.Z` segment.

## Test plan

- [x] Verified `apply_release_mapping('RHEL-6-ELS-EXTENSION')` returns `RHEL-6.10-ZStream`
- [x] Verified all existing mappings still produce correct results
- [x] Added unit test case

## Summary by Sourcery

Add a default compose mapping for the RHEL-6-ELS-EXTENSION release and cover it with tests.

Bug Fixes:
- Fix compose resolution for RHEL-6-ELS-EXTENSION by mapping it to the RHEL-6.10-ZStream compose.

Tests:
- Add a unit test case verifying the RHEL-6-ELS-EXTENSION to RHEL-6.10-ZStream mapping.