### PR TITLE
Change deduplicate_releases default to enabled

### DIFF
--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -53,7 +53,7 @@ class Settings:  # type: ignore[no-untyped-def]
     newa_color_config: str = ''
     et_url: str = ''
     et_enable_comments: bool = False
-    et_deduplicate_releases: bool = False
+    et_deduplicate_releases: bool = True
     rog_enable_comments: bool = False
     jira_enable_comments: bool = True
     rp_url: str = ''
@@ -125,7 +125,8 @@ class Settings:  # type: ignore[no-untyped-def]
                 _get(
                     cp,
                     'erratatool/deduplicate_releases',
-                    'NEWA_ET_DEDUPLICATE_RELEASES')),
+                    'NEWA_ET_DEDUPLICATE_RELEASES',
+                    default='1')),
             rog_enable_comments=_str_to_bool(
                 _get(
                     cp,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1095,11 +1095,11 @@ def test_deduplicate_releases_cli_flag_overrides_config():
 
 
 @pytest.mark.usefixtures('_mock_errata_tool_same_compose')
-def test_no_deduplication_without_config_or_flag():
-    """Test that without config or CLI flag, no deduplication occurs."""
+def test_deduplication_enabled_by_default():
+    """Test that deduplication is enabled by default without config or CLI flag."""
     event_files = _run_event_command()
-    assert len(event_files) == 2, (
-        f"Expected 2 event files without deduplication, got {len(event_files)}: "
+    assert len(event_files) == 1, (
+        f"Expected 1 event file with deduplication enabled by default, got {len(event_files)}: "
         f"{[f.name for f in event_files]}")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enable release deduplication by default and update tests to reflect the new default behavior.

Enhancements:
- Change settings so Errata Tool release deduplication is enabled by default via both code and configuration parsing.

Tests:
- Update CLI tests to assert that deduplication now occurs by default when no config or flag is provided.