### PR TITLE
Fix i386 architecture excluded from RHEL-6 test scheduling

### DIFF
--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -29,7 +29,7 @@ def _determine_architectures(
         compose: Optional[str]) -> list[Arch]:
     """Determine which architectures to use for scheduling."""
     if arch_options:
-        return Arch.architectures([Arch(a.strip()) for a in arch_options])
+        return Arch.architectures([Arch(a.strip()) for a in arch_options], compose=compose)
 
     if jira_job.erratum and jira_job.erratum.archs:
         return jira_job.erratum.archs

--- a/newa/models/base.py
+++ b/newa/models/base.py
@@ -41,24 +41,24 @@ class Arch(Enum):
                       preset: Optional[list['Arch']] = None,
                       compose: Optional[str] = None) -> list['Arch']:
 
-        _exclude = [Arch.MULTI, Arch.SRPMS, Arch.NOARCH, Arch.I386, Arch.I686, Arch.S390]
-        _all = [Arch(a) for a in Arch.__members__.values() if a not in _exclude]
-        _default = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'aarch64']]
-        _default_rhel7 = [Arch(a) for a in ['x86_64', 's390x', 'ppc64le', 'ppc64']]
+        _valid = [Arch.X86_64, Arch.AARCH64, Arch.S390X, Arch.PPC64LE, Arch.PPC64]
+        _default = [Arch.X86_64, Arch.S390X, Arch.PPC64LE, Arch.AARCH64]
 
-        if compose and re.match('^rhel-7', compose, flags=re.IGNORECASE):
-            default = _default_rhel7
-        else:
-            default = _default
+        if compose and re.match(r'^rhel-6', compose, flags=re.IGNORECASE):
+            _valid = [*_valid, Arch.I386]
+            _default = [Arch.X86_64, Arch.S390X, Arch.I386]
+        elif compose and re.match(r'^rhel-7', compose, flags=re.IGNORECASE):
+            _default = [Arch.X86_64, Arch.S390X, Arch.PPC64LE, Arch.PPC64]
+
         if not preset:
-            return default
+            return _default
         # 'noarch' should be tested on all architectures
         if Arch('noarch') in preset:
-            return default
+            return _default
         # 'multi' is given for container advisories
         if Arch('multi') in preset:
-            return default
-        return list(set(_all).intersection(set(preset)))
+            return _default
+        return list(set(_valid).intersection(set(preset)))
 
 
 class ErratumCommentTrigger(Enum):

--- a/newa/models/base.py
+++ b/newa/models/base.py
@@ -53,12 +53,12 @@ class Arch(Enum):
         if not preset:
             return _default
         # 'noarch' should be tested on all architectures
-        if Arch('noarch') in preset:
+        if Arch.NOARCH in preset:
             return _default
         # 'multi' is given for container advisories
-        if Arch('multi') in preset:
+        if Arch.MULTI in preset:
             return _default
-        return list(set(_valid).intersection(set(preset)))
+        return [a for a in preset if a in _valid]
 
 
 class ErratumCommentTrigger(Enum):

--- a/newa/services/errata_service.py
+++ b/newa/services/errata_service.py
@@ -262,6 +262,8 @@ class ErrataTool:
             deduplicated_candidates = candidate_errata
 
         # Create Erratum objects from deduplicated candidates
