### PR TITLE
Make file conflict checks respect active filters

### DIFF
--- a/newa/cli/commands/jira_cmd.py
+++ b/newa/cli/commands/jira_cmd.py
@@ -20,7 +20,7 @@ from newa.cli.jira_helpers import (
     _parse_issue_mapping,
     _process_issue_config,
     )
-from newa.cli.utils import initialize_state_dir, test_file_presence
+from newa.cli.utils import initialize_state_dir, test_filtered_file_presence
 
 
 @click.command(name='jira')
@@ -105,7 +105,8 @@ def cmd_jira(
         ctx.remove_job_files(JIRA_FILE_PREFIX)
 
     # Check for existing files unless --force is used
-    if test_file_presence(ctx.state_dirpath, JIRA_FILE_PREFIX) and not ctx.force:
+    if (not ctx.force and
+            test_filtered_file_presence(ctx, JIRA_FILE_PREFIX, ctx.load_jira_jobs)):
         ctx.logger.error(
             f'"{JIRA_FILE_PREFIX}" files already exist in state-dir {ctx.state_dirpath}, '
             'use --force to override')

--- a/newa/cli/commands/schedule_cmd.py
+++ b/newa/cli/commands/schedule_cmd.py
@@ -7,7 +7,7 @@ import click
 
 from newa import SCHEDULE_FILE_PREFIX, CLIContext
 from newa.cli.schedule_helpers import _process_jira_job
-from newa.cli.utils import initialize_state_dir, test_file_presence
+from newa.cli.utils import initialize_state_dir, test_filtered_file_presence
 
 
 @click.command(name='schedule')
@@ -79,7 +79,8 @@ def cmd_schedule(
     if ctx.settings.newa_clear_on_subcommand:
         ctx.remove_job_files(SCHEDULE_FILE_PREFIX)
 
-    if test_file_presence(ctx.state_dirpath, SCHEDULE_FILE_PREFIX) and not ctx.force:
+    if (not ctx.force and
+            test_filtered_file_presence(ctx, SCHEDULE_FILE_PREFIX, ctx.load_schedule_jobs)):
         ctx.logger.error(
             f'"{SCHEDULE_FILE_PREFIX}" files already exist in state-dir {ctx.state_dirpath}, '
             'use --force to override')

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -21,7 +21,7 @@ from newa import (
     ScheduleJob,
     )
 from newa.cli.constants import JIRA_NONE_ID, RP_LAUNCH_DESCR_CHARS_LIMIT
-from newa.cli.utils import test_file_presence
+from newa.cli.utils import test_filtered_file_presence
 
 
 def normalize_request_ids(request_ids: list[str]) -> list[str]:
@@ -96,9 +96,10 @@ def _validate_execute_parameters(
 
 def _check_execute_file_conflicts(ctx: CLIContext) -> None:
     """Check for execute file conflicts in state directory."""
-    if (test_file_presence(ctx.state_dirpath, EXECUTE_FILE_PREFIX) and
-            not ctx.continue_execution and
-            not ctx.force):
+    if ctx.continue_execution or ctx.force:
+        return
+
+    if test_filtered_file_presence(ctx, EXECUTE_FILE_PREFIX, ctx.load_execute_jobs):
         ctx.logger.error(
             f'"{EXECUTE_FILE_PREFIX}" files already exist in state-dir {ctx.state_dirpath}, '
             'use --force to override')

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -448,6 +448,8 @@ def main(click_context: click.Context,
             operation='copy',
             logger=ctx.logger)
 
+        ctx.new_state_dir = False
+
     def _split(s: str) -> tuple[str, str]:
         """Split key='some value' into a tuple (key, value)."""
         r = re.match(r"""^\s*([a-zA-Z0-9_][a-zA-Z0-9_\-]*)=["']?(.*?)["']?\s*$""", s)

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -14,6 +14,7 @@ from newa import (
     ExecuteHow,
     ExecuteJob,
     ReportPortal,
+    ReportPortalError,
     RequestResult,
     RoGCommentTrigger,
     RoGTool,
@@ -197,7 +198,13 @@ def _finalize_rp_launch(
         launch_url: Optional[str],
         launch_description: str) -> None:
     """Finalize ReportPortal launch by finishing and updating description."""
-    rp.finish_launch(launch_uuid)
+    try:
+        rp.finish_launch(launch_uuid)
+    except ReportPortalError as e:
+        if e.status_code == 406 and '40023' in e.response_text:
+            ctx.logger.warning(f'Launch {launch_uuid} is already finished, skipping finish step.')
+        else:
+            raise
     ctx.logger.info(f'Updating launch description, {launch_url}')
     rp.update_launch(launch_uuid, description=launch_description)
 

--- a/newa/cli/utils.py
+++ b/newa/cli/utils.py
@@ -2,8 +2,9 @@
 
 import os
 import re
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from newa import CLIContext
 from newa.cli.constants import STATEDIR_NAME_PATTERN
@@ -77,6 +78,21 @@ def initialize_state_dir(ctx: CLIContext) -> None:
 def test_file_presence(statedir: Path, prefix: str) -> bool:
     """Check if files with given prefix exist in state directory."""
     return any(child.name.startswith(prefix) for child in statedir.iterdir())
+
+
+def test_filtered_file_presence(
+        ctx: CLIContext,
+        prefix: str,
+        load_jobs: Callable[..., Iterator[Any]]) -> bool:
+    """Check if files with given prefix exist, respecting active filters.
+
+    When filters are active, uses the provided job loader to check only
+    among matching jobs. Otherwise falls back to a fast filesystem check.
+    """
+    if (ctx.action_id_filter_pattern or ctx.issue_id_filter_pattern or
+            ctx.event_filter_pattern or ctx.action_tag_filter_pattern):
+        return next(load_jobs(filter_actions=True), None) is not None
+    return test_file_presence(ctx.state_dirpath, prefix)
 
 
 def apply_release_mapping(string: str,


### PR DESCRIPTION
The "files already exist" checks in jira, schedule, and execute commands blocked execution even when active filters (--issue-id-filter, etc.) would match no existing files. Now when filters are active, only matching jobs are considered for the conflict check.

## Summary by Sourcery

Respect active job filters when checking for existing job files in jira, schedule, and execute commands to avoid blocking operations on non-matching jobs.

Bug Fixes:
- Ensure file conflict checks in jira, schedule, and execute commands only consider jobs matching active filters instead of all existing job files.

Enhancements:
- Introduce a filtered file presence helper that delegates to job loaders when filters are active and falls back to a fast filesystem check otherwise.