### PR TITLE
Add --skip-scheduled option to the schedule subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1849,6 +1849,27 @@ Example (force all tests to run):
 $ newa --prev-state-dir --clear schedule --schedule-all execute report
 ```
 
+#### Option `--skip-scheduled`
+
+Skips jira jobs that have already been scheduled, i.e. those that already have
+corresponding `schedule-*` YAML files in the state directory. This is useful
+when re-running the `schedule` command with `--force` to schedule only new
+jira jobs without duplicating already-scheduled test requests.
+
+This option is orthogonal to `--schedule-all`:
+- `--schedule-all` expands which jobs are eligible (includes `auto_schedule=False`)
+- `--skip-scheduled` shrinks which eligible jobs are processed (excludes already-scheduled)
+- Combined: schedules all not-yet-scheduled jobs, including those with `schedule: false`
+
+Example (schedule only new jira jobs, skip already-scheduled ones):
+```
+$ newa --prev-state-dir --force schedule --skip-scheduled execute report
+```
+
+Example (schedule all not-yet-scheduled jobs including those with schedule: false):
+```
+$ newa --prev-state-dir --force schedule --schedule-all --skip-scheduled execute report
+```
 
 ### Subcommand `cancel`
 

--- a/newa/cli/commands/schedule_cmd.py
+++ b/newa/cli/commands/schedule_cmd.py
@@ -47,6 +47,14 @@ from newa.cli.utils import initialize_state_dir, test_filtered_file_presence
     help=('Schedule all jobs including those with schedule: false. '
           'This overrides the auto_schedule attribute from issue-config.'),
     )
+@click.option(
+    '--skip-scheduled',
+    is_flag=True,
+    default=False,
+    help=('Skip jira jobs that have already been scheduled (i.e. have existing '
+          'schedule-* files in the state directory). Useful with --force to avoid '
+          'duplicating already-scheduled test requests.'),
+    )
 @click.pass_obj
 def cmd_schedule(
         ctx: CLIContext,
@@ -55,7 +63,8 @@ def cmd_schedule(
         no_reportportal: bool,
         rp_launch_uuid: Optional[str] = None,
         extra_tf_cli_args: Optional[str] = None,
-        schedule_all: bool = False) -> None:
+        schedule_all: bool = False,
+        skip_scheduled: bool = False) -> None:
     """
     Schedule subcommand - creates schedule jobs from jira jobs.
 
@@ -102,4 +111,5 @@ def cmd_schedule(
             no_reportportal=no_reportportal,
             rp_launch_uuid=rp_launch_uuid,
             extra_tf_cli_args=extra_tf_cli_args,
-            schedule_all=schedule_all)
+            schedule_all=schedule_all,
+            skip_scheduled=skip_scheduled)

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -184,7 +184,8 @@ def _process_jira_job(
         no_reportportal: bool,
         rp_launch_uuid: Optional[str] = None,
         extra_tf_cli_args: Optional[str] = None,
-        schedule_all: bool = False) -> None:
+        schedule_all: bool = False,
+        skip_scheduled: bool = False) -> None:
     """Process a single jira_job and create schedule jobs."""
     from newa import ScheduleJob
 
@@ -214,11 +215,21 @@ def _process_jira_job(
                 f'--action-tag-filter to override.')
             return
         # Filters are present, so we override auto_schedule
-        ctx.logger.info(
-            f'Scheduling jira job {jira_job.jira.id} - overridden by filter.')
+        ctx.logger.debug(
+            f'Processing jira job {jira_job.jira.id} - overridden by filter.')
     elif schedule_all and not auto_schedule:
-        ctx.logger.info(
-            f'Scheduling jira job {jira_job.jira.id} - overridden by --schedule-all.')
+        ctx.logger.debug(
+            f'Processing jira job {jira_job.jira.id} - overridden by --schedule-all.')
+
+    # Skip jira jobs that have already been scheduled
+    if skip_scheduled:
+        prefix = ctx.get_schedule_job_file_prefix(jira_job)
+        existing = list(ctx.state_dirpath.glob(f"{prefix}*.yaml"))
+        if existing:
+            ctx.logger.info(
+                f'Skipping jira job {jira_job.jira.id} - already scheduled '
+                f'({len(existing)} schedule file(s) found)')
+            return
 
     # Initialize ReportPortal connection if --rp-launch-uuid is provided
     rp = None

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -405,12 +405,18 @@ class CLIContext:  # type: ignore[no-untyped-def]
         return self.state_dirpath / \
             f'{filename_prefix}{job.event.short_id}-{job.short_id}-{job.jira.id}.yaml'
 
+    def get_schedule_job_file_prefix(
+            self,
+            job: 'JiraJob',
+            filename_prefix: str = SCHEDULE_FILE_PREFIX) -> str:
+        return f'{filename_prefix}{job.event.short_id}-{job.short_id}-{job.jira.id}-'
+
     def get_schedule_job_filepath(
             self,
             job: 'ScheduleJob',
             filename_prefix: str = SCHEDULE_FILE_PREFIX) -> Path:
         return self.state_dirpath / \
-            f'{filename_prefix}{job.event.short_id}-{job.short_id}-{job.jira.id}-{job.request.id}.yaml'
+            f'{self.get_schedule_job_file_prefix(job)}{job.request.id}.yaml'
 
     def get_execute_job_filepath(
             self,

--- a/tests/unit/test_jira_summary_and_schedule.py
+++ b/tests/unit/test_jira_summary_and_schedule.py
@@ -428,8 +428,8 @@ class TestScheduleAndRecipeFunctionality:
             )
 
         # Verify override log message
-        mock_ctx.logger.info.assert_any_call(
-            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+        mock_ctx.logger.debug.assert_any_call(
+            f'Processing jira job {JIRA_NONE_ID}-123 - overridden by filter.',
             )
 
         # Verify schedule job files WERE created (filter overrides auto_schedule=False)
@@ -466,8 +466,8 @@ class TestScheduleAndRecipeFunctionality:
             )
 
         # Verify override log message
-        mock_ctx.logger.info.assert_any_call(
-            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+        mock_ctx.logger.debug.assert_any_call(
+            f'Processing jira job {JIRA_NONE_ID}-123 - overridden by filter.',
             )
 
         # Verify schedule job files WERE created (filter overrides auto_schedule=False)
@@ -513,8 +513,8 @@ class TestScheduleAndRecipeFunctionality:
             )
 
         # Verify override log message
-        mock_ctx.logger.info.assert_any_call(
-            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by filter.',
+        mock_ctx.logger.debug.assert_any_call(
+            f'Processing jira job {JIRA_NONE_ID}-123 - overridden by filter.',
             )
 
         # Verify schedule job files WERE created (filter overrides auto_schedule=False)
@@ -548,8 +548,8 @@ class TestScheduleAndRecipeFunctionality:
             )
 
         # Verify override log message
-        mock_ctx.logger.info.assert_any_call(
-            f'Scheduling jira job {JIRA_NONE_ID}-123 - overridden by --schedule-all.',
+        mock_ctx.logger.debug.assert_any_call(
+            f'Processing jira job {JIRA_NONE_ID}-123 - overridden by --schedule-all.',
             )
 
         # Verify schedule job files WERE created (--schedule-all overrides auto_schedule=False)
@@ -731,3 +731,146 @@ class TestScheduleAndRecipeFunctionality:
             schedule_job = ScheduleJob.from_yaml_file(schedule_file)
             assert schedule_job.request.testingfarm is not None
             assert schedule_job.request.testingfarm['cli_args'] == '--new-arg value'
+
+    def test_skip_scheduled_skips_already_scheduled_job(self, mock_ctx):
+        """Test that --skip-scheduled skips jira jobs with existing schedule files."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml'),
+            )
+
+        # Create a fake existing schedule file matching this jira job
+        prefix = mock_ctx.get_schedule_job_file_prefix(jira_job)
+        (mock_ctx.state_dirpath / f"{prefix}request-1.yaml").touch()
+
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            skip_scheduled=True,
+            )
+
+        # Verify skip log message
+        mock_ctx.logger.info.assert_any_call(
+            f'Skipping jira job {JIRA_NONE_ID}-123 - already scheduled '
+            f'(1 schedule file(s) found)',
+            )
+
+        # Verify no NEW schedule job files were created (only the pre-existing fake one)
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) == 1
+
+    def test_skip_scheduled_processes_not_yet_scheduled_job(self, mock_ctx):
+        """Test that --skip-scheduled still schedules jobs without existing schedule files."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml'),
+            )
+
+        # No pre-existing schedule files
+
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            skip_scheduled=True,
+            )
+
+        # Verify schedule job files WERE created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0
+
+    def test_skip_scheduled_with_schedule_all_skips_already_scheduled(self, mock_ctx):
+        """Test --schedule-all --skip-scheduled skips already-scheduled jobs."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # Create a fake existing schedule file matching this jira job
+        prefix = mock_ctx.get_schedule_job_file_prefix(jira_job)
+        (mock_ctx.state_dirpath / f"{prefix}request-1.yaml").touch()
+
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=True,
+            skip_scheduled=True,
+            )
+
+        # Verify skip log message (--skip-scheduled takes priority over --schedule-all)
+        mock_ctx.logger.info.assert_any_call(
+            f'Skipping jira job {JIRA_NONE_ID}-123 - already scheduled '
+            f'(1 schedule file(s) found)',
+            )
+
+        # Verify no NEW schedule job files were created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) == 1
+
+    def test_skip_scheduled_with_schedule_all_processes_not_yet_scheduled(self, mock_ctx):
+        """Test --schedule-all --skip-scheduled schedules not-yet-scheduled auto_schedule=False."""
+        from newa import Compose, Recipe
+        from newa.cli.constants import JIRA_NONE_ID
+        from newa.cli.schedule_helpers import _process_jira_job
+
+        jira_job = JiraJob(
+            event=Event(id='12345', type_=EventType.ERRATUM),
+            erratum=None,
+            compose=Compose('RHEL-9.0'),
+            rog=None,
+            jira=Issue(f'{JIRA_NONE_ID}-123', summary='Test Issue'),
+            recipe=Recipe(url='tests/unit/data/sample_recipe.yaml', auto_schedule=False),
+            )
+
+        # No pre-existing schedule files
+
+        _process_jira_job(
+            ctx=mock_ctx,
+            jira_job=jira_job,
+            arch_options=['x86_64'],
+            fixtures=[],
+            no_reportportal=True,
+            schedule_all=True,
+            skip_scheduled=True,
+            )
+
+        # Verify override log message from --schedule-all
+        mock_ctx.logger.debug.assert_any_call(
+            f'Processing jira job {JIRA_NONE_ID}-123 - overridden by --schedule-all.',
+            )
+
+        # Verify schedule job files WERE created
+        schedule_job_files = list(Path(mock_ctx.state_dirpath).glob('schedule-*'))
+        assert len(schedule_job_files) > 0


### PR DESCRIPTION
Skip jira jobs that already have corresponding schedule-* YAML files in the state directory, avoiding duplicate test scheduling when re-running with --force. Orthogonal to --schedule-all: combined, they schedule all not-yet-scheduled jobs including auto_schedule=False.

## Summary by Sourcery

Introduce a --skip-scheduled option to the schedule subcommand to avoid re-scheduling Jira jobs that already have schedule YAML files.

Enhancements:
- Add logic in Jira job processing to detect existing schedule-* state files and skip already-scheduled jobs, including when combined with --schedule-all.

Documentation:
- Document the new --skip-scheduled option, its interaction with --schedule-all, and provide usage examples.

Tests:
- Add unit tests covering skip behavior for already-scheduled jobs, non-scheduled jobs, and interaction of --skip-scheduled with --schedule-all.