### PR TITLE
Move already-finished launch handling into finish_launch()

### DIFF
--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -439,5 +439,5 @@ def _finalize_rp_launches(
     if not ctx.no_wait:
         for uuid in launch_list:
             ctx.logger.info(f'Finishing launch {uuid}')
-            rp.finish_launch(uuid)
+            rp.finish_launch(uuid, logger=ctx.logger)
             rp.check_for_empty_launch(uuid, logger=ctx.logger)

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -14,7 +14,6 @@ from newa import (
     ExecuteHow,
     ExecuteJob,
     ReportPortal,
-    ReportPortalError,
     RequestResult,
     RoGCommentTrigger,
     RoGTool,
@@ -198,13 +197,7 @@ def _finalize_rp_launch(
         launch_url: Optional[str],
         launch_description: str) -> None:
     """Finalize ReportPortal launch by finishing and updating description."""
-    try:
-        rp.finish_launch(launch_uuid)
-    except ReportPortalError as e:
-        if e.status_code == 406 and '40023' in e.response_text:
-            ctx.logger.warning(f'Launch {launch_uuid} is already finished, skipping finish step.')
-        else:
-            raise
+    rp.finish_launch(launch_uuid)
     ctx.logger.info(f'Updating launch description, {launch_url}')
     rp.update_launch(launch_uuid, description=launch_description)
 

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -197,7 +197,7 @@ def _finalize_rp_launch(
         launch_url: Optional[str],
         launch_description: str) -> None:
     """Finalize ReportPortal launch by finishing and updating description."""
-    rp.finish_launch(launch_uuid)
+    rp.finish_launch(launch_uuid, logger=ctx.logger)
     ctx.logger.info(f'Updating launch description, {launch_url}')
     rp.update_launch(launch_uuid, description=launch_description)
 

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -66,7 +66,13 @@ class ReportPortal:
             }
         if description:
             query_data['description'] = description
-        self.put_request(f'/launch/{launch_uuid}/finish', json=query_data)
+        try:
+            self.put_request(f'/launch/{launch_uuid}/finish', json=query_data)
+        except ReportPortalError as e:
+            if e.status_code == 406 and '40023' in e.response_text:
+                pass
+            else:
+                raise
         return launch_uuid
 
     def update_launch(self,

--- a/newa/services/reportportal_service.py
+++ b/newa/services/reportportal_service.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
 HTTP_STATUS_CODES_OK = [200, 201]
 
+RP_LAUNCH_ALREADY_FINISHED_STATUS = 406
+RP_LAUNCH_ALREADY_FINISHED_ERROR = '40023'
+
 
 class ReportPortalError(Exception):
     """Raised when a ReportPortal API request fails with a non-OK status code."""
@@ -59,7 +62,13 @@ class ReportPortal:
         data = self.post_request('/launch', json=query_data)
         return str(data['id'])
 
-    def finish_launch(self, launch_uuid: str, description: Optional[str] = None) -> str:
+    def finish_launch(self, launch_uuid: str, description: Optional[str] = None,
+                      logger: Optional['logging.Logger'] = None) -> str:
+        """Finish a ReportPortal launch.
+
+        This method is idempotent: if the launch has already been finished,
+        it logs a debug message and returns normally instead of raising.
+        """
         query_data: JSON = {
             'endTime': str(int(time.time() * 1000)),
             "status": "PASSED",
@@ -69,8 +78,13 @@ class ReportPortal:
         try:
             self.put_request(f'/launch/{launch_uuid}/finish', json=query_data)
         except ReportPortalError as e:
-            if e.status_code == 406 and '40023' in e.response_text:
-                pass
+            if e.status_code == RP_LAUNCH_ALREADY_FINISHED_STATUS \
+                    and RP_LAUNCH_ALREADY_FINISHED_ERROR in e.response_text:
+                if logger:
+                    logger.debug(
+                        f'ReportPortal launch {launch_uuid} already finished '
+                        f'(status_code={e.status_code}, '
+                        f'error_code={RP_LAUNCH_ALREADY_FINISHED_ERROR})')
             else:
                 raise
         return launch_uuid


### PR DESCRIPTION
Handle the 406/40023 "launch already finished" error directly in ReportPortal.finish_launch() so all callers are protected, and remove the duplicate handling from report_helpers.py.

## Summary by Sourcery

Make ReportPortal launch finalization idempotent and centralize handling of already-finished launches.

Enhancements:
- Add idempotent handling of the "launch already finished" ReportPortal error directly in ReportPortal.finish_launch().
- Propagate an optional logger into finish_launch() to log already-finished launch cases instead of raising.
- Simplify CLI helpers by removing redundant error handling now covered by ReportPortal.finish_launch().