### PR TITLE
Support reportportal: null in recipe dimensions to disable RP per com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,17 @@ In this example, `full` scenario combinations will report to ReportPortal as con
 
 **Note:** Once `reportportal` is set to `null` for a combination, it cannot be overridden back to a non-null value by later merge sources, including CLI-provided options (e.g. `--fixture`). This is a deliberate deviation from the general priority rule where CLI options and fixtures normally take precedence. The rationale is that an explicit `null` represents an intentional opt-out from RP reporting for that combination.
 
-To disable ReportPortal reporting for all combinations at once, use the `schedule --no-reportportal` CLI option instead.
+To disable ReportPortal reporting for all combinations of a recipe, set `reportportal: null` in `fixtures`. This has the same effect as the `schedule --no-reportportal` CLI option but is scoped to the recipe itself:
+
+```yaml
+fixtures:
+    reportportal: null
+    tmt:
+        url: https://github.com/example/tests.git
+        ...
+```
+
+Alternatively, use the `schedule --no-reportportal` CLI option to disable RP reporting globally across all recipes in a scheduling run.
 
 #### when
 A condition that restricts when an item should be used. See "In-config tests" section for examples.

--- a/README.md
+++ b/README.md
@@ -917,6 +917,31 @@ Example:
       trigger: build
 ```
 
+##### Disabling ReportPortal for specific combinations
+
+To disable ReportPortal reporting for specific combinations, set `reportportal: null` in the corresponding dimension or adjustment item. This overrides any `reportportal` configuration inherited from `fixtures`.
+
+Example:
+```yaml
+fixtures:
+    reportportal:
+        launch_name: "my-tests"
+        launch_description: "My test launch"
+dimensions:
+    scenario:
+        - context:
+              scenario: full
+        - context:
+              scenario: smoke
+          reportportal: null    # no RP reporting for smoke test combinations
+```
+
+In this example, `full` scenario combinations will report to ReportPortal as configured in `fixtures`, while `smoke` scenario combinations will skip RP reporting entirely.
+
+**Note:** Once `reportportal` is set to `null` for a combination, it cannot be overridden back to a non-null value by later merge sources, including CLI-provided options (e.g. `--fixture`). This is a deliberate deviation from the general priority rule where CLI options and fixtures normally take precedence. The rationale is that an explicit `null` represents an intentional opt-out from RP reporting for that combination.
+
+To disable ReportPortal reporting for all combinations at once, use the `schedule --no-reportportal` CLI option instead.
+
 #### when
 A condition that restricts when an item should be used. See "In-config tests" section for examples.
 

--- a/README.md
+++ b/README.md
@@ -870,6 +870,42 @@ Example:
     swtpm: yes
 ```
 
+#### description
+
+Defines a human-readable description for a combination. This attribute is independent of the `reportportal` section and can be used even when ReportPortal reporting is disabled for the combination.
+
+The `description` value appears in the Jira comment summary table. When ReportPortal reporting is enabled, it also serves as a fallback for `reportportal.suite_description` if that is not explicitly set.
+
+For the Jira comment table, the value is resolved in this order:
+ 1. `description` (this attribute)
+ 2. `reportportal.suite_description` (legacy fallback)
+ 3. `(not reported to RP)` for combinations with `reportportal: null`
+
+For the ReportPortal suite description, the value is resolved in this order:
+ 1. `reportportal.suite_description` (explicit RP setting)
+ 2. `description` (fallback)
+
+The `description` attribute supports Jinja2 templates.
+
+Example:
+```yaml
+fixtures:
+    description: "tier {{ CONTEXT.tier }} on {{ ENVIRONMENT.CITY }}"
+dimensions:
+    scenario:
+        - context:
+              tier: 1
+          environment:
+              CITY: Brno
+        - context:
+              tier: 2
+          environment:
+              CITY: Boston
+          reportportal: null
+```
+
+In this example, both combinations have a description shown in the Jira comment. The second combination additionally shows `(not reported to RP)` after its description since it has ReportPortal disabled.
+
 #### how
 
 Optional attribute. Defines if requests should be run through Testing Farm or `tmt`. The default value is `testingfarm`.

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -129,13 +129,25 @@ def _create_jira_job_mapping(
     return jira_job_mapping
 
 
+def _find_rp_job(
+        jobs: Union[list[ScheduleJob], list[ExecuteJob]]) -> Optional[
+            Union[ScheduleJob, ExecuteJob]]:
+    """Find the first job in a group that has reportportal configured."""
+    for job in jobs:
+        if job.request.reportportal:
+            return job
+    return None
+
+
 def _prepare_launch_description(
         jira_id: str,
         schedule_jobs: Union[list[ScheduleJob], list[ExecuteJob]],
         jira_url: str) -> str:
     """Prepare the launch description for ReportPortal."""
+    # Not all jobs in the group may have reportportal configured
+    rp_job = _find_rp_job(schedule_jobs)
     launch_description: str = str(
-        schedule_jobs[0].request.reportportal.get('launch_description', ''))
+        rp_job.request.reportportal.get('launch_description', '') if rp_job else '')
     if launch_description:
         launch_description += '<br><br>'
 
