### PR TITLE
Fix case-insensitive Reporter field handling in Jira issue creation

### DIFF
--- a/newa/services/jira_service.py
+++ b/newa/services/jira_service.py
@@ -315,9 +315,10 @@ class IssueHandler:  # type: ignore[no-untyped-def]
         transition_name: Optional[str] = None
 
         for field_name, value in fields.items():
-            # Skip Reporter field during updates as it cannot be changed after creation
-            if for_update and field_name == 'Reporter':
-                if self.logger:
+            # Skip Reporter field - handled separately during creation
+            # and cannot be changed after creation
+            if field_name.lower() == 'reporter':
+                if self.logger and for_update:
                     self.logger.debug("Skipping Reporter field (cannot be updated after creation)")
                 continue
 
@@ -491,10 +492,14 @@ class IssueHandler:  # type: ignore[no-untyped-def]
         else:
             raise Exception(f"Unknown issue type {action.type}!")
 
-        # handle fields['Reporter'] already during ticket creation
-        if fields and 'Reporter' in fields and isinstance(fields['Reporter'], str):
-            user_field = self._get_user_field_name()
-            data |= {"reporter": {user_field: self.get_user_name(fields['Reporter'])}}
+        # handle Reporter field during ticket creation (case-insensitive)
+        if fields:
+            reporter_value = next(
+                (v for k, v in fields.items() if k.lower() == 'reporter'), None)
+            if isinstance(reporter_value, str):
+                user_field = self._get_user_field_name()
+                data |= {"reporter": {
+                    user_field: self.get_user_name(reporter_value)}}
 
         try:
             jira_issue = self.connection.create_issue(data)


### PR DESCRIPTION
The Reporter field lookup was case-sensitive, causing issue-config files using lowercase 'reporter' to fail with "Could not find field 'reporter' in Jira" on Jira Cloud. Additionally, Reporter was only skipped in _process_fields_for_jira during updates, but not during creation where it is already handled separately via the Jira API.

## Summary by Sourcery

Ensure Jira Reporter field is handled case-insitively and consistently skipped from generic field processing during both issue creation and updates.

Bug Fixes:
- Fix Reporter field lookup to be case-insensitive during Jira issue creation so configurations using lowercase or mixed-case keys work correctly.
- Prevent Reporter from being processed in the generic Jira fields loop for both creations and updates, avoiding conflicts with its dedicated handling.