### PR TITLE
Fix list command silently ignoring non-existent -D/--state-dir path

### DIFF
--- a/newa/cli/commands/list_cmd.py
+++ b/newa/cli/commands/list_cmd.py
@@ -391,6 +391,8 @@ def cmd_list(
         ctx.logger.setLevel(logging.WARN)
     # when existing state-dir has been provided, use it
     specific_state_dir = saved_state_dir.is_dir()
+    if ctx.state_dir_explicit and not specific_state_dir:
+        raise click.UsageError(f'State directory does not exist: {saved_state_dir}')
     if specific_state_dir:
         state_dirs = [ctx.state_dirpath]
     # otherwise choose last N dirs or all dirs

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -258,6 +258,7 @@ def main(click_context: click.Context,
             'to identify the source directory.')
 
     # handle state_dir settings
+    state_dir_explicit = bool(state_dir) or prev_state_dir
     if prev_state_dir and state_dir:
         raise Exception('Use either --state-dir or --prev-state-dir')
     if prev_state_dir:
@@ -309,6 +310,7 @@ def main(click_context: click.Context,
         state_dirpath=Path(os.path.expandvars(state_dir)),
         cli_environment={},
         cli_context={},
+        state_dir_explicit=state_dir_explicit,
         prev_state_dirpath=prev_state_dirpath,
         force=force,
         no_comments=no_comments,

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -239,6 +239,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
                                                      else RequestResult(r))
                                                     for r in results])
     new_state_dir: bool = False
+    state_dir_explicit: bool = False
     prev_state_dirpath: Optional[Path] = None
     force: bool = False
     no_comments: bool = False


### PR DESCRIPTION
When an explicit state directory was provided via -D but did not exist, the list command fell back to listing the last 10 directories instead of reporting an error.

## Summary by Sourcery

Bug Fixes:
- Report a usage error when -D/--state-dir or --prev-state-dir points to a non-existent state directory instead of listing recent state directories.