@@ -154,8 +166,13 @@ def _create_or_reuse_rp_launch(
         schedule_jobs: list[ScheduleJob],
         launch_description: str) -> Optional[str]:
     """Create or reuse a ReportPortal launch for the given jira_id."""
+    # Not all jobs in the group may have reportportal configured
+    rp_job = _find_rp_job(schedule_jobs)
+    if not rp_job or not rp_job.request.reportportal:
+        return None
+
     # Check if launch already exists
-    existing_launch_uuid: Optional[str] = schedule_jobs[0].request.reportportal.get(
+    existing_launch_uuid: Optional[str] = rp_job.request.reportportal.get(
         'launch_uuid', None)
     if existing_launch_uuid:
         ctx.logger.debug(
@@ -163,11 +180,11 @@ def _create_or_reuse_rp_launch(
         return str(existing_launch_uuid)
 
     # Create new launch
-    launch_name: str = str(schedule_jobs[0].request.reportportal['launch_name']).strip()
+    launch_name: str = str(rp_job.request.reportportal['launch_name']).strip()
     if not launch_name:
         raise Exception("RP launch name is not configured")
 
-    launch_attrs: dict[str, Any] = schedule_jobs[0].request.reportportal.get(
+    launch_attrs: dict[str, Any] = rp_job.request.reportportal.get(
         'launch_attributes', {})
     launch_attrs.update({'newa_statedir': str(ctx.state_dirpath)})
 
@@ -201,6 +218,8 @@ def _update_schedule_jobs_with_launch(
     """Update schedule jobs with launch UUID and URL."""
     launch_url = rp.get_launch_url(launch_uuid)
     for job in jira_schedule_job_mapping[jira_id]:
+        if not job.request.reportportal:
+            continue
         job.request.reportportal['launch_uuid'] = launch_uuid
         job.request.reportportal['launch_url'] = launch_url
         ctx.save_schedule_job(job)
@@ -306,9 +325,11 @@ def _process_rp_launches_and_jira_updates(
 
     for jira_id, schedule_jobs in jira_schedule_job_mapping.items():
         job = schedule_jobs[0]
+        # Not all jobs in the group may have reportportal configured
+        rp_job = _find_rp_job(schedule_jobs)
 
         # Handle ReportPortal launch creation
-        if schedule_jobs[0].request.reportportal:
+        if rp_job and rp_job.request.reportportal:
             launch_description = _prepare_launch_description(jira_id, schedule_jobs, jira_url)
             launch_uuid = _create_or_reuse_rp_launch(
                 ctx, rp, jira_id, schedule_jobs, launch_description)
@@ -316,7 +337,7 @@ def _process_rp_launches_and_jira_updates(
             if launch_uuid:
                 launch_list.append(launch_uuid)
                 # Update schedule jobs if launch was just created
-                if launch_uuid != schedule_jobs[0].request.reportportal.get('launch_uuid', None):
+                if launch_uuid != rp_job.request.reportportal.get('launch_uuid', None):
                     launch_url = _update_schedule_jobs_with_launch(
                         ctx, rp, jira_id, schedule_jobs, launch_uuid, jira_schedule_job_mapping)
                 else:

--- a/newa/cli/execute_helpers.py
+++ b/newa/cli/execute_helpers.py
@@ -155,7 +155,8 @@ def _prepare_launch_description(
         issue_url = urllib.parse.urljoin(jira_url, f"/browse/{jira_id}")
         launch_description += f'[{jira_id}]({issue_url}): '
 
-    launch_description += f'{len(schedule_jobs)} request(s) in total'
+    rp_count = sum(1 for j in schedule_jobs if j.request.reportportal)
+    launch_description += f'{rp_count} request(s) in total'
     return launch_description
 
 
@@ -427,10 +428,12 @@ def _finalize_rp_launches(
     # Update launch descriptions for each Jira ID with TF request URLs if --no-wait
     if ctx.no_wait:
         for jira_id, execute_jobs in jira_execute_job_mapping.items():
-            if not execute_jobs[0].request.reportportal:
+            # Not all jobs in the group may have reportportal configured
+            rp_job = _find_rp_job(execute_jobs)
+            if not rp_job or not rp_job.request.reportportal:
                 continue
 
-            launch_uuid = execute_jobs[0].request.reportportal.get('launch_uuid', '')
+            launch_uuid = rp_job.request.reportportal.get('launch_uuid', '')
             if not launch_uuid:
                 continue
 
@@ -438,13 +441,15 @@ def _finalize_rp_launches(
             launch_description = _prepare_launch_description(
                 jira_id, execute_jobs, ctx.settings.jira_url)
 
-            # Add TF request URLs for this Jira ID's execute jobs
+            # Add TF request URLs for this Jira ID's RP-enabled execute jobs
             rp_chars_limit = (ctx.settings.rp_launch_descr_chars_limit or
                               RP_LAUNCH_DESCR_CHARS_LIMIT)
             rp_launch_descr_updated = launch_description + "\n"
             rp_launch_descr_dots = True
 
             for execute_job in execute_jobs:
+                if not execute_job.request.reportportal:
+                    continue
                 req_link = f"[{execute_job.request.id}]({execute_job.execution.request_api})\n"
                 if len(req_link) + len(rp_launch_descr_updated) < int(rp_chars_limit):
                     rp_launch_descr_updated += req_link

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -40,9 +40,11 @@ def execute_jobs_summary(ctx: CLIContext,
     summary = ''
     msg_next_comment = 'TBC in the next comment...'
     magic_number = len(separator + msg_next_comment)
-    # add configured RP description if available
-    if execute_jobs[0].request.reportportal:
-        launch_description = execute_jobs[0].request.reportportal.get(
+    # add configured RP description if available;
+    # not all jobs in the group may have reportportal configured
+    rp_job = next((j for j in execute_jobs if j.request.reportportal), None)
+    if rp_job and rp_job.request.reportportal:
+        launch_description = rp_job.request.reportportal.get(
             'launch_description', '')
         summary += launch_description + 2 * separator if launch_description else ''
     # prepare content with individual results
@@ -168,9 +170,11 @@ def _get_rp_launch_details(
     launch_uuid = None
     launch_url = None
 
-    if execute_jobs[0].request.reportportal:
-        launch_uuid = execute_jobs[0].request.reportportal.get('launch_uuid', None)
-        launch_url = execute_jobs[0].request.reportportal.get('launch_url', None)
+    # Not all jobs in the group may have reportportal configured
+    rp_job = next((j for j in execute_jobs if j.request.reportportal), None)
+    if rp_job and rp_job.request.reportportal:
+        launch_uuid = rp_job.request.reportportal.get('launch_uuid', None)
+        launch_url = rp_job.request.reportportal.get('launch_url', None)
 
     return launch_uuid, launch_url
 

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -20,6 +20,7 @@ from newa import (
     TFRequest,
     )
 from newa.cli.constants import JIRA_NONE_ID
+from newa.cli.execute_helpers import _find_rp_job
 from newa.cli.initialization import issue_transition
 from newa.utils.helpers import short_sleep
 
@@ -42,7 +43,7 @@ def execute_jobs_summary(ctx: CLIContext,
     magic_number = len(separator + msg_next_comment)
     # add configured RP description if available;
     # not all jobs in the group may have reportportal configured
-    rp_job = next((j for j in execute_jobs if j.request.reportportal), None)
+    rp_job = _find_rp_job(execute_jobs)
     if rp_job and rp_job.request.reportportal:
         launch_description = rp_job.request.reportportal.get(
             'launch_description', '')
@@ -183,7 +184,7 @@ def _get_rp_launch_details(
     launch_url = None
 
     # Not all jobs in the group may have reportportal configured
-    rp_job = next((j for j in execute_jobs if j.request.reportportal), None)
+    rp_job = _find_rp_job(execute_jobs)
     if rp_job and rp_job.request.reportportal:
         launch_uuid = rp_job.request.reportportal.get('launch_uuid', None)
         launch_url = rp_job.request.reportportal.get('launch_url', None)

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -62,11 +62,18 @@ def execute_jobs_summary(ctx: CLIContext,
             'uuid': job.execution.request_uuid,
             'url': url,
             'plan': job.request.tmt.get('plan', '')}
+        desc = getattr(job.request, 'description', '') or ''
         if job.request.reportportal:
-            results[job.request.id]['suite_desc'] = job.request.reportportal.get(
-                'suite_description', '')
+            results[job.request.id]['suite_desc'] = (
+                desc
+                or job.request.reportportal.get('suite_description', '')
+                or '')
+            results[job.request.id]['has_rp'] = 'yes'
         else:
-            results[job.request.id]['suite_desc'] = ''
+            rp_note = '(not reported to RP)'
+            results[job.request.id]['suite_desc'] = (
+                f'{desc} {rp_note}' if desc else rp_note)
+            results[job.request.id]['has_rp'] = ''
     if not jira_id.startswith(JIRA_NONE_ID):
         jira_url = ctx.settings.jira_url
         issue_url = urllib.parse.urljoin(
@@ -76,11 +83,17 @@ def execute_jobs_summary(ctx: CLIContext,
             summary += f'[{jira_id}]({issue_url}): '
         else:
             summary += f'{jira_id}: '
-    summary += f'{len(execute_jobs)} request(s) in total:'
+    if target == 'ReportPortal':
+        rp_count = sum(1 for r in results.values() if r['has_rp'])
+        summary += f'{rp_count} request(s) in total:'
+    else:
+        summary += f'{len(execute_jobs)} request(s) in total:'
     for req in sorted(results.keys(), key=lambda x: int(x.split('.')[-1])):
         # it would be nice to use hyperlinks in launch description however we
         # would hit launch description length limit. Therefore using plain text
         if target == 'ReportPortal':
+            if not results[req]['has_rp']:
+                continue
             new_line = "{id}: {state}, {result}".format(**results[req])
         else:
             # replace "|" with unicode "Fullwidth Vertical Line"

--- a/newa/cli/report_helpers.py
+++ b/newa/cli/report_helpers.py
@@ -70,9 +70,8 @@ def execute_jobs_summary(ctx: CLIContext,
                 or '')
             results[job.request.id]['has_rp'] = 'yes'
         else:
-            rp_note = '(not reported to RP)'
-            results[job.request.id]['suite_desc'] = (
-                f'{desc} {rp_note}' if desc else rp_note)
+            results[job.request.id]['state'] += ' (not reported to RP)'
+            results[job.request.id]['suite_desc'] = desc
             results[job.request.id]['has_rp'] = ''
     if not jira_id.startswith(JIRA_NONE_ID):
         jira_url = ctx.settings.jira_url

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -126,6 +126,10 @@ def _render_request_attributes(
         # compose and description values are strings, not dicts
         if attr in ('compose', 'description'):
             value = getattr(request, attr, '')
+            # skip when None or empty — str(None) would produce the string
+            # "None" which then gets saved as the attribute value
+            if not value:
+                continue
             new_value = render_template(str(value), **jinja_vars)
             if new_value:
                 setattr(request, attr, new_value)

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -121,9 +121,10 @@ def _render_request_attributes(
     evaluated during build_requests() and contains references to variables
     that may be None, which would cause errors if re-rendered.
     """
-    for attr in ("reportportal", "tmt", "testingfarm", "environment", "context", "compose"):
-        # compose value is a string, not dict
-        if attr == 'compose':
+    for attr in ("reportportal", "tmt", "testingfarm", "environment", "context",
+                 "compose", "description"):
+        # compose and description values are strings, not dicts
+        if attr in ('compose', 'description'):
             value = getattr(request, attr, '')
             new_value = render_template(str(value), **jinja_vars)
             if new_value:

--- a/newa/cli/schedule_helpers.py
+++ b/newa/cli/schedule_helpers.py
@@ -101,8 +101,8 @@ def _configure_recipe(
         for architecture in architectures:
             config.dimensions['arch'].append({'arch': architecture})
 
-    # If RP launch name is not specified in the recipe, set it based on the recipe filename
-    if not config.fixtures.get('reportportal', None):
+    # If RP is not mentioned in the recipe, set a default; explicit null is preserved
+    if 'reportportal' not in config.fixtures:
         config.fixtures['reportportal'] = RawRecipeReportPortalConfigDimension()
 
     # Populate default for config.fixtures['reportportal']['launch_name']

--- a/newa/models/execution.py
+++ b/newa/models/execution.py
@@ -106,6 +106,7 @@ class Request(Cloneable, Serializable):
     environment: RecipeEnvironment = field(factory=dict)
     arch: Optional[Arch] = field(converter=Arch, default=Arch.X86_64)
     compose: Optional[str] = None
+    description: Optional[str] = None
     tmt: Optional[RawRecipeTmtConfigDimension] = None
     testingfarm: Optional[RawRecipeTFConfigDimension] = None
     reportportal: Optional[RawRecipeReportPortalConfigDimension] = None
@@ -156,12 +157,13 @@ class Request(Cloneable, Serializable):
                         '--context',
                         'newa_report_rp=1',
                         ]
-            if self.reportportal.get("suite_description", None):
+            desc = (self.reportportal.get("suite_description", None)
+                    or self.description)
+            if desc:
                 # we are intentionally using suite_description, not launch description
                 # as due to SUITE_PER_PLAN enabled the launch description will end up
                 # in suite description as well once
                 # https://github.com/teemtee/tmt/issues/2990 is implemented
-                desc = self.reportportal.get("suite_description")
                 command += [
                     '--tmt-environment',
                     f"""'TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH_DESCRIPTION="{desc}"'"""]
@@ -268,12 +270,13 @@ class Request(Cloneable, Serializable):
                 'TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH': f"{self.reportportal['launch_name']}",
                 'TMT_PLUGIN_REPORT_REPORTPORTAL_SUITE_PER_PLAN': '1',
                 })
-            if self.reportportal.get("suite_description", None):
+            desc = (self.reportportal.get("suite_description", None)
+                    or self.description)
+            if desc:
                 # we are intentionally using suite_description, not launch description
                 # as due to SUITE_PER_PLAN enabled the launch description will end up
                 # in suite description as well once
                 # https://github.com/teemtee/tmt/issues/2990 is implemented
-                desc = self.reportportal.get("suite_description")
                 environment['TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH_DESCRIPTION'] = f"{desc}"
             if rp_test_param_filter:
                 environment['TMT_PLUGIN_REPORT_REPORTPORTAL_EXCLUDE_VARIABLES'] = \

--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -66,6 +66,7 @@ class RawRecipeConfigDimension(TypedDict, total=False):
     context: RecipeContext
     environment: RecipeEnvironment
     compose: Optional[str]
+    description: Optional[str]
     arch: Optional[Arch]
     tmt: Optional[RawRecipeTmtConfigDimension]
     testingfarm: Optional[RawRecipeTFConfigDimension]
@@ -74,7 +75,8 @@ class RawRecipeConfigDimension(TypedDict, total=False):
 
 
 _RecipeConfigDimensionKey = Literal['context', 'environment',
-                                    'tmt', 'testingfarm', 'reportportal', 'when', 'arch']
+                                    'tmt', 'testingfarm', 'reportportal',
+                                    'when', 'arch', 'description']
 
 
 # A list of recipe config dimensions, as stored in a recipe config file.

--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -379,6 +379,12 @@ class RecipeConfig(Cloneable, Serializable):
             elif key not in dest:
                 # we need to do a deep copy so we won't corrupt the original data
                 dest[key] = copy.deepcopy(src[key])  # type: ignore[literal-required]
+            # Null override is intentionally limited to 'reportportal' key;
+            # other keys (context, environment, etc.) are not safe to null out.
+            elif key == 'reportportal' and src[key] is None:  # type: ignore[literal-required]
+                dest[key] = None  # type: ignore[literal-required]
+            elif key == 'reportportal' and dest[key] is None:  # type: ignore[literal-required]
+                pass
             elif isinstance(dest[key], dict) and isinstance(src[key], dict):  # type: ignore[literal-required]
                 dest[key].update(src[key])  # type: ignore[literal-required]
             elif isinstance(dest[key], list) and isinstance(src[key], list):  # type: ignore[literal-required]

--- a/newa/models/recipes.py
+++ b/newa/models/recipes.py
@@ -381,10 +381,11 @@ class RecipeConfig(Cloneable, Serializable):
                 dest[key] = copy.deepcopy(src[key])  # type: ignore[literal-required]
             # Null override is intentionally limited to 'reportportal' key;
             # other keys (context, environment, etc.) are not safe to null out.
-            elif key == 'reportportal' and src[key] is None:  # type: ignore[literal-required]
+            # Once null, the value stays null (sticky) — later records cannot
+            # un-null it, which prevents the isinstance checks below from raising.
+            elif key == 'reportportal' and (
+                    src[key] is None or dest[key] is None):  # type: ignore[literal-required]
                 dest[key] = None  # type: ignore[literal-required]
-            elif key == 'reportportal' and dest[key] is None:  # type: ignore[literal-required]
-                pass
             elif isinstance(dest[key], dict) and isinstance(src[key], dict):  # type: ignore[literal-required]
                 dest[key].update(src[key])  # type: ignore[literal-required]
             elif isinstance(dest[key], list) and isinstance(src[key], list):  # type: ignore[literal-required]

--- a/tests/unit/data/recipe_description.yaml
+++ b/tests/unit/data/recipe_description.yaml
@@ -1,0 +1,24 @@
+fixtures:
+    tmt:
+        url: https://github.com/RedHatQE/newa.git
+        ref: main
+        path: demodata
+        plan: /plan/plan1
+    reportportal:
+        launch_name: "test-launch"
+    context:
+        tier: 1
+    compose: Fedora-fix
+dimensions:
+    scenario:
+       - context:
+             scenario: full
+         description: "full scenario"
+       - context:
+             scenario: smoke
+         description: "smoke scenario"
+         reportportal: null
+       - context:
+             scenario: minimal
+         reportportal:
+             suite_description: "explicit suite desc"

--- a/tests/unit/data/recipe_rp_null.yaml
+++ b/tests/unit/data/recipe_rp_null.yaml
@@ -1,0 +1,26 @@
+fixtures:
+    tmt:
+        url: https://github.com/RedHatQE/newa.git
+        ref: main
+        path: demodata
+        plan: /plan/plan1
+    reportportal:
+        launch_name: "test-launch"
+        launch_description: "test description"
+    context:
+        tier: 1
+    environment:
+        DESCRIPTION: "fixtures description"
+    compose: Fedora-fix
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - context:
+             arch: aarch64
+    scenario:
+       - context:
+             scenario: full
+       - context:
+             scenario: smoke
+         reportportal: null

--- a/tests/unit/data/recipe_rp_null_fixtures.yaml
+++ b/tests/unit/data/recipe_rp_null_fixtures.yaml
@@ -1,0 +1,18 @@
+fixtures:
+    tmt:
+        url: https://github.com/RedHatQE/newa.git
+        ref: main
+        path: demodata
+        plan: /plan/plan1
+    reportportal: null
+    context:
+        tier: 1
+    environment:
+        DESCRIPTION: "fixtures description"
+    compose: Fedora-fix
+dimensions:
+    arch:
+       - context:
+             arch: x86_64
+       - context:
+             arch: aarch64

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -63,3 +63,113 @@ def test_cli_config_override():
 
     assert all(r.environment['DESCRIPTION'] == "cli description" for r in reqs)
     assert all(r.compose == "Fedora-cli" for r in reqs)
+
+
+def test_reportportal_null_in_dimension():
+    """reportportal: null in a dimension disables RP for those combinations."""
+    config = RecipeConfig.from_yaml_file(
+        Path('tests/unit/data/recipe_rp_null.yaml').absolute())
+    reqs = list(config.build_requests(initial_config={}, cli_config={}))
+
+    # 2 arches * 2 scenarios = 4 requests
+    assert len(reqs) == 4
+
+    full_reqs = [r for r in reqs if r.context.get('scenario') == 'full']
+    smoke_reqs = [r for r in reqs if r.context.get('scenario') == 'smoke']
+
+    assert len(full_reqs) == 2
+    assert len(smoke_reqs) == 2
+
+    # "full" scenario should have RP enabled (inherited from fixtures)
+    for r in full_reqs:
+        assert r.reportportal is not None
+        assert r.reportportal['launch_name'] == 'test-launch'
+
+    # "smoke" scenario should have RP disabled (null overrides fixtures)
+    for r in smoke_reqs:
+        assert r.reportportal is None
+
+
+def test_reportportal_null_sticky():
+    """Once reportportal is set to null, cli_config cannot override it back."""
+    config = RecipeConfig.from_yaml_file(
+        Path('tests/unit/data/recipe_rp_null.yaml').absolute())
+    reqs = list(config.build_requests(
+        initial_config={},
+        cli_config={
+            'reportportal': {'launch_name': 'cli-launch'},
+            }))
+
+    smoke_reqs = [r for r in reqs if r.context.get('scenario') == 'smoke']
+    full_reqs = [r for r in reqs if r.context.get('scenario') == 'full']
+
+    # Smoke: null is sticky — cli_config can't un-null it
+    for r in smoke_reqs:
+        assert r.reportportal is None
+
+    # Full: cli_config merges normally, overriding launch_name
+    for r in full_reqs:
+        assert r.reportportal is not None
+        assert r.reportportal['launch_name'] == 'cli-launch'
+
+
+def test_merge_combination_data_null_override():
+    """Direct test of merge_combination_data with null values."""
+    config = RecipeConfig(fixtures={}, dimensions={})
+
+    # null overrides an existing dict
+    merged = config.merge_combination_data((
+        {'reportportal': {'launch_name': 'test'}},
+        {'reportportal': None},
+        ))
+    assert merged['reportportal'] is None
+
+    # null is sticky — later dict cannot un-null
+    merged = config.merge_combination_data((
+        {'reportportal': {'launch_name': 'test'}},
+        {'reportportal': None},
+        {'reportportal': {'launch_name': 'override'}},
+        ))
+    assert merged['reportportal'] is None
+
+    # null from the start stays null
+    merged = config.merge_combination_data((
+        {'reportportal': None},
+        {'reportportal': {'launch_name': 'override'}},
+        ))
+    assert merged['reportportal'] is None
+
+
+def test_merge_combination_data_preserves_existing_behavior():
+    """Existing merge behavior is preserved after adding null handling."""
+    config = RecipeConfig(fixtures={}, dimensions={})
+
+    # dict merging still works
+    merged = config.merge_combination_data((
+        {'reportportal': {'launch_name': 'a'}},
+        {'reportportal': {'launch_description': 'b'}},
+        ))
+    assert merged['reportportal'] == {'launch_name': 'a', 'launch_description': 'b'}
+
+    # string override still works
+    merged = config.merge_combination_data((
+        {'compose': 'Fedora-1'},
+        {'compose': 'Fedora-2'},
+        ))
+    assert merged['compose'] == 'Fedora-2'
+
+    # list extend still works
+    merged = config.merge_combination_data((
+        {'environment': {'A': '1'}},
+        {'environment': {'B': '2'}},
+        ))
+    assert merged['environment'] == {'A': '1', 'B': '2'}
+
+    # when merging still works
+    merged = config.merge_combination_data((
+        {'when': 'cond1'},
+        {'when': 'cond2'},
+        ))
+    assert 'cond1' in merged['when']
+    assert 'cond2' in merged['when']
+    assert 'and' in merged['when']

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -147,6 +147,17 @@ def test_merge_combination_data_null_override():
     assert merged['reportportal'] is None
 
 
+def test_reportportal_null_in_fixtures():
+    """reportportal: null in fixtures disables RP for all combinations."""
+    config = RecipeConfig.from_yaml_file(
+        Path('tests/unit/data/recipe_rp_null_fixtures.yaml').absolute())
+    reqs = list(config.build_requests(initial_config={}, cli_config={}))
+
+    assert len(reqs) == 2
+    for r in reqs:
+        assert r.reportportal is None
+
+
 def test_merge_combination_data_preserves_existing_behavior():
     """Existing merge behavior is preserved after adding null handling."""
     config = RecipeConfig(fixtures={}, dimensions={})

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -158,6 +158,64 @@ def test_reportportal_null_in_fixtures():
         assert r.reportportal is None
 
 
+def test_description_attribute():
+    """description attribute is set on requests and merged correctly."""
+    config = RecipeConfig.from_yaml_file(
+        Path('tests/unit/data/recipe_description.yaml').absolute())
+    reqs = list(config.build_requests(initial_config={}, cli_config={}))
+
+    # 3 scenarios = 3 requests
+    assert len(reqs) == 3
+
+    full_req = next(r for r in reqs if r.context.get('scenario') == 'full')
+    smoke_req = next(r for r in reqs if r.context.get('scenario') == 'smoke')
+    minimal_req = next(r for r in reqs if r.context.get('scenario') == 'minimal')
+
+    # description is set from dimensions
+    assert full_req.description == 'full scenario'
+    assert smoke_req.description == 'smoke scenario'
+    # minimal has no description
+    assert minimal_req.description is None
+
+    # smoke has RP disabled, full and minimal have RP enabled
+    assert smoke_req.reportportal is None
+    assert full_req.reportportal is not None
+    assert minimal_req.reportportal is not None
+
+    # minimal has explicit suite_description in reportportal
+    assert minimal_req.reportportal['suite_description'] == 'explicit suite desc'
+
+
+def test_description_missing_backward_compat():
+    """Requests from old YAMLs without description field work correctly."""
+    config = RecipeConfig.from_yaml_file(
+        Path('tests/unit/data/sample_recipe.yaml').absolute())
+    reqs = list(config.build_requests(initial_config={}, cli_config={}))
+
+    # old recipe has no description attribute — defaults to None
+    for r in reqs:
+        assert r.description is None
+
+
+def test_description_merge_as_string():
+    """description merges as a string — later value overrides earlier."""
+    config = RecipeConfig(fixtures={}, dimensions={})
+
+    merged = config.merge_combination_data((
+        {'description': 'from fixtures'},
+        {'description': 'from dimension'},
+        ))
+    assert merged['description'] == 'from dimension'
+
+    # description alongside other keys
+    merged = config.merge_combination_data((
+        {'description': 'test', 'compose': 'Fedora-1'},
+        {'compose': 'Fedora-2'},
+        ))
+    assert merged['description'] == 'test'
+    assert merged['compose'] == 'Fedora-2'
+
+
 def test_merge_combination_data_preserves_existing_behavior():
     """Existing merge behavior is preserved after adding null handling."""
     config = RecipeConfig(fixtures={}, dimensions={})

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -117,12 +117,19 @@ def test_merge_combination_data_null_override():
     """Direct test of merge_combination_data with null values."""
     config = RecipeConfig(fixtures={}, dimensions={})
 
-    # null overrides an existing dict
+    # null overrides an existing dict; other keys still merge normally
     merged = config.merge_combination_data((
-        {'reportportal': {'launch_name': 'test'}},
-        {'reportportal': None},
+        {
+            'reportportal': {'launch_name': 'test'},
+            'environment': {'name': 'dev'},
+            },
+        {
+            'reportportal': None,
+            'environment': {'name': 'prod'},
+            },
         ))
     assert merged['reportportal'] is None
+    assert merged['environment'] == {'name': 'prod'}
 
     # null is sticky — later dict cannot un-null
     merged = config.merge_combination_data((


### PR DESCRIPTION
…bination

Allow recipe authors to opt specific combinations out of ReportPortal reporting by setting reportportal: null in a dimension or adjustment. The null is sticky — once set, it cannot be overridden back by later merge sources including CLI fixtures, which is a deliberate deviation from the normal priority rule. The null override logic is intentionally limited to the reportportal key to avoid errors with other keys.

## Summary by Sourcery

Allow recipes to explicitly disable ReportPortal per combination using `reportportal: null`, introduce a human-readable `description` attribute for combinations, and ensure CLI and reporting flows respect these settings.

New Features:
- Support setting `reportportal: null` in fixtures, dimensions, or adjustments to opt specific or all combinations out of ReportPortal reporting, with this opt-out treated as sticky against later overrides.
- Add a `description` attribute on recipe combinations and propagate it through requests for use in Jira summaries and as a fallback for ReportPortal suite descriptions.

Enhancements:
- Update ReportPortal launch handling and Jira/report summaries to operate only on RP-enabled jobs and to correctly count and display requests that report to RP.
- Preserve default ReportPortal configuration only when it is not mentioned in fixtures, ensuring explicit `null` is not overridden.
- Extend Jinja2 rendering of request attributes to include the new `description` field while avoiding spurious 'None' string values.

Documentation:
- Document the new `description` attribute semantics and its interaction with ReportPortal and Jira summaries, including Jinja2 support and examples.
- Document how to disable ReportPortal for specific or all combinations via `reportportal: null` in recipes and how this differs from the global CLI `--no-reportportal` option.

Tests:
- Add unit tests and sample recipe YAMLs covering `reportportal: null` behavior, sticky null semantics, merge logic, description merging, and backwards compatibility for recipes without `description`.