### PR TITLE
Fix hardcoded '???' placeholder for missing Jira issues in summarize

### DIFF
--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -33,8 +33,8 @@ def fetch_jira_issues_bulk(jira_connection: JiraConnection,
     if not issue_keys:
         return {}
 
-    # Remove '???' entries if present
-    valid_keys = [k for k in issue_keys if k != '???']
+    # Remove JIRA_NONE_ID entries if present
+    valid_keys = [k for k in issue_keys if k != JIRA_NONE_ID]
     if not valid_keys:
         return {}
 

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -139,8 +139,12 @@ def format_launch_test_items(item_type: str, data: dict[str, Any]) -> list[str]:
 
     # Print individual failures
     for failure in data.get('failures', []):
-        issue_keys = ', '.join(failure['issue_ids'])
-        output.append(f'{4 * " "}{failure["name"]} [{issue_keys}]: {failure["comment"]}')
+        valid_keys = [k for k in failure['issue_ids'] if k != JIRA_NONE_ID]
+        if valid_keys:
+            issue_keys = ', '.join(valid_keys)
+            output.append(f'{4 * " "}{failure["name"]} [{issue_keys}]: {failure["comment"]}')
+        else:
+            output.append(f'{4 * " "}{failure["name"]}: {failure["comment"]}')
 
     return output
 

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -56,6 +56,7 @@ def get_launch_test_items_data(
                 'page.size': '1024',
                 'page.number': str(page_number),
                 'filter.eq.issueType': TEST_ITEM_TYPE_MAPPING[item_type],
+                'filter.eq.hasChildren': 'false',
                 })
 
         if not test_items or not test_items.get('content'):
@@ -79,6 +80,13 @@ def get_launch_test_items_data(
         return {'count': 0, 'issues': {}, 'failures': []}
 
     count = len(all_content)
+
+    if logger:
+        for i in all_content:
+            logger.debug(
+                f'{item_type}: test item: {i.get("name", "Unknown")}'
+                f' (id={i.get("id", "?")},'
+                f' issueType={i.get("issue", {}).get("issueType", "?")})')
 
     if item_type == 'To Investigate':
         return {'count': count, 'issues': {}, 'failures': []}
@@ -242,11 +250,18 @@ def collect_launch_details(
         output.append(f'Error: Could not retrieve launch details for launch ID {launch_id}')
         return output, set()
 
+    # Log raw RP statistics for debugging
+    if logger:
+        rp_stats = launch_details.get('statistics', {})
+        logger.debug(f'RP raw statistics: {rp_stats}')
+
     # Read test items data for all item types
     all_data = {}
     all_jira_issues = set()
     for item_type in TEST_ITEM_TYPE_MAPPING:
         all_data[item_type] = get_launch_test_items_data(rp, launch_id, item_type, logger)
+        if logger:
+            logger.debug(f'{item_type}: {all_data[item_type]["count"]} items fetched')
         # Collect Jira issue keys (excluding JIRA_NONE_ID)
         for issue_key in all_data[item_type]['issues']:
             if issue_key != JIRA_NONE_ID:

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import Any, Optional
 
 from newa import ReportPortal
+from newa.cli.constants import JIRA_NONE_ID
 
 # Test item type mapping for ReportPortal
 TEST_ITEM_TYPE_MAPPING = {
@@ -100,7 +101,7 @@ def get_launch_test_items_data(
         failures.append({
             'name': i.get('name', 'Unknown'),
             'comment': comment,
-            'issue_ids': issue_ids or ['???'],
+            'issue_ids': issue_ids or [JIRA_NONE_ID],
             })
 
         # Store issues with their comments (for backward compatibility)
@@ -110,7 +111,7 @@ def get_launch_test_items_data(
                     issues[issue_id] = comment
         else:
             # No issue ID found
-            issues['???'] = comment
+            issues[JIRA_NONE_ID] = comment
 
     return {'count': count, 'issues': issues, 'failures': failures}
 
@@ -242,9 +243,9 @@ def collect_launch_details(
     all_jira_issues = set()
     for item_type in TEST_ITEM_TYPE_MAPPING:
         all_data[item_type] = get_launch_test_items_data(rp, launch_id, item_type, logger)
-        # Collect Jira issue keys (excluding '???')
+        # Collect Jira issue keys (excluding JIRA_NONE_ID)
         for issue_key in all_data[item_type]['issues']:
-            if issue_key != '???':
+            if issue_key != JIRA_NONE_ID:
                 all_jira_issues.add(issue_key)
 
     # Print launch header

--- a/newa/services/ai_service.py
+++ b/newa/services/ai_service.py
@@ -74,11 +74,13 @@ REPORT GENERATION RULES:
 
     Not a defect test failures
 
-    Grouping Rule: Within each category, group failures by their associated Jira Issue ID. If multiple tests fail due to the same Jira, list the Jira once and provide the count of failing tests.
+    Grouping Rule: Within each category, group failures by their associated Jira Issue ID. If multiple tests fail due to the same Jira, list the Jira once and provide the count of failing tests. For failures without a Jira issue (no issue ID in the input), list them directly without any ID prefix — just the count and comment.
 
     Jira Formatting Rule:
 
         Format: JIRA-ID [Status: <Status>, <Version Info>]: <Count> failing tests - <Consolidated Comment>
+
+        For failures without a Jira issue: <Count> failing tests - <Consolidated Comment> (no JIRA-ID prefix, no brackets)
 
             Never refer Jira issues using full URL (starts with https://issues.redhat.com/) but only the issue ID/key.
 

--- a/newa/services/ai_service.py
+++ b/newa/services/ai_service.py
@@ -98,7 +98,7 @@ REPORT GENERATION RULES:
 
     Triggers (Include this section only if these exist):
 
-        Missing Jira: Any failure categorized as a bug but missing a Jira ID (often indicated by "???").
+        Missing Jira: Any failure categorized as a bug but missing a Jira ID (indicated by "{jira_none_id}").
 
         Missing Link: Failures missing both a Jira ID and a Pull Request URL.
 
@@ -242,7 +242,8 @@ class AIService:
             The AI model's response text
         """
         if system_prompt is None:
-            system_prompt = SYSTEM_PROMPT
+            from newa.cli.constants import JIRA_NONE_ID
+            system_prompt = SYSTEM_PROMPT.format(jira_none_id=JIRA_NONE_ID)
 
         if not self.api_url:
             raise Exception("AI API URL is not configured")


### PR DESCRIPTION
The summarize code used '???' as a sentinel for failures without a Jira issue, but the rest of the codebase already uses the JIRA_NONE_ID constant ('_NO_ISSUE'). Replace all '???' occurrences with JIRA_NONE_ID to keep the summarize output consistent and prevent '???' from leaking into AI-generated summary reports.

## Summary by Sourcery

Standardize handling of missing Jira IDs in summarize and AI reporting workflows by using the shared JIRA_NONE_ID constant instead of hardcoded placeholders.

Bug Fixes:
- Prevent "???" placeholder values from appearing in summarize outputs and AI-generated summary reports when Jira IDs are missing.

Enhancements:
- Use the shared JIRA_NONE_ID constant across summarize helpers, Jira bulk fetching, and AI system prompts to keep missing-Jira handling consistent.