### PR TITLE
Reduce log noise when loading and filtering YAML job files

### DIFF
--- a/newa/cli/event_helpers.py
+++ b/newa/cli/event_helpers.py
@@ -69,8 +69,7 @@ def parse_event_filter(event_filter: str) -> 'EventFilter':
 def should_filter_by_event(
         event_filter: 'EventFilter',
         job: Union['ArtifactJob', 'JiraJob', 'ScheduleJob', 'ExecuteJob'],
-        logger: logging.Logger,
-        log_message: bool = True) -> bool:
+        logger: logging.Logger) -> bool:
     """
     Check if a job should be filtered out based on event filter pattern.
 
@@ -78,7 +77,6 @@ def should_filter_by_event(
         event_filter: EventFilter with object type, attribute, and pattern
         job: Job to check (ArtifactJob or any subclass: JiraJob, ScheduleJob, ExecuteJob)
         logger: Logger instance for messages
-        log_message: Whether to log info messages (vs debug only)
 
     Returns:
         True if the job should be skipped, False if it should be processed.
@@ -104,30 +102,22 @@ def should_filter_by_event(
 
     # If the artifact type doesn't match the filter, skip it
     if artifact_type is None:
-        if log_message:
-            logger.debug(
-                f"Skipping job {job.id} - it doesn't have a "
-                f"{event_filter.object_type} artifact")
+        logger.debug(
+            f"Skipping job {job.id} - it doesn't have a "
+            f"{event_filter.object_type} artifact")
         return True
 
-    # If we couldn't extract a value, skip it
     if not value_to_check:
-        if log_message:
-            logger.debug(
-                f"Skipping job {job.id} - {event_filter.object_type}.{event_filter.attribute} "
-                "has no value")
+        logger.debug(
+            f"Skipping job {job.id} - {event_filter.object_type}.{event_filter.attribute} "
+            "has no value")
         return True
 
     # Check if the value matches the pattern
     if not event_filter.pattern.fullmatch(value_to_check):
-        if log_message:
-            logger.info(
-                f"Skipping job {job.id} - {event_filter.object_type}.{event_filter.attribute}="
-                f'"{value_to_check}" doesn\'t match the --event-filter regular expression.')
-        else:
-            logger.debug(
-                f"Skipping job {job.id} - {event_filter.object_type}.{event_filter.attribute}="
-                f'"{value_to_check}" doesn\'t match the --event-filter regular expression.')
+        logger.debug(
+            f"Skipping job {job.id} - {event_filter.object_type}.{event_filter.attribute}="
+            f'"{value_to_check}" doesn\'t match the --event-filter regular expression.')
         return True
 
     logger.debug(

--- a/newa/cli/main.py
+++ b/newa/cli/main.py
@@ -101,7 +101,7 @@ def _should_filter_yaml_file(
 
             # Create job from already-loaded YAML data (avoids double parsing)
             job = ArtifactJob(**yaml_data)
-            if should_filter_by_event(event_filter_pattern, job, logger, log_message=False):
+            if should_filter_by_event(event_filter_pattern, job, logger):
                 logger.debug(f'Filtering {yaml_file.name} (event filter)')
                 return True
 

--- a/newa/models/settings.py
+++ b/newa/models/settings.py
@@ -293,7 +293,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
         from newa.models.jobs import ArtifactJob
         job = ArtifactJob.from_yaml_file(filepath)
 
-        self.logger.info(f'Discovered event job {job.id} in {filepath}')
+        self.logger.debug(f'Discovered event job {job.id} in {filepath}')
 
         return job
 
@@ -308,13 +308,14 @@ class CLIContext:  # type: ignore[no-untyped-def]
             job = self.load_artifact_job(child.resolve())
             if filter_events and self.should_filter_job(job):
                 continue
+            self.logger.info(f'Processing event job {job.id} from {child.resolve()}')
             yield job
 
     def load_jira_job(self, filepath: Path) -> 'JiraJob':
         from newa.models.jobs import JiraJob
         job = JiraJob.from_yaml_file(filepath)
 
-        self.logger.info(f'Discovered jira job {job.id} in {filepath}')
+        self.logger.debug(f'Discovered jira job {job.id} in {filepath}')
 
         return job
 
@@ -336,13 +337,14 @@ class CLIContext:  # type: ignore[no-untyped-def]
                     continue
                 if self.should_filter_job(job):
                     continue
+            self.logger.info(f'Processing jira job {job.id} from {child.resolve()}')
             yield job
 
     def load_schedule_job(self, filepath: Path) -> 'ScheduleJob':
         from newa.models.jobs import ScheduleJob
         job = ScheduleJob.from_yaml_file(filepath)
 
-        self.logger.info(f'Discovered schedule job {job.id} in {filepath}')
+        self.logger.debug(f'Discovered schedule job {job.id} in {filepath}')
 
         return job
 
@@ -364,13 +366,14 @@ class CLIContext:  # type: ignore[no-untyped-def]
                     continue
                 if self.should_filter_job(job):
                     continue
+            self.logger.info(f'Processing schedule job {job.id} from {child.resolve()}')
             yield job
 
     def load_execute_job(self, filepath: Path) -> 'ExecuteJob':
         from newa.models.jobs import ExecuteJob
         job = ExecuteJob.from_yaml_file(filepath)
 
-        self.logger.info(f'Discovered execute job {job.id} in {filepath}')
+        self.logger.debug(f'Discovered execute job {job.id} in {filepath}')
 
         return job
 
@@ -392,6 +395,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
                     continue
                 if self.should_filter_job(job):
                     continue
+            self.logger.info(f'Processing execute job {job.id} from {child.resolve()}')
             yield job
 
     def get_artifact_job_filepath(
@@ -468,8 +472,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
 
     def _should_filter_by_action_id(
             self,
-            action_id: Optional[str],
-            log_message: bool = True) -> bool:
+            action_id: Optional[str]) -> bool:
         """Check if job should be filtered out based on action_id pattern.
 
         Returns True if the job should be skipped, False if it should be processed.
