### PR TITLE
Raise ReportPortalError instead of returning None from RP API methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,11 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.1"
+    rev: "v1.20.2"
     hooks:
       - id: mypy
         additional_dependencies:
-          - "click>=8.0.3,!=8.1.4"
+          - "click>=8.0.3,!=8.1.4,<8.2.0"
           - "attrs>=20.3.0"
           - "ruamel.yaml>=0.16.6"
           - "jinja2>=2.11.3"

--- a/newa/__init__.py
+++ b/newa/__init__.py
@@ -64,6 +64,7 @@ from newa.services import (
     JiraField,
     JiraIssueLinkType,
     ReportPortal,
+    ReportPortalError,
     RoGTool,
     )
 
@@ -142,6 +143,7 @@ __all__ = [
     'RecipeEnvironment',
     'ReportPortal',
     'ReportPortalAttributes',
+    'ReportPortalError',
     'Request',
     'RequestResult',
     'ResponseContentType',

--- a/newa/cli/commands/summarize_cmd.py
+++ b/newa/cli/commands/summarize_cmd.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import click
 
-from newa import CLIContext, ExecuteJob
+from newa import CLIContext, ExecuteJob, ReportPortalError
 from newa.cli.constants import JIRA_NONE_ID
 from newa.cli.initialization import initialize_rp_connection
 from newa.cli.summarize_helpers import (
@@ -141,13 +141,8 @@ def process_execute_job_for_summary(
     # Get launch info to convert UUID to ID
     try:
         launch_info = rp.get_launch_info(launch_uuid)
-        if not launch_info:
-            ctx.logger.warning(
-                f'Could not find launch {launch_uuid} in ReportPortal project '
-                f'{ctx.settings.rp_project}')
-            return
         launch_id = launch_info['id']
-    except Exception as e:
+    except ReportPortalError as e:
         ctx.logger.error(f'Error getting launch info for {launch_uuid}: {e}')
         return
 

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -183,13 +183,11 @@ def _create_or_reuse_rp_launch(
         launch_attrs['erratum'] = str(schedule_jobs[0].erratum.id)
 
     # Create the launch
-    new_launch_uuid: Optional[str] = rp.create_launch(
+    new_launch_uuid = rp.create_launch(
         launch_name, launch_description, attributes=launch_attrs)
-    if not new_launch_uuid:
-        raise Exception('Failed to create RP launch')
 
     ctx.logger.info(f'Created RP launch {new_launch_uuid} for issue {jira_id}')
-    return str(new_launch_uuid)
+    return new_launch_uuid
 
 
 def _update_schedule_jobs_with_launch(

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -13,6 +13,7 @@ from newa import (
     RawRecipeReportPortalConfigDimension,
     RawRecipeTFConfigDimension,
     RecipeConfig,
+    ReportPortalError,
     Request,
     get_url_basename,
     render_template,
@@ -228,12 +229,12 @@ def _process_jira_job(
 
         # Fetch launch metadata once (outside the request loop)
         ctx.logger.info(f'Fetching ReportPortal launch {rp_launch_uuid}')
-        launch_info = rp.get_launch_info(rp_launch_uuid)
-
-        if not launch_info:
+        try:
+            launch_info = rp.get_launch_info(rp_launch_uuid)
+        except ReportPortalError as e:
             ctx.logger.error(
                 f'ERROR: Could not find ReportPortal launch {rp_launch_uuid} '
-                f'in project {rp.project}')
+                f'in project {rp.project}: {e}')
             sys.exit(1)
 
         # Store metadata to apply to all requests

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -253,8 +253,9 @@ def collect_launch_details(
     # Read launch details
     try:
         launch_details = rp.get_request(f'/launch/{launch_id}')
-    except ReportPortalError:
-        output.append(f'Error: Could not retrieve launch details for launch ID {launch_id}')
+    except ReportPortalError as e:
+        output.append(
+            f'Error: Could not retrieve launch details for launch ID {launch_id}: {e}')
         return output, set()
 
     # Log raw RP statistics for debugging

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -60,6 +60,10 @@ def get_launch_test_items_data(
                     'filter.eq.hasChildren': 'false',
                     })
         except ReportPortalError:
+            if logger:
+                logger.warning(
+                    f'Failed to fetch page {page_number} of test items '
+                    f'for launch {launch_id}, results may be incomplete')
             break
 
         if not test_items.get('content'):

--- a/newa/cli/summarize_helpers.py
+++ b/newa/cli/summarize_helpers.py
@@ -5,7 +5,7 @@ import re
 import textwrap
 from typing import Any, Optional
 
-from newa import ReportPortal
+from newa import ReportPortal, ReportPortalError
 from newa.cli.constants import JIRA_NONE_ID
 
 # Test item type mapping for ReportPortal
@@ -49,17 +49,20 @@ def get_launch_test_items_data(
     total_pages = 1
 
     while page_number <= total_pages:
-        test_items = rp.get_request(
-            '/item',
-            {
-                'filter.eq.launchId': str(launch_id),
-                'page.size': '1024',
-                'page.number': str(page_number),
-                'filter.eq.issueType': TEST_ITEM_TYPE_MAPPING[item_type],
-                'filter.eq.hasChildren': 'false',
-                })
+        try:
+            test_items = rp.get_request(
+                '/item',
+                {
+                    'filter.eq.launchId': str(launch_id),
+                    'page.size': '1024',
+                    'page.number': str(page_number),
+                    'filter.eq.issueType': TEST_ITEM_TYPE_MAPPING[item_type],
+                    'filter.eq.hasChildren': 'false',
+                    })
+        except ReportPortalError:
+            break
 
-        if not test_items or not test_items.get('content'):
+        if not test_items.get('content'):
             break
 
         all_content.extend(test_items['content'])
@@ -244,9 +247,9 @@ def collect_launch_details(
     output = []
 
     # Read launch details
-    launch_details = rp.get_request(f'/launch/{launch_id}')
-
-    if not launch_details:
+    try:
+        launch_details = rp.get_request(f'/launch/{launch_id}')
+    except ReportPortalError:
         output.append(f'Error: Could not retrieve launch details for launch ID {launch_id}')
         return output, set()
 

--- a/newa/services/__init__.py
+++ b/newa/services/__init__.py
@@ -4,7 +4,7 @@ from newa.services.ai_service import AIService
 from newa.services.errata_service import ErrataTool
 from newa.services.jira_connection import JiraConnection, JiraField, JiraIssueLinkType
 from newa.services.jira_service import IssueHandler
-from newa.services.reportportal_service import ReportPortal
+from newa.services.reportportal_service import ReportPortal, ReportPortalError
 from newa.services.rog_service import RoGTool
 
 __all__ = [
@@ -15,5 +15,6 @@ __all__ = [
     'JiraField',
     'JiraIssueLinkType',
     'ReportPortal',
+    'ReportPortalError',
     'RoGTool',
     ]

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -117,10 +117,7 @@ class ReportPortal:
             rp_user_info = self.get_current_user_info()
             logger.debug(f"ReportPortal user is={rp_user_info['id']}")
         except ReportPortalError as e:
-            raise ReportPortalError(
-                e.status_code, rp_url,
-                f"ReportPortal is not available. "
-                f"API response from {e.url}: {e.response_text}") from e
+            raise ReportPortalError(e.status_code, e.url, e.response_text) from e
         except requests.RequestException as e:
             raise Exception(f"ReportPortal is not available at {rp_url}.") from e
 

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -118,8 +118,11 @@ class ReportPortal:
             logger.debug(f"ReportPortal user is={rp_user_info['id']}")
         except ReportPortalError as e:
             raise ReportPortalError(
-                e.status_code, e.url,
-                f"ReportPortal is not available at {rp_url}") from e
+                e.status_code, rp_url,
+                f"ReportPortal is not available. "
+                f"API response from {e.url}: {e.response_text}") from e
+        except requests.RequestException as e:
+            raise Exception(f"ReportPortal is not available at {rp_url}.") from e
 
     def check_for_empty_launch(self, launch_uuid: str,
                                logger: Optional['logging.Logger'] = None) -> bool:
@@ -235,6 +238,10 @@ class ReportPortal:
             try:
                 items = self.get_request('/item', params=paginated_params, version=1)
             except ReportPortalError:
+                if logger:
+                    logger.warning(
+                        f'Failed to fetch page {page} of test suites '
+                        f'for launch {launch_uuid}, cleanup may be incomplete')
                 break
 
             if not items.get('content'):

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -23,6 +23,18 @@ if TYPE_CHECKING:
 HTTP_STATUS_CODES_OK = [200, 201]
 
 
+class ReportPortalError(Exception):
+    """Raised when a ReportPortal API request fails with a non-OK status code."""
+
+    def __init__(self, status_code: int, url: str, response_text: str):
+        self.status_code = status_code
+        self.url = url
+        self.response_text = response_text
+        super().__init__(
+            f"ReportPortal API request failed: {status_code} {url}\n"
+            f"Response: {response_text[:500]}")
+
+
 @define
 class ReportPortal:
     """ReportPortal integration service."""
@@ -34,7 +46,7 @@ class ReportPortal:
     def create_launch(self,
                       launch_name: str,
                       description: str,
-                      attributes: Optional[dict[str, str]] = None) -> Optional[str]:
+                      attributes: Optional[dict[str, str]] = None) -> str:
         query_data: JSON = {
             "attributes": [],
             "name": launch_name,
@@ -45,32 +57,25 @@ class ReportPortal:
             for key, value in attributes.items():
                 query_data['attributes'].append({"key": key.strip(), "value": value.strip()})
         data = self.post_request('/launch', json=query_data)
-        if data:
-            return str(data['id'])
-        return None
+        return str(data['id'])
 
-    def finish_launch(self, launch_uuid: str, description: Optional[str] = None) -> Optional[str]:
+    def finish_launch(self, launch_uuid: str, description: Optional[str] = None) -> str:
         query_data: JSON = {
             'endTime': str(int(time.time() * 1000)),
             "status": "PASSED",
             }
         if description:
             query_data['description'] = description
-        data = self.put_request(f'/launch/{launch_uuid}/finish', json=query_data)
-        if data:
-            return launch_uuid
-        return None
+        self.put_request(f'/launch/{launch_uuid}/finish', json=query_data)
+        return launch_uuid
 
     def update_launch(self,
                       launch_uuid: str,
                       description: Optional[str] = None,
                       attributes: Optional[dict[str, str]] = None,
-                      extend: bool = False) -> Optional[str]:
+                      extend: bool = False) -> str:
         # RP API for update requires launch ID, not UUID
         info = self.get_launch_info(launch_uuid)
-        if not info:
-            raise Exception(
-                f"Could not find launch {launch_uuid} in ReportPortal project {self.project}")
         launch_id = info['id']
         query_data: JSON = {
             "mode": "DEFAULT",
@@ -87,10 +92,8 @@ class ReportPortal:
                 query_data['attributes'] = []
             for key, value in attributes.items():
                 query_data['attributes'].append({"key": key.strip(), "value": value.strip()})
-        data = self.put_request(f'/launch/{launch_id}/update', json=query_data, version=1)
-        if data:
-            return launch_uuid
-        return None
+        self.put_request(f'/launch/{launch_id}/update', json=query_data, version=1)
+        return launch_uuid
 
     def get_launch_info(self, launch_uuid: str) -> 'JSON':
         return self.get_request(f'/launch/uuid/{launch_uuid}')
@@ -107,16 +110,16 @@ class ReportPortal:
         req = requests.get(url, headers=headers)
         if req.status_code in HTTP_STATUS_CODES_OK:
             return req.json()
-        return None
+        raise ReportPortalError(req.status_code, url, req.text)
 
     def check_connection(self, rp_url: str, logger: 'logging.Logger') -> None:
         try:
             rp_user_info = self.get_current_user_info()
             logger.debug(f"ReportPortal user is={rp_user_info['id']}")
-            if not rp_user_info:
-                raise Exception("Could not get ReportPortal user info.")
-        except Exception as e:
-            raise Exception(f"ReportPortal is not available at {rp_url}.") from e
+        except ReportPortalError as e:
+            raise ReportPortalError(
+                e.status_code, e.url,
+                f"ReportPortal is not available at {rp_url}") from e
 
     def check_for_empty_launch(self, launch_uuid: str,
                                logger: Optional['logging.Logger'] = None) -> bool:
@@ -141,7 +144,7 @@ class ReportPortal:
         req = requests.get(url, headers=headers)
         if req.status_code in HTTP_STATUS_CODES_OK:
             return req.json()
-        return None
+        raise ReportPortalError(req.status_code, url, req.text)
 
     def put_request(self,
                     path: str,
@@ -154,7 +157,7 @@ class ReportPortal:
         req = requests.put(url, headers=headers, json=json)
         if req.status_code in HTTP_STATUS_CODES_OK:
             return req.json()
-        return None
+        raise ReportPortalError(req.status_code, url, req.text)
 
     def post_request(self,
                      path: str,
@@ -168,7 +171,7 @@ class ReportPortal:
         req = requests.post(url, headers=headers, json=json)
         if req.status_code in HTTP_STATUS_CODES_OK:
             return req.json()
-        return None
+        raise ReportPortalError(req.status_code, url, req.text)
 
     def delete_request(self,
                        path: str,
@@ -197,8 +200,9 @@ class ReportPortal:
             True if suite was found and removed, False otherwise
         """
         # First get launch info to retrieve numeric launch ID
-        launch_info = self.get_launch_info(launch_uuid)
-        if not launch_info:
+        try:
+            launch_info = self.get_launch_info(launch_uuid)
+        except ReportPortalError:
             if logger:
                 logger.warning(f'Could not find launch {launch_uuid} in ReportPortal')
             return False
@@ -228,9 +232,12 @@ class ReportPortal:
             paginated_params['page.page'] = str(page)
             paginated_params['page.size'] = str(page_size)
 
-            items = self.get_request('/item', params=paginated_params, version=1)
+            try:
+                items = self.get_request('/item', params=paginated_params, version=1)
+            except ReportPortalError:
+                break
 
-            if not items or not items.get('content'):
+            if not items.get('content'):
                 # No more items on this page
                 break
 

--- a/newa/utils/helpers.py
+++ b/newa/utils/helpers.py
@@ -3,7 +3,7 @@
 import os
 import re
 import time
-import urllib
+import urllib.parse
 
 # common sleep times to avoid too frequent Jira API requests
 SHORT_SLEEP = 1


### PR DESCRIPTION
## Summary by Sourcery

Raise a dedicated ReportPortalError on failed ReportPortal API calls and update callers to handle it explicitly instead of relying on None returns, while tightening type expectations and improving error logging.

Bug Fixes:
- Prevent silent failures by raising ReportPortalError when ReportPortal HTTP requests return non-OK responses instead of returning None.
- Ensure summarize and schedule flows handle ReportPortal API failures gracefully with clearer error messages and partial-result warnings.

Enhancements:
- Introduce a ReportPortalError exception carrying HTTP status, URL, and response snippet for easier debugging of ReportPortal issues.
- Make ReportPortal service methods return non-optional values, simplifying callers and removing redundant None checks.
- Improve logging around ReportPortal connectivity and data-fetching issues to clarify when cleanup or summary results may be incomplete.
- Update helper imports and public exports so ReportPortalError is available across CLI and services modules.
- Use urllib.parse explicitly in helpers for clearer URL parsing semantics.

Build:
- Update pre-commit mypy hook to v1.20.2 and constrain click dependency to <8.2.0 for type-check compatibility.