### PR TITLE
Fix search command --full option not showing full details

### DIFF
--- a/newa/cli/commands/search_cmd.py
+++ b/newa/cli/commands/search_cmd.py
@@ -321,7 +321,8 @@ def cmd_search(
             refresh=False,
             refresh_all=False,
             specific_state_dir=False,
-            brief=show_brief)
+            brief=show_brief,
+            full=full)
         # Build description of search criteria
         search_desc_parts = []
         if text:


### PR DESCRIPTION
The search command was not passing the full parameter to print_state_dirs(), causing --full flag to be ignored. Now properly displays ReportPortal launch and suite descriptions when --full is specified.

## Summary by Sourcery

Bug Fixes:
- Ensure the search command propagates the --full option to print full state directory details.