@@ -478,14 +481,9 @@ class CLIContext:  # type: ignore[no-untyped-def]
             return False
 
         if not action_id or not self.action_id_filter_pattern.fullmatch(action_id):
-            if log_message:
-                self.logger.info(
-                    f"Skipping action {action_id} as it doesn't match "
-                    "the --action-id-filter regular expression.")
-            else:
-                self.logger.debug(
-                    f"Skipping action {action_id} as it doesn't match "
-                    "the --action-id-filter regular expression.")
+            self.logger.debug(
+                f"Skipping action {action_id} as it doesn't match "
+                "the --action-id-filter regular expression.")
             return True
 
         self.logger.debug(
@@ -495,8 +493,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
 
     def _should_filter_by_issue_id(
             self,
-            issue_id: Optional[str],
-            log_message: bool = True) -> bool:
+            issue_id: Optional[str]) -> bool:
         """Check if job should be filtered out based on issue_id pattern.
 
         Returns True if the job should be skipped, False if it should be processed.
@@ -505,14 +502,9 @@ class CLIContext:  # type: ignore[no-untyped-def]
             return False
 
         if not issue_id or not self.issue_id_filter_pattern.fullmatch(issue_id):
-            if log_message:
-                self.logger.info(
-                    f"Skipping issue {issue_id} as it doesn't match "
-                    "the --issue-id-filter regular expression.")
-            else:
-                self.logger.debug(
-                    f"Skipping issue {issue_id} as it doesn't match "
-                    "the --issue-id-filter regular expression.")
+            self.logger.debug(
+                f"Skipping issue {issue_id} as it doesn't match "
+                "the --issue-id-filter regular expression.")
             return True
 
         self.logger.debug(
@@ -522,8 +514,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
 
     def _should_filter_by_action_tags(
             self,
-            action_tags: Optional[list[str]],
-            log_message: bool = True) -> bool:
+            action_tags: Optional[list[str]]) -> bool:
         """Check if job should be filtered out based on action_tags filter.
 
         Returns True if the job should be skipped, False if it should be processed.
@@ -537,23 +528,13 @@ class CLIContext:  # type: ignore[no-untyped-def]
         should_filter = should_filter_by_action_tags(action_tags, self.action_tag_filter_pattern)
 
         if should_filter:
-            # Action should be filtered out - log it
             if not action_tags:
-                if log_message:
-                    self.logger.info(
-                        "Skipping action with no tags as --action-tag-filter is specified.")
-                else:
-                    self.logger.debug(
-                        "Skipping action with no tags as --action-tag-filter is specified.")
+                self.logger.debug(
+                    "Skipping action with no tags as --action-tag-filter is specified.")
             else:
