### PR TITLE
Add --full option to list command for RP descriptions

### DIFF
--- a/newa/cli/color_utils.py
+++ b/newa/cli/color_utils.py
@@ -13,6 +13,7 @@ DEFAULT_COLORS = {
     'BLUE': '\033[38;5;75m',  # medium blue
     'ORANGE': '\033[38;5;208m',
     'PURPLE': '\033[38;5;141m',
+    'CYAN': '\033[36m',
     }
 
 
@@ -29,6 +30,7 @@ class Colors:
     BLUE = DEFAULT_COLORS['BLUE']
     ORANGE = DEFAULT_COLORS['ORANGE']
     PURPLE = DEFAULT_COLORS['PURPLE']
+    CYAN = DEFAULT_COLORS['CYAN']
 
     # Palette colors (for output elements)
     STATE_DIR: Optional[str] = None  # None means use default (no override)
@@ -62,6 +64,7 @@ class Colors:
         cls.BLUE = ''
         cls.ORANGE = ''
         cls.PURPLE = ''
+        cls.CYAN = ''
 
 
 def should_use_colors() -> bool:

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -96,6 +96,20 @@ def print_state_dirs(
         brief: Only show state dir headers (no events/issues/executions)
         full: Show full details including RP launch and suite descriptions
     """
+    # Base indentation unit (spaces per nesting level)
+    indent_unit = 2
+
+    def _indent(level: int) -> int:
+        """Calculate indentation based on nesting level.
+
+        Args:
+            level: Nesting level (0=state_dir, 1=event, 2=issue, 3=rp_launch, 4=request, 5=status)
+
+        Returns:
+            Number of spaces for indentation
+        """
+        return level * indent_unit
+
     def _print(indent: int, s: str, end: str = '\n') -> None:
         print(f'{" " * indent}{s}', end=end)
 
@@ -145,25 +159,25 @@ def print_state_dirs(
         event_color = Colors.EVENT or Colors.RED
         for event_job in event_jobs:
             if event_job.erratum:
-                _print(2, colorize_text(
+                _print(_indent(1), colorize_text(
                     f'event {event_job.id} - {event_job.erratum.summary}', event_color))
-                _print(2, event_job.erratum.url)
+                _print(_indent(1), event_job.erratum.url)
             elif event_job.rog:
-                _print(2, colorize_text(
+                _print(_indent(1), colorize_text(
                     f'event {event_job.id} - {event_job.rog.title}', event_color))
             elif event_job.jira_issue:
-                _print(2, colorize_text(
+                _print(_indent(1), colorize_text(
                     f'event {event_job.id} - {event_job.jira_issue.summary}', event_color))
-                _print(2, event_job.jira_issue.url)
+                _print(_indent(1), event_job.jira_issue.url)
                 people_info = []
                 if event_job.jira_issue.assignee:
                     people_info.append(f'assignee: {event_job.jira_issue.assignee}')
                 if event_job.jira_issue.reporter:
                     people_info.append(f'reporter: {event_job.jira_issue.reporter}')
                 if people_info:
-                    _print(2, ', '.join(people_info))
+                    _print(_indent(1), ', '.join(people_info))
             else:
-                _print(2, colorize_text(f'event {event_job.id}', event_color))
+                _print(_indent(1), colorize_text(f'event {event_job.id}', event_color))
             # Skip Jira issues and other details if --events flag is set
             if events:
                 continue
@@ -174,17 +188,17 @@ def print_state_dirs(
                 jira_summary = f'- {jira_job.jira.summary}' if jira_job.jira.summary else ''
                 jira_action_id = jira_job.jira.action_id or 'no action id'
                 issue_line = f'issue {jira_job.jira.id} ({jira_action_id}) {jira_summary}'
-                _print(4, colorize_text(issue_line, issue_color))
+                _print(_indent(2), colorize_text(issue_line, issue_color))
                 if jira_job.jira.url:
-                    _print(4, jira_job.jira.url)
+                    _print(_indent(2), jira_job.jira.url)
                 if jira_job.jira.action_tags:
                     tags_str = ', '.join(jira_job.jira.action_tags)
-                    _print(4, f'tags: {tags_str}')
+                    _print(_indent(2), f'tags: {tags_str}')
                 if jira_job.recipe and jira_job.recipe.url:
                     # Show indicator only when auto_schedule is false
                     auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
                     auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
-                    _print(4, f'recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
+                    _print(_indent(2), f'recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
                 # Skip schedule/execute details if --issues flag is set
                 if issues:
                     continue
@@ -201,7 +215,7 @@ def print_state_dirs(
                     launch_name = schedule_jobs[0].request.reportportal.get('launch_name', None)
                     if launch_name:
                         _print(
-                            6,
+                            _indent(3),
                             colorize_text(
                                 f'ReportPortal launch: {launch_name}',
                                 reportportal_color))
@@ -209,10 +223,12 @@ def print_state_dirs(
                         launch_description = schedule_jobs[0].request.reportportal.get(
                             'launch_description', None)
                         if full and launch_description:
-                            _print(6, colorize_text(launch_description, reportportal_color))
+                            _print(
+                                _indent(3), colorize_text(
+                                    launch_description, reportportal_color))
                         launch_url = schedule_jobs[0].request.reportportal.get('launch_url', None)
                         if launch_url:
-                            _print(6, launch_url)
+                            _print(_indent(3), launch_url)
                 for schedule_job in schedule_jobs:
                     # Get suite description to print with REQ line if it differs from launch
                     suite_description = None
@@ -224,11 +240,17 @@ def print_state_dirs(
                     if full and suite_description and suite_description != launch_description:
                         # Use cyan color for entire REQ line in full mode
                         req_line = f'{schedule_job.request.id} - {suite_description}'
-                        _print(8, colorize_text(req_line, Colors.CYAN))
-                        status_indent = 10  # Extra indent for status when description is shown
+                        _print(_indent(4), colorize_text(req_line, Colors.CYAN))
+                        # Extra indent for status when description is shown
+                        status_indent = _indent(5)
                     else:
                         # Use cyan color for REQ ID in non-full mode
-                        _print(8, colorize_text(schedule_job.request.id, Colors.CYAN), end='')
+                        _print(
+                            _indent(4),
+                            colorize_text(
+                                schedule_job.request.id,
+                                Colors.CYAN),
+                            end='')
                         status_indent = 0  # Status continues on same line
                     execute_file_prefix = (f'{EXECUTE_FILE_PREFIX}{event_job.event.short_id}-'
                                            f'{event_job.short_id}-{jira_job.jira.id}-'

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -194,7 +194,7 @@ def print_state_dirs(
                 if jira_job.jira.action_tags:
                     tags_str = ', '.join(jira_job.jira.action_tags)
                     _print(_indent(2), f'tags: {tags_str}')
-                if jira_job.recipe and jira_job.recipe.url:
+                if full and jira_job.recipe and jira_job.recipe.url:
                     # Show indicator only when auto_schedule is false
                     auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
                     auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''

--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -81,7 +81,8 @@ def print_state_dirs(
         refresh: bool = False,
         refresh_all: bool = False,
         specific_state_dir: bool = False,
-        brief: bool = False) -> None:
+        brief: bool = False,
+        full: bool = False) -> None:
     """Print state directories with their event/issue/execution details.
 
     Args:
@@ -93,6 +94,7 @@ def print_state_dirs(
         refresh_all: Refresh all TF request statuses
         specific_state_dir: Whether printing a specific state dir (affects filtering)
         brief: Only show state dir headers (no events/issues/executions)
+        full: Show full details including RP launch and suite descriptions
     """
     def _print(indent: int, s: str, end: str = '\n') -> None:
         print(f'{" " * indent}{s}', end=end)
@@ -182,7 +184,7 @@ def print_state_dirs(
                     # Show indicator only when auto_schedule is false
                     auto_schedule = getattr(jira_job.recipe, 'auto_schedule', True)
                     auto_schedule_indicator = ' [no-auto-schedule]' if not auto_schedule else ''
-                    _print(6, f'recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
+                    _print(4, f'recipe: {jira_job.recipe.url}{auto_schedule_indicator}')
                 # Skip schedule/execute details if --issues flag is set
                 if issues:
                     continue
@@ -194,6 +196,7 @@ def print_state_dirs(
                         filter_actions=True))
                 # print RP launch URL, should be common for all execute jobs
                 reportportal_color = Colors.REPORTPORTAL or Colors.PURPLE
+                launch_description = None
                 if schedule_jobs and schedule_jobs[0].request.reportportal:
                     launch_name = schedule_jobs[0].request.reportportal.get('launch_name', None)
                     if launch_name:
@@ -202,12 +205,31 @@ def print_state_dirs(
                             colorize_text(
                                 f'ReportPortal launch: {launch_name}',
                                 reportportal_color))
+                        # Print launch description before URL only if --full is set
+                        launch_description = schedule_jobs[0].request.reportportal.get(
+                            'launch_description', None)
+                        if full and launch_description:
+                            _print(6, colorize_text(launch_description, reportportal_color))
                         launch_url = schedule_jobs[0].request.reportportal.get('launch_url', None)
                         if launch_url:
                             _print(6, launch_url)
-                request_id_color = Colors.REQUEST_ID or Colors.GREEN
                 for schedule_job in schedule_jobs:
-                    _print(6, colorize_text(schedule_job.request.id, request_id_color), end='')
+                    # Get suite description to print with REQ line if it differs from launch
+                    suite_description = None
+                    if schedule_job.request.reportportal:
+                        suite_description = schedule_job.request.reportportal.get(
+                            'suite_description', None)
+                    # Print REQ ID with suite description on same line if --full is set
+                    # and it differs from launch description
+                    if full and suite_description and suite_description != launch_description:
+                        # Use cyan color for entire REQ line in full mode
+                        req_line = f'{schedule_job.request.id} - {suite_description}'
+                        _print(8, colorize_text(req_line, Colors.CYAN))
+                        status_indent = 10  # Extra indent for status when description is shown
+                    else:
+                        # Use cyan color for REQ ID in non-full mode
+                        _print(8, colorize_text(schedule_job.request.id, Colors.CYAN), end='')
+                        status_indent = 0  # Status continues on same line
                     execute_file_prefix = (f'{EXECUTE_FILE_PREFIX}{event_job.event.short_id}-'
                                            f'{event_job.short_id}-{jira_job.jira.id}-'
                                            f'{schedule_job.request.id}')
@@ -243,13 +265,25 @@ def print_state_dirs(
                                 # Apply color formatting to state and result
                                 colored_state = colorize_state(state)
                                 colored_result = colorize_result(result.value)
-                                print(
-                                    f' - state: {colored_state}, '
-                                    f'result: {colored_result}, '
-                                    f'artifacts: {url}{arch_suffix}')
+                                if status_indent > 0:
+                                    # Status on new line with extra indent
+                                    _print(
+                                        status_indent,
+                                        f'state: {colored_state}, '
+                                        f'result: {colored_result}, '
+                                        f'artifacts: {url}{arch_suffix}')
+                                else:
+                                    # Status continues on same line
+                                    print(
+                                        f' - state: {colored_state}, '
+                                        f'result: {colored_result}, '
+                                        f'artifacts: {url}{arch_suffix}')
                     else:
                         # Apply color formatting to 'not executed' state
-                        print(f' - {colorize_state("not executed")}')
+                        if status_indent > 0:
+                            _print(status_indent, f'{colorize_state("not executed")}')
+                        else:
+                            print(f' - {colorize_state("not executed")}')
         print()
 
 
@@ -293,6 +327,12 @@ def print_state_dirs(
     help='Refresh all Testing Farm request statuses before listing (overrides --refresh). '
          'Requires -D/--state-dir, -P/--prev-state-dir, or --event-filter.',
     )
+@click.option(
+    '--full',
+    is_flag=True,
+    default=False,
+    help='Show full details including ReportPortal launch and suite descriptions.',
+    )
 @click.pass_obj
 def cmd_list(
         ctx: CLIContext,
@@ -301,7 +341,8 @@ def cmd_list(
         events: bool,
         issues: bool,
         refresh: bool,
-        refresh_all: bool) -> None:
+        refresh_all: bool,
+        full: bool) -> None:
     """List NEWA execution details from state directories."""
     ctx.enter_command('list')
     # Initialize colors based on environment, terminal capabilities, and config
@@ -350,7 +391,8 @@ def cmd_list(
         issues=issues,
         refresh=refresh,
         refresh_all=refresh_all,
-        specific_state_dir=specific_state_dir)
+        specific_state_dir=specific_state_dir,
+        full=full)
 
     # restore logger level and statedir
     ctx.logger.setLevel(saved_logger_level)


### PR DESCRIPTION
Enhance the list command with a new --full flag that displays ReportPortal launch and suite descriptions for more detailed output.

Changes:
- Add --full flag to list command
- Display RP launch description before URL when --full is enabled
- Display RP suite description on same line as REQ ID when --full is enabled and it differs from launch description
- Move recipe URL indentation one level left (from 6 to 4 spaces)
- Indent status lines when suite description is shown
- Add cyan color for REQ ID and description lines
- Apply ReportPortal color (purple) to launch descriptions

## Summary by Sourcery

Add a --full mode to the list command to show enriched ReportPortal metadata and adjust list output formatting and colors.

New Features:
- Introduce a --full flag to the list command to display ReportPortal launch and suite descriptions alongside existing execution details.

Enhancements:
- Shift recipe URL indentation to improve alignment of list output.
- Render ReportPortal launch descriptions in the ReportPortal (purple) color and use cyan for request ID and description lines.
- Indent status lines when suite descriptions are displayed to keep output readable.