+        from newa.cli.utils import derive_compose
+
         for candidate in deduplicated_candidates:
             errata.append(
                 Erratum(
@@ -276,7 +278,9 @@ class ErrataTool:
                     builds=candidate['builds'],
                     blocking_builds=candidate['blocking_builds'],
                     blocking_errata=[e.id for e in blocking_errata],
-                    archs=Arch.architectures([Arch(a) for a in candidate['archs']]),
+                    archs=Arch.architectures(
+                        [Arch(a) for a in candidate['archs']],
+                        compose=derive_compose(candidate['release'])),
                     components=candidate['components'],
                     url=urllib.parse.urljoin(self.url, f"/advisory/{event.id}"),
                     people_assigned_to=info_json["people"]["assigned_to"],

--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -18,3 +18,39 @@ def test_arch_ok():
     assert set(default_list_rhel7) == set(noarch_list_rhel7)
     assert set(default_list) == set(exp_default_list)
     assert set(subset) == set(intersect)
+
+
+def test_arch_rhel6_default():
+    default = Arch.architectures(compose='RHEL-6.10-ZStream')
+    assert set(default) == {Arch.X86_64, Arch.S390X, Arch.I386}
+
+
+def test_arch_rhel6_preset_includes_i386():
+    preset = [Arch.I386, Arch.S390X, Arch.S390, Arch.X86_64]
+    result = Arch.architectures(preset, compose='RHEL-6.10-ZStream')
+    assert Arch.I386 in result
+    assert Arch.X86_64 in result
+    assert Arch.S390X in result
+    assert Arch.S390 not in result
+
+
+def test_arch_rhel6_noarch_returns_default():
+    result = Arch.architectures([Arch.NOARCH], compose='RHEL-6.10-ZStream')
+    assert set(result) == {Arch.X86_64, Arch.S390X, Arch.I386}
+
+
+def test_arch_rhel6_multi_returns_default():
+    result = Arch.architectures([Arch.MULTI], compose='RHEL-6.10-ZStream')
+    assert set(result) == {Arch.X86_64, Arch.S390X, Arch.I386}
+
+
+def test_arch_i386_excluded_without_rhel6():
+    preset = [Arch.I386, Arch.X86_64, Arch.S390X]
+    result = Arch.architectures(preset)
+    assert Arch.I386 not in result
+
+    result_rhel8 = Arch.architectures(preset, compose='RHEL-8.10.0.Z.MAIN')
+    assert Arch.I386 not in result_rhel8
+
+    result_rhel9 = Arch.architectures(preset, compose='RHEL-9.6.0.Z.MAIN')
+    assert Arch.I386 not in result_rhel9


### PR DESCRIPTION
## Summary

- Refactor `Arch.architectures()` to use explicit whitelists (`_valid`, `_default`) instead of an exclude list, and add a RHEL-6 compose check that includes i386 as a valid test architecture
- Pass `compose` to `Arch.architectures()` in `errata_service.py` (via `derive_compose()`) and `schedule_helpers.py` so the RHEL-6 logic activates
- Add unit tests for RHEL-6 i386 inclusion, noarch/multi fallback, and confirming i386 stays excluded for non-RHEL-6

## Problem

When newa processes an errata advisory for RHEL-6 (e.g. ER#168066, `RHEL-6-ELS-EXTENSION`), the i386 architecture is dropped from the arch list even though the ET product listings include i686 RPMs. The ET API returns `i386` as the channel key, but `Arch.architectures()` unconditionally filtered it out. No tests were scheduled for i386 on RHEL-6, where it is a first-class architecture with standalone composes.

## Test plan

- [x] All 271 existing unit tests pass
- [x] 5 new tests in `test_arch.py` cover RHEL-6 defaults, preset intersection, noarch/multi fallback, and non-RHEL-6 exclusion
- [x] Ruff and mypy clean (no new warnings)
- [x] Verified with COPR build (`sbroz/newa-testing`) against advisory 168066 — i386 now appears in scheduled arches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow i386 to be treated as a valid test architecture for RHEL-6 composes while keeping it excluded elsewhere, and ensure compose-aware architecture selection is used when scheduling tests and fetching errata.

New Features:
- Enable i386 as a valid and default test architecture specifically for RHEL-6 composes.

Bug Fixes:
- Fix omission of i386 tests for RHEL-6 advisories where i386 is a first-class architecture.

Enhancements:
- Refine architecture selection to use explicit valid/default architecture whitelists with compose-specific behavior.
- Propagate compose information into architecture resolution in errata processing and scheduling helpers.

Tests:
- Add unit tests covering RHEL-6 default architectures, preset inclusion of i386, noarch/multi fallbacks, and i386 exclusion for non-RHEL releases.