-                if log_message:
-                    self.logger.info(
-                        f"Skipping action with tags {action_tags} as they don't match "
-                        "the --action-tag-filter expression.")
-                else:
-                    self.logger.debug(
-                        f"Skipping action with tags {action_tags} as they don't match "
-                        "the --action-tag-filter expression.")
+                self.logger.debug(
+                    f"Skipping action with tags {action_tags} as they don't match "
+                    "the --action-tag-filter expression.")
         else:
             # Action matches - log at debug level
             self.logger.debug(
@@ -578,7 +559,7 @@ class CLIContext:  # type: ignore[no-untyped-def]
         if action_id and action_id in filtered_id_list:
             self.logger.debug(f"Action {action_id} matches the user provided filter.")
             return False
-        self.logger.info(
+        self.logger.debug(
             f"Skipping action {action_id} as it doesn't match the user provided filter.")
         return True
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -85,22 +85,12 @@ class TestActionIdFilter:
         """When action_id doesn't match pattern, should filter (return True)."""
         result = ctx_with_action_filter._should_filter_by_action_id('build_x86')
         assert result is True
-        # Check info log was called (log_message=True by default)
-        ctx_with_action_filter.logger.info.assert_called_once()
+        ctx_with_action_filter.logger.debug.assert_called_once()
 
     def test_none_action_id_returns_true(self, ctx_with_action_filter):
         """When action_id is None, should filter (return True)."""
         result = ctx_with_action_filter._should_filter_by_action_id(None)
         assert result is True
-
-    def test_log_message_false_uses_debug(self, ctx_with_action_filter):
-        """When log_message=False, should use debug log for skips."""
-        result = ctx_with_action_filter._should_filter_by_action_id(
-            'build_x86', log_message=False)
-        assert result is True
-        # Check debug log was called, not info
-        ctx_with_action_filter.logger.debug.assert_called_once()
-        ctx_with_action_filter.logger.info.assert_not_called()
 
 
 class TestIssueIdFilter:
@@ -122,22 +112,12 @@ class TestIssueIdFilter:
         """When issue_id doesn't match pattern, should filter (return True)."""
         result = ctx_with_issue_filter._should_filter_by_issue_id('RHEL-99999')
         assert result is True
-        # Check info log was called (log_message=True by default)
-        ctx_with_issue_filter.logger.info.assert_called_once()
+        ctx_with_issue_filter.logger.debug.assert_called_once()
 
     def test_none_issue_id_returns_true(self, ctx_with_issue_filter):
         """When issue_id is None, should filter (return True)."""
         result = ctx_with_issue_filter._should_filter_by_issue_id(None)
         assert result is True
-
-    def test_log_message_false_uses_debug(self, ctx_with_issue_filter):
-        """When log_message=False, should use debug log for skips."""
-        result = ctx_with_issue_filter._should_filter_by_issue_id(
-            'RHEL-99999', log_message=False)
-        assert result is True
-        # Check debug log was called, not info
-        ctx_with_issue_filter.logger.debug.assert_called_once()
-        ctx_with_issue_filter.logger.info.assert_not_called()
 
 
 class TestBothFilters:
@@ -471,32 +451,21 @@ class TestActionTagFilter:
         result = ctx_with_tag_filter._should_filter_by_action_tags(
             ['performance', 'nightly'])
         assert result is True
-        # Check info log was called for skip message (log_message=True by default)
-        ctx_with_tag_filter.logger.info.assert_called_once()
+        ctx_with_tag_filter.logger.debug.assert_called_once()
 
     def test_none_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is None, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags(None)
         assert result is True
-        # Check info log was called with "no tags" message (log_message=True by default)
-        ctx_with_tag_filter.logger.info.assert_called_once_with(
+        ctx_with_tag_filter.logger.debug.assert_called_once_with(
             "Skipping action with no tags as --action-tag-filter is specified.")
 
     def test_empty_action_tags_returns_true(self, ctx_with_tag_filter):
         """When action_tags is empty list, should filter (return True)."""
         result = ctx_with_tag_filter._should_filter_by_action_tags([])
         assert result is True
-        # Check info log was called with "no tags" message (log_message=True by default)
-        ctx_with_tag_filter.logger.info.assert_called_once_with(
+        ctx_with_tag_filter.logger.debug.assert_called_once_with(
             "Skipping action with no tags as --action-tag-filter is specified.")
-
-    def test_log_message_false_uses_debug(self, ctx_with_tag_filter):
-        """When log_message=False, should use debug log for skips."""
-        result = ctx_with_tag_filter._should_filter_by_action_tags(
-            ['performance', 'nightly'], log_message=False)
-        assert result is True
-        # Check debug log was called (logging now always uses debug)
-        ctx_with_tag_filter.logger.debug.assert_called_once()
 
     def test_pattern_matches_full_tag_only(self, ctx_with_tag_filter):
         """Pattern should match full tag, not partial."""


### PR DESCRIPTION
Move "Discovered" and "Skipping" log messages from INFO to DEBUG, and add INFO-level "Processing" messages only for jobs that pass all filters. Remove the now-unused log_message parameter from filter methods.

## Summary by Sourcery

Reduce verbosity of job discovery and filtering logs while keeping visibility into jobs that are actually processed.

Enhancements:
- Log job discovery and filter-based skip messages at debug level instead of info to reduce log noise.
- Add info-level logging only for jobs that pass filters and are being processed across artifact, Jira, schedule, and execute job loaders.
- Simplify filter helper APIs by removing the log_message parameter and standardizing on debug-level skip logging.

Tests:
- Update filter unit tests to assert debug-level logging for skipped actions, issues, and tags and remove cases tied to the removed log_message parameter.